### PR TITLE
Fix loopback code exchange for /oauth/token/request

### DIFF
--- a/pkg/operator2/ca.go
+++ b/pkg/operator2/ca.go
@@ -1,0 +1,55 @@
+package operator2
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	injectCABundleAnnotationName  = "service.alpha.openshift.io/inject-cabundle"
+	injectCABundleAnnotationValue = "true"
+)
+
+func (c *authOperator) handleCA() (*corev1.ConfigMap, error) {
+	cm := c.configMaps.ConfigMaps(targetName)
+	ca, err := cm.Get(servingCAName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		ca, err = cm.Create(defaultCA())
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ca.Data[servingCAKey]) == 0 {
+		return nil, fmt.Errorf("config map has no ca data: %#v", ca)
+	}
+
+	if err := isValidCA(ca); err != nil {
+		// delete the CA config map so that it is replaced with the proper one in next reconcile loop
+		glog.Infof("deleting invalid ca config map %#v, deleteErr=%v", ca, cm.Delete(ca.Name, &metav1.DeleteOptions{}))
+		return nil, err
+	}
+
+	return ca, nil
+}
+
+func isValidCA(ca *corev1.ConfigMap) error {
+	if ca.Annotations[injectCABundleAnnotationName] != injectCABundleAnnotationValue {
+		return fmt.Errorf("config map missing injection annotation: %#v", ca)
+	}
+	return nil
+}
+
+func defaultCA() *corev1.ConfigMap {
+	meta := defaultMeta()
+	meta.Name = servingCAName
+	meta.Annotations[injectCABundleAnnotationName] = injectCABundleAnnotationValue
+	return &corev1.ConfigMap{
+		ObjectMeta: meta,
+	}
+}

