### PR TITLE
Add log level support

### DIFF
--- a/manifests/0000_09_cluster-osin-operator_00_roles.yaml
+++ b/manifests/0000_09_cluster-osin-operator_00_roles.yaml
@@ -9,3 +9,6 @@ subjects:
 - kind: ServiceAccount
   namespace: openshift-core-operators
   name: origin-cluster-osin-operator
+- kind: ServiceAccount
+  namespace: openshift-osin
+  name: openshift-osin

--- a/manifests/0000_09_cluster-osin-operator_04_sa.yaml
+++ b/manifests/0000_09_cluster-osin-operator_04_sa.yaml
@@ -5,3 +5,11 @@ metadata:
   name: origin-cluster-osin-operator
   labels:
     app: origin-cluster-osin-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: openshift-osin
+  name: openshift-osin
+  labels:
+    app: origin-cluster-osin-operator2

--- a/pkg/apis/authentication/v1alpha1/register.go
+++ b/pkg/apis/authentication/v1alpha1/register.go
@@ -9,8 +9,9 @@ import (
 	operatorsv1alpha1api "github.com/openshift/api/operator/v1alpha1"
 )
 
+const GroupName = "authentication.operator.openshift.io"
+
 var (
-	GroupName     = "authentication.operator.openshift.io"
 	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, configv1.Install, operatorsv1alpha1api.Install)
 	// Install is a function which adds this version to a scheme

--- a/pkg/apis/authentication/v1alpha1/types.go
+++ b/pkg/apis/authentication/v1alpha1/types.go
@@ -19,11 +19,11 @@ type AuthenticationOperatorConfig struct {
 }
 
 type AuthenticationOperatorConfigSpec struct {
-	v1.OperatorSpec
+	v1.OperatorSpec `json:",inline"`
 }
 
 type AuthenticationOperatorConfigStatus struct {
-	v1.OperatorStatus
+	v1.OperatorStatus `json:",inline"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -132,6 +132,7 @@ func defaultDeployment(syncData []idpSyncData, resourceVersions ...string) *apps
 					//		Effect:   corev1.TaintEffectNoSchedule,
 					//	},
 					//},
+					ServiceAccountName:            targetName,
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					SchedulerName:                 corev1.DefaultSchedulerName,
 					TerminationGracePeriodSeconds: &gracePeriod,

--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+	authv1alpha1 "github.com/openshift/cluster-osin-operator/pkg/apis/authentication/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +17,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1alpha1helpers"
 )
 
+const hashAnnotation = authv1alpha1.GroupName + "/rvs-hash"
+
 func (c *authOperator) getGeneration() int64 {
 	deployment, err := c.deployments.Deployments(targetName).Get(targetName, metav1.GetOptions{})
 	if err != nil {
@@ -23,7 +27,7 @@ func (c *authOperator) getGeneration() int64 {
 	return deployment.Generation
 }
 
-func defaultDeployment(syncData []idpSyncData, resourceVersions ...string) *appsv1.Deployment {
+func defaultDeployment(operatorConfig *authv1alpha1.AuthenticationOperatorConfig, syncData []idpSyncData, resourceVersions ...string) *appsv1.Deployment {
 	replicas := int32(3) // TODO configurable?
 	gracePeriod := int64(30)
 
@@ -89,8 +93,12 @@ func defaultDeployment(syncData []idpSyncData, resourceVersions ...string) *apps
 	rvsHash := sha512.Sum512([]byte(rvs))
 	rvsHashStr := base64.RawURLEncoding.EncodeToString(rvsHash[:])
 
+	// make sure ApplyDeployment knows to update
+	meta := defaultMeta()
+	meta.Annotations[hashAnnotation] = rvsHashStr
+
 	deployment := &appsv1.Deployment{
-		ObjectMeta: defaultMeta(), // TODO add hash annotation here as well
+		ObjectMeta: meta,
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
@@ -101,7 +109,7 @@ func defaultDeployment(syncData []idpSyncData, resourceVersions ...string) *apps
 					Name:   targetName,
 					Labels: defaultLabels(),
 					Annotations: map[string]string{
-						"authentication.operator.openshift.io/rvs-hash": rvsHashStr,
+						hashAnnotation: rvsHashStr,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -146,6 +154,7 @@ func defaultDeployment(syncData []idpSyncData, resourceVersions ...string) *apps
 								"hypershift",
 								"openshift-osinserver",
 								fmt.Sprintf("--config=%s/%s", systemConfigPath, configKey),
+								fmt.Sprintf("--v=%d", getLogLevel(operatorConfig.Spec.LogLevel)),
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -205,4 +214,19 @@ func toVolumesAndMounts(data map[string]sourceData, volumes []corev1.Volume, mou
 		mounts = append(mounts, data[name].mount)
 	}
 	return volumes, mounts
+}
+
+func getLogLevel(logLevel operatorv1.LogLevel) int {
+	switch logLevel {
+	case operatorv1.Normal:
+		return 2
+	case operatorv1.Debug:
+		return 4
+	case operatorv1.Trace:
+		return 6
+	case operatorv1.TraceAll:
+		return 100 // this is supposed to be 8 but I prefer "all" to really mean all
+	default:
+		return 0
+	}
 }


### PR DESCRIPTION
Add service account for deployment

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Add log level support

This allows configuring the log level of the integrated OAuth server
via the operator config.

We now track the operator config's resource version in the
deployment hash.  This along with including the hash in the
deployment's metadata guarantees that we rollout correctly when the
operator's config changes.

We still do not rollout in all cases due to the resource syncer.
Once we correctly track those config maps and secrets, we should be
good.

We may end up rolling out "too often," but we can target the hash
more closely in the future if that happens.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

@openshift/sig-auth 