### PR TITLE
Add status updates

### DIFF
--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -158,10 +158,16 @@ func (c *authOperator) Sync(obj metav1.Object) error {
 	}
 
 	if err := c.handleSync(operatorConfig); err != nil {
+		if statusErr := c.setFailingStatus(operatorConfig, "OperatorSyncLoopError", err.Error()); statusErr != nil {
+			glog.Errorf("error updating operator status: %s", statusErr)
+		}
+
 		return err
 	}
 
-	// TODO update states and handle ClusterOperator spec/status
+	if statusErr := c.setAvailableStatus(operatorConfig); statusErr != nil {
+		glog.Errorf("error updating operator status: %s", statusErr)
+	}
 
 	return nil
 }

--- a/pkg/operator2/operatorclient.go
+++ b/pkg/operator2/operatorclient.go
@@ -14,11 +14,11 @@ type OperatorClient struct {
 	Client    operatorconfigclient.AuthenticationsGetter
 }
 
-func (c *OperatorClient) Informer() cache.SharedIndexInformer {
+func (c OperatorClient) Informer() cache.SharedIndexInformer {
 	return c.Informers.Operator().V1().Authentications().Informer()
 }
 
-func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
+func (c OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	instance, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
 	if err != nil {
 		return nil, nil, "", err
@@ -27,7 +27,7 @@ func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operator
 	return &instance.Spec.OperatorSpec, &instance.Status.OperatorStatus, instance.ResourceVersion, nil
 }
 
-func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
+func (c OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
 	original, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
 	if err != nil {
 		return nil, "", err
@@ -44,7 +44,7 @@ func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operat
 	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
 }
 
-func (c *OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+func (c OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
 	original, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
 	if err != nil {
 		return nil, err

--- a/pkg/operator2/operatorclient.go
+++ b/pkg/operator2/operatorclient.go
@@ -1,0 +1,62 @@
+package operator2
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	operatorconfigclient "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	operatorclientinformers "github.com/openshift/client-go/operator/informers/externalversions"
+)
+
+type OperatorClient struct {
+	Informers operatorclientinformers.SharedInformerFactory
+	Client    operatorconfigclient.AuthenticationsGetter
+}
+
+func (c *OperatorClient) Informer() cache.SharedIndexInformer {
+	return c.Informers.Operator().V1().Authentications().Informer()
+}
+
+func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
+	instance, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return &instance.Spec.OperatorSpec, &instance.Status.OperatorStatus, instance.ResourceVersion, nil
+}
+
+func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
+	original, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
+	if err != nil {
+		return nil, "", err
+	}
+	copy := original.DeepCopy()
+	copy.ResourceVersion = resourceVersion
+	copy.Spec.OperatorSpec = *spec
+
+	ret, err := c.Client.Authentications().Update(copy)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
+}
+
+func (c *OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+	original, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
+	if err != nil {
+		return nil, err
+	}
+	copy := original.DeepCopy()
+	copy.ResourceVersion = resourceVersion
+	copy.Status.OperatorStatus = *status
+
+	ret, err := c.Client.Authentications().Update(copy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret.Status.OperatorStatus, nil
+}

--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -128,8 +128,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	)
 
 	operator := NewAuthenticationOperator(
-		authOperatorConfigInformers.Operator().V1().Authentications(),
-		authConfigClient.OperatorV1(),
+		*operatorClient,
 		kubeInformersNamespaced,
 		kubeClient,
 		routeInformersNamespaced.Route().V1().Routes(),
@@ -141,12 +140,15 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	)
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
-		"openshift-authentication",
+		targetName,
 		[]configv1.ObjectReference{
-			{Group: "operator.openshift.io", Resource: "authentication", Name: globalConfigName},
-			{Resource: "namespaces", Name: "openshift-config"},
-			{Resource: "namespaces", Name: "openshift-config-managed"},
+			{Group: operatorv1.GroupName, Resource: "authentications", Name: globalConfigName},
+			{Group: configv1.GroupName, Resource: "authentications", Name: globalConfigName},
+			{Group: configv1.GroupName, Resource: "oauths", Name: globalConfigName},
+			{Resource: "namespaces", Name: userConfigNamespace},
+			{Resource: "namespaces", Name: machineConfigNamespace},
 			{Resource: "namespaces", Name: targetName},
+			{Resource: "namespaces", Name: targetNameOperator},
 		},
 		configClient.ConfigV1(),
 		operatorClient,

--- a/pkg/operator2/status.go
+++ b/pkg/operator2/status.go
@@ -1,0 +1,50 @@
+package operator2
+
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func (c *authOperator) setFailingStatus(operatorConfig *operatorv1.Authentication, reason, message string) error {
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions,
+		operatorv1.OperatorCondition{
+			Type:    operatorv1.OperatorStatusTypeFailing,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  reason,
+			Message: message,
+		})
+
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeProgressing,
+		Status: operatorv1.ConditionFalse,
+	})
+
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions,
+		operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeAvailable,
+			Status: operatorv1.ConditionFalse,
+		})
+
+	_, updateErr := c.authOperatorConfig.UpdateStatus(operatorConfig)
+	return updateErr
+}
+
+func (c *authOperator) setAvailableStatus(operatorConfig *operatorv1.Authentication) error {
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeAvailable,
+		Status: operatorv1.ConditionTrue,
+	})
+
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeProgressing,
+		Status: operatorv1.ConditionFalse,
+	})
+
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeFailing,
+		Status: operatorv1.ConditionFalse,
+	})
+
+	_, updateErr := c.authOperatorConfig.UpdateStatus(operatorConfig)
+	return updateErr
+}

