### PR TITLE
Merge top-level IdP config traversal functions, check for improper IdP config

### DIFF
--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -26,8 +26,12 @@ func (c *authOperator) getGeneration() int64 {
 	return deployment.Generation
 }
 
-func defaultDeployment(operatorConfig *authv1alpha1.AuthenticationOperatorConfig, syncData []idpSyncData, resourceVersions ...string) *appsv1.Deployment {
-	replicas := int32(3)
+func defaultDeployment(
+	operatorConfig *authv1alpha1.AuthenticationOperatorConfig,
+	syncData *idpSyncData,
+	resourceVersions ...string,
+) *appsv1.Deployment {
+	replicas := int32(3) // TODO configurable?
 	gracePeriod := int64(30)
 
 	var (
@@ -66,10 +70,8 @@ func defaultDeployment(operatorConfig *authv1alpha1.AuthenticationOperatorConfig
 		mounts = append(mounts, m)
 	}
 
-	for _, d := range syncData {
-		volumes, mounts = toVolumesAndMounts(d.configMaps, volumes, mounts)
-		volumes, mounts = toVolumesAndMounts(d.secrets, volumes, mounts)
-	}
+	volumes, mounts = toVolumesAndMounts(syncData.configMaps, volumes, mounts)
+	volumes, mounts = toVolumesAndMounts(syncData.secrets, volumes, mounts)
 
 	// force redeploy when any associated resource changes
 	// we use a hash to prevent this value from growing indefinitely

--- a/pkg/operator2/helpers.go
+++ b/pkg/operator2/helpers.go
@@ -2,7 +2,7 @@ package operator2
 
 import configv1 "github.com/openshift/api/config/v1"
 
-func moveSecretFromRefToFileStringSource(syncData []idpSyncData, i int, name configv1.SecretNameReference, key string) configv1.StringSource {
+func moveSecretFromRefToFileStringSource(syncData *idpSyncData, i int, name configv1.SecretNameReference, key string) configv1.StringSource {
 	return configv1.StringSource{
 		StringSourceSpec: configv1.StringSourceSpec{
 			File: getFilenameFromSecretNameRef(syncData, i, name, key),
@@ -10,12 +10,12 @@ func moveSecretFromRefToFileStringSource(syncData []idpSyncData, i int, name con
 	}
 }
 
-func getFilenameFromConfigMapNameRef(syncData []idpSyncData, i int, name configv1.ConfigMapNameReference, key string) string {
+func getFilenameFromConfigMapNameRef(syncData *idpSyncData, i int, name configv1.ConfigMapNameReference, key string) string {
 	// TODO make sure this makes sense (some things are optional)
-	return syncData[i].configMaps[getIDPName(i, name.Name, key)].path
+	return syncData.configMaps[getIDPName(i, name.Name, key)].path
 }
 
-func getFilenameFromSecretNameRef(syncData []idpSyncData, i int, name configv1.SecretNameReference, key string) string {
+func getFilenameFromSecretNameRef(syncData *idpSyncData, i int, name configv1.SecretNameReference, key string) string {
 	// TODO make sure this makes sense (some things are optional)
-	return syncData[i].secrets[getIDPName(i, name.Name, key)].path
+	return syncData.secrets[getIDPName(i, name.Name, key)].path
 }

--- a/pkg/operator2/helpers.go
+++ b/pkg/operator2/helpers.go
@@ -2,20 +2,10 @@ package operator2
 
 import configv1 "github.com/openshift/api/config/v1"
 
-func moveSecretFromRefToFileStringSource(syncData *idpSyncData, i int, name configv1.SecretNameReference, key string) configv1.StringSource {
+func createFileStringSource(filename string) configv1.StringSource {
 	return configv1.StringSource{
 		StringSourceSpec: configv1.StringSourceSpec{
-			File: getFilenameFromSecretNameRef(syncData, i, name, key),
+			File: filename,
 		},
 	}
-}
-
-func getFilenameFromConfigMapNameRef(syncData *idpSyncData, i int, name configv1.ConfigMapNameReference, key string) string {
-	// TODO make sure this makes sense (some things are optional)
-	return syncData.configMaps[getIDPName(i, name.Name, key)].path
-}
-
-func getFilenameFromSecretNameRef(syncData *idpSyncData, i int, name configv1.SecretNameReference, key string) string {
-	// TODO make sure this makes sense (some things are optional)
-	return syncData.secrets[getIDPName(i, name.Name, key)].path
 }

--- a/pkg/operator2/idp.go
+++ b/pkg/operator2/idp.go
@@ -33,10 +33,10 @@ func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderC
 		p = &osinv1.BasicAuthPasswordIdentityProvider{
 			RemoteConnectionInfo: configv1.RemoteConnectionInfo{
 				URL: basicAuthConfig.URL,
-				CA:  getFilenameFromConfigMapNameRef(syncData, i, basicAuthConfig.CA, corev1.ServiceAccountRootCAKey),
+				CA:  syncData.AddConfigMap(i, basicAuthConfig.CA.Name, corev1.ServiceAccountRootCAKey),
 				CertInfo: configv1.CertInfo{
-					CertFile: getFilenameFromSecretNameRef(syncData, i, basicAuthConfig.TLSClientCert, corev1.TLSCertKey),
-					KeyFile:  getFilenameFromSecretNameRef(syncData, i, basicAuthConfig.TLSClientKey, corev1.TLSPrivateKeyKey),
+					CertFile: syncData.AddSecret(i, basicAuthConfig.TLSClientCert.Name, corev1.TLSCertKey),
+					KeyFile:  syncData.AddSecret(i, basicAuthConfig.TLSClientKey.Name, corev1.TLSPrivateKeyKey),
 				},
 			},
 		}
@@ -45,19 +45,19 @@ func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderC
 		githubConfig := providerConfig.GitHub
 		p = &osinv1.GitHubIdentityProvider{
 			ClientID:      githubConfig.ClientID,
-			ClientSecret:  moveSecretFromRefToFileStringSource(syncData, i, githubConfig.ClientSecret, configv1.ClientSecretKey),
+			ClientSecret:  createFileStringSource(syncData.AddSecret(i, githubConfig.ClientSecret.Name, configv1.ClientSecretKey)),
 			Organizations: githubConfig.Organizations,
 			Hostname:      githubConfig.Hostname,
-			CA:            getFilenameFromConfigMapNameRef(syncData, i, githubConfig.CA, corev1.ServiceAccountRootCAKey),
+			CA:            syncData.AddConfigMap(i, githubConfig.CA.Name, corev1.ServiceAccountRootCAKey),
 		}
 
 	case configv1.IdentityProviderTypeGitLab:
 		gitlabConfig := providerConfig.GitLab
 		p = &osinv1.GitLabIdentityProvider{
-			CA:           getFilenameFromConfigMapNameRef(syncData, i, gitlabConfig.CA, corev1.ServiceAccountRootCAKey),
+			CA:           syncData.AddConfigMap(i, gitlabConfig.CA.Name, corev1.ServiceAccountRootCAKey),
 			URL:          gitlabConfig.URL,
 			ClientID:     gitlabConfig.ClientID,
-			ClientSecret: moveSecretFromRefToFileStringSource(syncData, i, gitlabConfig.ClientSecret, configv1.ClientSecretKey),
+			ClientSecret: createFileStringSource(syncData.AddSecret(i, gitlabConfig.ClientSecret.Name, configv1.ClientSecretKey)),
 			Legacy:       new(bool), // we require OIDC for GitLab now
 		}
 
@@ -65,13 +65,13 @@ func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderC
 		googleConfig := providerConfig.Google
 		p = &osinv1.GoogleIdentityProvider{
 			ClientID:     googleConfig.ClientID,
-			ClientSecret: moveSecretFromRefToFileStringSource(syncData, i, googleConfig.ClientSecret, configv1.ClientSecretKey),
+			ClientSecret: createFileStringSource(syncData.AddSecret(i, googleConfig.ClientSecret.Name, configv1.ClientSecretKey)),
 			HostedDomain: googleConfig.HostedDomain,
 		}
 
 	case configv1.IdentityProviderTypeHTPasswd:
 		p = &osinv1.HTPasswdPasswordIdentityProvider{
-			File: getFilenameFromSecretNameRef(syncData, i, providerConfig.HTPasswd.FileData, configv1.HTPasswdDataKey),
+			File: syncData.AddSecret(i, providerConfig.HTPasswd.FileData.Name, configv1.HTPasswdDataKey),
 		}
 
 	case configv1.IdentityProviderTypeKeystone:
@@ -79,10 +79,10 @@ func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderC
 		p = &osinv1.KeystonePasswordIdentityProvider{
 			RemoteConnectionInfo: configv1.RemoteConnectionInfo{
 				URL: keystoneConfig.URL,
-				CA:  getFilenameFromConfigMapNameRef(syncData, i, keystoneConfig.CA, corev1.ServiceAccountRootCAKey),
+				CA:  syncData.AddConfigMap(i, keystoneConfig.CA.Name, corev1.ServiceAccountRootCAKey),
 				CertInfo: configv1.CertInfo{
-					CertFile: getFilenameFromSecretNameRef(syncData, i, keystoneConfig.TLSClientCert, corev1.TLSCertKey),
-					KeyFile:  getFilenameFromSecretNameRef(syncData, i, keystoneConfig.TLSClientKey, corev1.TLSPrivateKeyKey),
+					CertFile: syncData.AddSecret(i, keystoneConfig.TLSClientCert.Name, corev1.TLSCertKey),
+					KeyFile:  syncData.AddSecret(i, keystoneConfig.TLSClientKey.Name, corev1.TLSPrivateKeyKey),
 				},
 			},
 			DomainName:          keystoneConfig.DomainName,
@@ -94,17 +94,17 @@ func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderC
 		p = &osinv1.LDAPPasswordIdentityProvider{
 			URL:          ldapConfig.URL,
 			BindDN:       ldapConfig.BindDN,
-			BindPassword: moveSecretFromRefToFileStringSource(syncData, i, ldapConfig.BindPassword, configv1.BindPasswordKey),
+			BindPassword: createFileStringSource(syncData.AddSecret(i, ldapConfig.BindPassword.Name, configv1.BindPasswordKey)),
 			Insecure:     ldapConfig.Insecure,
-			CA:           getFilenameFromConfigMapNameRef(syncData, i, ldapConfig.CA, corev1.ServiceAccountRootCAKey),
+			CA:           syncData.AddConfigMap(i, ldapConfig.CA.Name, corev1.ServiceAccountRootCAKey),
 		}
 
 	case configv1.IdentityProviderTypeOpenID:
 		openIDConfig := providerConfig.OpenID
 		p = &osinv1.OpenIDIdentityProvider{
-			CA:                       getFilenameFromConfigMapNameRef(syncData, i, openIDConfig.CA, corev1.ServiceAccountRootCAKey),
+			CA:                       syncData.AddConfigMap(i, openIDConfig.CA.Name, corev1.ServiceAccountRootCAKey),
 			ClientID:                 openIDConfig.ClientID,
-			ClientSecret:             moveSecretFromRefToFileStringSource(syncData, i, openIDConfig.ClientSecret, configv1.ClientSecretKey),
+			ClientSecret:             createFileStringSource(syncData.AddSecret(i, openIDConfig.ClientSecret.Name, configv1.ClientSecretKey)),
 			ExtraScopes:              openIDConfig.ExtraScopes,
 			ExtraAuthorizeParameters: openIDConfig.ExtraAuthorizeParameters,
 			URLs: osinv1.OpenIDURLs{
@@ -126,7 +126,7 @@ func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderC
 		p = &osinv1.RequestHeaderIdentityProvider{
 			LoginURL:                 requestHeaderConfig.LoginURL,
 			ChallengeURL:             requestHeaderConfig.ChallengeURL,
-			ClientCA:                 getFilenameFromConfigMapNameRef(syncData, i, requestHeaderConfig.ClientCA, corev1.ServiceAccountRootCAKey),
+			ClientCA:                 syncData.AddConfigMap(i, requestHeaderConfig.ClientCA.Name, corev1.ServiceAccountRootCAKey),
 			ClientCommonNames:        requestHeaderConfig.ClientCommonNames,
 			Headers:                  requestHeaderConfig.Headers,
 			PreferredUsernameHeaders: requestHeaderConfig.PreferredUsernameHeaders,

--- a/pkg/operator2/idp.go
+++ b/pkg/operator2/idp.go
@@ -22,7 +22,7 @@ func init() {
 	utilruntime.Must(osinv1.Install(scheme))
 }
 
-func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderConfig, syncData []idpSyncData, i int) ([]byte, error) {
+func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderConfig, syncData *idpSyncData, i int) ([]byte, error) {
 	// FIXME: we need validation to make sure each of the IdP fields in each case is not nil!
 
 	var p runtime.Object

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -31,7 +31,17 @@ func init() {
 	utilruntime.Must(kubecontrolplanev1.Install(kubeControlplaneScheme))
 }
 
-func (c *authOperator) handleOAuthConfig(operatorConfig *authv1alpha1.AuthenticationOperatorConfig, route *routev1.Route, service *corev1.Service) (*configv1.OAuth, *configv1.Console, *corev1.ConfigMap, []idpSyncData, error) {
+func (c *authOperator) handleOAuthConfig(
+	operatorConfig *authv1alpha1.AuthenticationOperatorConfig,
+	route *routev1.Route,
+	service *corev1.Service,
+) (
+	*configv1.OAuth,
+	*configv1.Console,
+	*corev1.ConfigMap,
+	*idpSyncData,
+	error,
+) {
 	oauthConfig, err := c.oauth.Get(globalConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, nil, nil, err


### PR DESCRIPTION
This PR does a bunch refactorings:
* removes unnecessary creations of `idpDataSync` structures, uses only one such struct instead
* simplifies the way `sourceData` objects are stored in `idpDataSync` structure so that there's but a small amount of boilerplate
* merges the `configsync:convertToData()` and `idp:convertProviderCOnfigToOsinBytes()` functions to only traverse the IdP config once

It also adds checking for improperly created IdP configs so that we don't panic.