--- a/pkg/operator2/configmap.go
+++ b/pkg/operator2/configmap.go
@@ -12,7 +12,7 @@ import (
 
 const stubMetadata = `
 {
-  "issuer": "%s",
+  "issuer": "https://%s",
   "authorization_endpoint": "https://%s/oauth/authorize",
   "token_endpoint": "https://%s/oauth/token",
   "scopes_supported": [

--- a/pkg/operator2/configsync.go
+++ b/pkg/operator2/configsync.go
@@ -282,12 +282,6 @@ func convertToData(idps []configv1.IdentityProvider) []idpSyncData {
 }
 
 const (
-	// if one day we ever need to come up with something else, we can still find the old stuff
-	versionPrefix = "v4-0-"
-
-	// anything synced from openshift-config into our namespace has this prefix
-	userConfigPrefix = versionPrefix + "config-user-"
-
 	// idps that are synced have this prefix
 	userConfigPrefixIDP = userConfigPrefix + "idp-"
 
@@ -322,7 +316,7 @@ func syncOrDie(syncFunc func(dest, src resourcesynccontroller.ResourceLocation) 
 	}
 	if err := syncFunc(
 		resourcesynccontroller.ResourceLocation{
-			Namespace: targetName, // TODO fix
+			Namespace: targetName,
 			Name:      dest,
 		},
 		resourcesynccontroller.ResourceLocation{

--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -28,58 +28,43 @@ func (c *authOperator) getGeneration() int64 {
 }
 
 func defaultDeployment(operatorConfig *authv1alpha1.AuthenticationOperatorConfig, syncData []idpSyncData, resourceVersions ...string) *appsv1.Deployment {
-	replicas := int32(3) // TODO configurable?
+	replicas := int32(3)
 	gracePeriod := int64(30)
 
-	// TODO fix these names
-	sessionVolumeName := targetName + "-secret"
-	configVolumeName := targetName + "-configmap"
+	var (
+		volumes []corev1.Volume
+		mounts  []corev1.VolumeMount
+	)
 
-	volumes := []corev1.Volume{
+	for _, data := range []volume{
 		{
-			Name: sessionVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: targetName,
-				},
-			},
+			name:      sessionNameAndKey,
+			configmap: false,
+			path:      sessionMount,
+			keys:      []string{sessionNameAndKey},
 		},
 		{
-			Name: configVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: targetName,
-					},
-				},
-			},
+			name:      cliConfigNameAndKey,
+			configmap: true,
+			path:      cliConfigMount,
+			keys:      []string{cliConfigNameAndKey},
 		},
 		{
-			Name: servingCertName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: servingCertName,
-				},
-			},
-		},
-	}
-
-	mounts := []corev1.VolumeMount{
-		{
-			Name:      sessionVolumeName,
-			ReadOnly:  true,
-			MountPath: sessionMount,
+			name:      servingCertName,
+			configmap: false,
+			path:      servingCertMount,
+			keys:      []string{corev1.TLSCertKey, corev1.TLSPrivateKeyKey},
 		},
 		{
-			Name:      configVolumeName,
-			ReadOnly:  true,
-			MountPath: systemConfigPath,
+			name:      servingCAName,
+			configmap: true,
+			path:      servingCAMount,
+			keys:      []string{servingCAKey},
 		},
-		{
-			Name:      servingCertName,
-			ReadOnly:  true,
-			MountPath: servingCertMount,
-		},
+	} {
+		v, m := data.split()
+		volumes = append(volumes, v)
+		mounts = append(mounts, m)
 	}
 
 	for _, d := range syncData {
@@ -105,13 +90,7 @@ func defaultDeployment(operatorConfig *authv1alpha1.AuthenticationOperatorConfig
 				MatchLabels: defaultLabels(),
 			},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   targetName,
-					Labels: defaultLabels(),
-					Annotations: map[string]string{
-						hashAnnotation: rvsHashStr,
-					},
-				},
+				ObjectMeta: meta,
 				Spec: corev1.PodSpec{
 					// we want to deploy on master nodes
 					//NodeSelector: map[string]string{
@@ -153,7 +132,7 @@ func defaultDeployment(operatorConfig *authv1alpha1.AuthenticationOperatorConfig
 							Command: []string{
 								"hypershift",
 								"openshift-osinserver",
-								fmt.Sprintf("--config=%s/%s", systemConfigPath, configKey),
+								fmt.Sprintf("--config=%s", cliConfigPath),
 								fmt.Sprintf("--v=%d", getLogLevel(operatorConfig.Spec.LogLevel)),
 							},
 							Ports: []corev1.ContainerPort{
@@ -228,5 +207,46 @@ func getLogLevel(logLevel operatorv1.LogLevel) int {
 		return 100 // this is supposed to be 8 but I prefer "all" to really mean all
 	default:
 		return 0
+	}
+}
+
+type volume struct {
+	name      string
+	configmap bool
+	path      string
+	keys      []string
+}
+
+func (v *volume) split() (corev1.Volume, corev1.VolumeMount) {
+	vol := corev1.Volume{
+		Name: v.name,
+	}
+
+	var items []corev1.KeyToPath
+	for _, key := range v.keys {
+		items = append(items, corev1.KeyToPath{
+			Key:  key,
+			Path: key,
+		})
+	}
+
+	if v.configmap {
+		vol.ConfigMap = &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: v.name,
+			},
+			Items: items,
+		}
+	} else {
+		vol.Secret = &corev1.SecretVolumeSource{
+			SecretName: v.name,
+			Items:      items,
+		}
+	}
+
+	return vol, corev1.VolumeMount{
+		Name:      v.name,
+		ReadOnly:  true,
+		MountPath: v.path,
 	}
 }

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -31,7 +31,7 @@ func init() {
 	utilruntime.Must(kubecontrolplanev1.Install(kubeControlplaneScheme))
 }
 
-func (c *authOperator) handleOAuthConfig(operatorConfig *authv1alpha1.AuthenticationOperatorConfig, route *routev1.Route) (*configv1.OAuth, *corev1.ConfigMap, []idpSyncData, error) {
+func (c *authOperator) handleOAuthConfig(operatorConfig *authv1alpha1.AuthenticationOperatorConfig, route *routev1.Route, service *corev1.Service) (*configv1.OAuth, *corev1.ConfigMap, []idpSyncData, error) {
 	oauthConfig, err := c.oauth.Get(globalConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, nil, err
@@ -96,7 +96,7 @@ func (c *authOperator) handleOAuthConfig(operatorConfig *authv1alpha1.Authentica
 				ServingInfo: configv1.ServingInfo{
 					BindAddress: fmt.Sprintf("0.0.0.0:%d", containerPort),
 					BindNetwork: "tcp4",
-					// we have valid certs provided by alfred so that we can use reencrypt routes
+					// we have valid serving certs provided by alfred so that we can use reencrypt routes
 					CertInfo: configv1.CertInfo{
 						CertFile: servingCertPathCert,
 						KeyFile:  servingCertPathKey,
@@ -120,13 +120,13 @@ func (c *authOperator) handleOAuthConfig(operatorConfig *authv1alpha1.Authentica
 			},
 		},
 		OAuthConfig: &osinv1.OAuthConfig{
-			MasterCA: getMasterCA(), // assumed to be valid for the route
+			MasterCA: getMasterCA(), // we have valid serving certs provided by alfred so we can use the service for loopback
 			// TODO osin's code needs to be updated to properly use these values
 			// it should use MasterURL in almost all places except the token request endpoint
 			// which needs to direct the user to the real public URL (MasterPublicURL)
 			// that means we still need to get that value from the installer's config
 			// TODO ask installer team to make it easier to get that URL
-			MasterURL:                   fmt.Sprintf("https://%s", route.Spec.Host),
+			MasterURL:                   fmt.Sprintf("https://%s.%s.svc", service.Name, service.Namespace),
 			MasterPublicURL:             fmt.Sprintf("https://%s", route.Spec.Host),
 			AssetPublicURL:              "", // TODO do we need this?
 			AlwaysShowProviderSelection: false,
@@ -156,17 +156,23 @@ func (c *authOperator) handleOAuthConfig(operatorConfig *authv1alpha1.Authentica
 		return nil, nil, nil, err
 	}
 
-	return oauthConfig, // TODO update OAuth status
-		&corev1.ConfigMap{
-			ObjectMeta: defaultMeta(),
-			Data: map[string]string{
-				configKey: string(completeConfigBytes),
-			},
-		}, syncData, nil
+	// TODO update OAuth status
+	return oauthConfig, getCliConfigMap(completeConfigBytes), syncData, nil
+}
+
+func getCliConfigMap(completeConfigBytes []byte) *corev1.ConfigMap {
+	meta := defaultMeta()
+	meta.Name = cliConfigNameAndKey
+	return &corev1.ConfigMap{
+		ObjectMeta: meta,
+		Data: map[string]string{
+			cliConfigNameAndKey: string(completeConfigBytes),
+		},
+	}
 }
 
 func getMasterCA() *string {
-	ca := clusterCAPath // need local var to be able to take address of it
+	ca := servingCAPath // need local var to be able to take address of it
 	return &ca
 }
 

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -29,29 +29,47 @@ import (
 )
 
 const (
-	targetName = "openshift-authentication"
-
-	configKey = "config.yaml"
-
-	servingCertName     = "serving-cert"
-	servingCertMount    = "/var/run/secrets/serving-cert"
-	servingCertPathCert = servingCertMount + "/" + corev1.TLSCertKey
-	servingCertPathKey  = servingCertMount + "/" + corev1.TLSPrivateKeyKey
-
-	clusterCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-
-	systemConfigPath = "/var/config/system"
-
-	userConfigPath = "/var/config/user"
-
-	sessionKey   = "session"
-	sessionMount = systemConfigPath + "/" + sessionKey
-	sessionPath  = sessionMount + "/" + sessionKey
-
+	targetName       = "openshift-authentication"
 	globalConfigName = "cluster"
 
 	machineConfigNamespace = "openshift-config-managed"
 	userConfigNamespace    = "openshift-config"
+
+	systemConfigPath           = "/var/config/system"
+	systemConfigPathConfigMaps = systemConfigPath + "/configmaps"
+	systemConfigPathSecrets    = systemConfigPath + "/secrets"
+
+	// if one day we ever need to come up with something else, we can still find the old secrets and config maps
+	versionPrefix = "v4-0-"
+
+	configVersionPrefix = versionPrefix + "config-"
+
+	// secrets and config maps that we manually managed have this prefix
+	systemConfigPrefix = configVersionPrefix + "system-"
+
+	// secrets and config maps synced from openshift-config into our namespace have this prefix
+	userConfigPrefix = configVersionPrefix + "user-"
+
+	sessionNameAndKey = systemConfigPrefix + "session"
+	sessionMount      = systemConfigPathSecrets + "/" + sessionNameAndKey
+	sessionPath       = sessionMount + "/" + sessionNameAndKey
+
+	servingCABase  = "service-ca"
+	servingCAName  = systemConfigPrefix + servingCABase
+	servingCAKey   = servingCABase + ".crt"
+	servingCAMount = systemConfigPathConfigMaps + "/" + servingCAName
+	servingCAPath  = servingCAMount + "/" + servingCAKey
+
+	servingCertName     = systemConfigPrefix + "serving-cert"
+	servingCertMount    = systemConfigPathSecrets + "/" + servingCertName
+	servingCertPathCert = servingCertMount + "/" + corev1.TLSCertKey
+	servingCertPathKey  = servingCertMount + "/" + corev1.TLSPrivateKeyKey
+
+	cliConfigNameAndKey = systemConfigPrefix + "cliconfig"
+	cliConfigMount      = systemConfigPathConfigMaps + "/" + cliConfigNameAndKey
+	cliConfigPath       = cliConfigMount + "/" + cliConfigNameAndKey
+
+	userConfigPath = "/var/config/user"
 
 	servicePort   = 443
 	containerPort = 6443
@@ -108,14 +126,14 @@ func NewAuthenticationOperator(
 	coreInformers := kubeInformersNamespaced.Core().V1()
 	configV1Informers := configInformers.Config().V1()
 
-	osinNameFilter := operator.FilterByNames(targetName)
+	targetNameFilter := operator.FilterByNames(targetName)
 	configNameFilter := operator.FilterByNames(globalConfigName)
 	prefixFilter := getPrefixFilter()
 
 	return operator.New("AuthenticationOperator2", c,
-		operator.WithInformer(routeInformer, osinNameFilter),
-		operator.WithInformer(coreInformers.Services(), osinNameFilter),
-		operator.WithInformer(kubeInformersNamespaced.Apps().V1().Deployments(), osinNameFilter),
+		operator.WithInformer(routeInformer, targetNameFilter),
+		operator.WithInformer(coreInformers.Services(), targetNameFilter),
+		operator.WithInformer(kubeInformersNamespaced.Apps().V1().Deployments(), targetNameFilter),
 
 		operator.WithInformer(coreInformers.Secrets(), prefixFilter),
 		operator.WithInformer(coreInformers.ConfigMaps(), prefixFilter),
@@ -152,6 +170,11 @@ func (c *authOperator) handleSync(operatorConfig *authv1alpha1.AuthenticationOpe
 		return err
 	}
 
+	ca, err := c.handleCA()
+	if err != nil {
+		return err
+	}
+
 	metadata, _, err := resourceapply.ApplyConfigMap(c.configMaps, c.recorder, getMetadataConfigMap(route))
 	if err != nil {
 		return err
@@ -176,7 +199,7 @@ func (c *authOperator) handleSync(operatorConfig *authv1alpha1.AuthenticationOpe
 		return err
 	}
 
-	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route)
+	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, service)
 	if err != nil {
 		return err
 	}
@@ -188,11 +211,13 @@ func (c *authOperator) handleSync(operatorConfig *authv1alpha1.AuthenticationOpe
 	// deployment, have RV of all resources
 	// TODO use ExpectedDeploymentGeneration func
 	// TODO manually get RV of all the config maps and secrets in syncData
+	// TODO we also need the RV for the serving-cert secret (servingCertName)
 	expectedDeployment := defaultDeployment(
 		operatorConfig,
 		syncData,
 		operatorConfig.ResourceVersion,
 		route.ResourceVersion,
+		ca.ResourceVersion,
 		metadata.ResourceVersion,
 		authConfig.ResourceVersion,
 		service.ResourceVersion,
@@ -200,6 +225,8 @@ func (c *authOperator) handleSync(operatorConfig *authv1alpha1.AuthenticationOpe
 		oauthConfig.ResourceVersion,
 		cliConfig.ResourceVersion,
 	)
+	// TODO add support for spec.operandSpecs.unsupportedResourcePatches, like:
+	// operatorConfig.Spec.OperandSpecs[...].UnsupportedResourcePatches[...].Patch
 	deployment, _, err := resourceapply.ApplyDeployment(c.deployments, c.recorder, expectedDeployment, c.getGeneration(), false)
 	if err != nil {
 		return err
@@ -227,9 +254,9 @@ func defaultMeta() metav1.ObjectMeta {
 }
 
 func getPrefixFilter() controller.Filter {
-	names := operator.FilterByNames(targetName, servingCertName)
+	names := operator.FilterByNames(targetName)
 	prefix := func(obj metav1.Object) bool { // TODO add helper to combine filters
-		return names.Add(obj) || strings.HasPrefix(obj.GetName(), userConfigPrefix)
+		return names.Add(obj) || strings.HasPrefix(obj.GetName(), configVersionPrefix)
 	}
 	return controller.FilterFuncs{
 		AddFunc: prefix,

--- a/pkg/operator2/route.go
+++ b/pkg/operator2/route.go
@@ -3,6 +3,8 @@ package operator2
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -13,7 +15,7 @@ import (
 func (c *authOperator) handleRoute() (*routev1.Route, error) {
 	route, err := c.route.Get(targetName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		return c.route.Create(defaultRoute())
+		route, err = c.route.Create(defaultRoute())
 	}
 	if err != nil {
 		return nil, err
@@ -25,7 +27,7 @@ func (c *authOperator) handleRoute() (*routev1.Route, error) {
 
 	if err := isValidRoute(route); err != nil {
 		// delete the route so that it is replaced with the proper one in next reconcile loop
-		c.route.Delete(route.Name, &metav1.DeleteOptions{})
+		glog.Infof("deleting invalid route %#v, deleteErr=%v", route, c.route.Delete(route.Name, &metav1.DeleteOptions{}))
 		return nil, err
 	}
 

--- a/pkg/operator2/secret.go
+++ b/pkg/operator2/secret.go
@@ -15,9 +15,9 @@ import (
 )
 
 func (c *authOperator) expectedSessionSecret() (*v1.Secret, error) {
-	secret, err := c.secrets.Secrets(targetName).Get(targetName, metav1.GetOptions{})
+	secret, err := c.secrets.Secrets(targetName).Get(sessionNameAndKey, metav1.GetOptions{})
 	if err != nil || !isValidSessionSecret(secret) {
-		glog.V(4).Infof("failed to get secret %s: %v", targetName, err)
+		glog.V(4).Infof("failed to get secret %s: %v", sessionNameAndKey, err)
 		generatedSessionSecret, err := randomSessionSecret()
 		if err != nil {
 			return nil, err
@@ -57,10 +57,12 @@ func randomSessionSecret() (*v1.Secret, error) {
 	if err != nil {
 		return nil, err
 	}
+	meta := defaultMeta()
+	meta.Name = sessionNameAndKey
 	return &v1.Secret{
-		ObjectMeta: defaultMeta(),
+		ObjectMeta: meta,
 		Data: map[string][]byte{
-			sessionKey: skey,
+			sessionNameAndKey: skey,
 		},
 	}, nil
 }

--- a/pkg/operator2/secret_test.go
+++ b/pkg/operator2/secret_test.go
@@ -42,7 +42,7 @@ func secret(sessionSecret []byte) *v1.Secret {
 	return &v1.Secret{
 		ObjectMeta: defaultMeta(),
 		Data: map[string][]byte{
-			sessionKey: sessionSecret,
+			sessionNameAndKey: sessionSecret,
 		},
 	}
 }

--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -93,7 +93,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	kubeInformersNamespaced := informers.NewSharedInformerFactoryWithOptions(kubeClient, resync,
 		informers.WithNamespace(targetName),
-		informers.WithTweakListOptions(singleNameListOptions(targetName)),
 	)
 
 	authOperatorConfigInformers := authopinformer.NewSharedInformerFactoryWithOptions(authConfigClient, resync,
@@ -115,7 +114,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	resourceSyncerInformers := map[string]informers.SharedInformerFactory{
 		targetName: informers.NewSharedInformerFactoryWithOptions(kubeClient, resync,
-			informers.WithNamespace(targetName), // TODO fix
+			informers.WithNamespace(targetName),
 		),
 		userConfigNamespace: informers.NewSharedInformerFactoryWithOptions(kubeClient, resync,
 			informers.WithNamespace(userConfigNamespace),


### PR DESCRIPTION
This change updates MasterCA and MasterURL to use the SSCS CA and
osin service URL.  These values are only used during loopback server
to server calls for the /oauth/token/request endpoint.

Signed-off-by: Monis Khan <mkhan@redhat.com>