--- a/pkg/operator2/status.go
+++ b/pkg/operator2/status.go
@@ -6,45 +6,53 @@ import (
 )
 
 func (c *authOperator) setFailingStatus(operatorConfig *operatorv1.Authentication, reason, message string) error {
-	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions,
-		operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeFailing,
-			Status:  operatorv1.ConditionTrue,
-			Reason:  reason,
-			Message: message,
-		})
+	failStatusFunc := func(status *operatorv1.OperatorStatus) error {
+		v1helpers.SetOperatorCondition(&status.Conditions,
+			operatorv1.OperatorCondition{
+				Type:    operatorv1.OperatorStatusTypeFailing,
+				Status:  operatorv1.ConditionTrue,
+				Reason:  reason,
+				Message: message,
+			})
 
-	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
-		Type:   operatorv1.OperatorStatusTypeProgressing,
-		Status: operatorv1.ConditionFalse,
-	})
-
-	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions,
-		operatorv1.OperatorCondition{
-			Type:   operatorv1.OperatorStatusTypeAvailable,
+		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeProgressing,
 			Status: operatorv1.ConditionFalse,
 		})
 
-	_, updateErr := c.authOperatorConfig.UpdateStatus(operatorConfig)
-	return updateErr
+		v1helpers.SetOperatorCondition(&status.Conditions,
+			operatorv1.OperatorCondition{
+				Type:   operatorv1.OperatorStatusTypeAvailable,
+				Status: operatorv1.ConditionFalse,
+			})
+
+		return nil
+	}
+
+	_, _, err := v1helpers.UpdateStatus(c.authOperatorConfigClient, failStatusFunc)
+	return err
 }
 
 func (c *authOperator) setAvailableStatus(operatorConfig *operatorv1.Authentication) error {
-	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
-		Type:   operatorv1.OperatorStatusTypeAvailable,
-		Status: operatorv1.ConditionTrue,
-	})
+	availStatusFunc := func(status *operatorv1.OperatorStatus) error {
+		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeAvailable,
+			Status: operatorv1.ConditionTrue,
+		})
 
-	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
-		Type:   operatorv1.OperatorStatusTypeProgressing,
-		Status: operatorv1.ConditionFalse,
-	})
+		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeProgressing,
+			Status: operatorv1.ConditionFalse,
+		})
 
-	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
-		Type:   operatorv1.OperatorStatusTypeFailing,
-		Status: operatorv1.ConditionFalse,
-	})
+		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeFailing,
+			Status: operatorv1.ConditionFalse,
+		})
 
-	_, updateErr := c.authOperatorConfig.UpdateStatus(operatorConfig)
-	return updateErr
+		return nil
+	}
+
+	_, _, err := v1helpers.UpdateStatus(c.authOperatorConfigClient, availStatusFunc)
+	return err
 }


### PR DESCRIPTION
Adds a `library-go` controller for status changes and also
adds status failure reporting in auth operator Sync() if an error
occured in the lower level machinery.

Based on current `library-go` and `kube-apiserver-operator` code.