### PR TITLE
handle kubeapiserver api movement

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,25 +19,31 @@ import (
 )
 
 const (
-	targetNamespaceName              = "kube-system"
-	targetConfigMap                  = "cluster-config-v1"
-	targtKubeAPIServerOperatorConfig = "instance"
+	targetNamespaceName                  = "kube-system"
+	targetConfigMap                      = "cluster-config-v1"
+	oldTargetKubeAPIServerOperatorConfig = "instance"
+	targetKubeAPIServerOperatorConfig    = "cluster"
 )
 
 type osinOperator struct {
-	configMap                   coreclientv1.ConfigMapsGetter
-	kubeAPIServerOperatorConfig dynamic.ResourceInterface
+	configMap                      coreclientv1.ConfigMapsGetter
+	oldKubeAPIServerOperatorClient dynamic.ResourceInterface
+	kubeAPIServerOperatorClient    dynamic.ResourceInterface
 }
 
-func NewOsinOperator(cmi v1.ConfigMapInformer, cm coreclientv1.ConfigMapsGetter, operatorConfigInformer controller.InformerGetter, operatorConfig dynamic.ResourceInterface) operator.Runner {
+func NewOsinOperator(cmi v1.ConfigMapInformer, cm coreclientv1.ConfigMapsGetter,
+	oldOperatorConfigInformer controller.InformerGetter, oldKubeAPIServerOperatorClient dynamic.ResourceInterface,
+	kubeAPIServerOperatorConfigInformer controller.InformerGetter, kubeAPIServerOperatorClient dynamic.ResourceInterface) operator.Runner {
 	c := &osinOperator{
-		configMap:                   cm,
-		kubeAPIServerOperatorConfig: operatorConfig,
+		configMap:                      cm,
+		oldKubeAPIServerOperatorClient: oldKubeAPIServerOperatorClient,
+		kubeAPIServerOperatorClient:    kubeAPIServerOperatorClient,
 	}
 
 	return operator.New("OsinOperator", c,
 		operator.WithInformer(cmi, operator.FilterByNames(targetConfigMap)),
-		operator.WithInformer(operatorConfigInformer, operator.FilterByNames(targtKubeAPIServerOperatorConfig)),
+		operator.WithInformer(oldOperatorConfigInformer, operator.FilterByNames(oldTargetKubeAPIServerOperatorConfig, targetKubeAPIServerOperatorConfig)),
+		operator.WithInformer(kubeAPIServerOperatorConfigInformer, operator.FilterByNames(oldTargetKubeAPIServerOperatorConfig, targetKubeAPIServerOperatorConfig)),
 	)
 }
 
@@ -61,7 +67,32 @@ func (c osinOperator) Sync(obj metav1.Object) error {
 		return err
 	}
 
-	apiServerOperatorConfig, err := c.kubeAPIServerOperatorConfig.Get(targtKubeAPIServerOperatorConfig, metav1.GetOptions{})
+	// try all the potential names and resources to update.  Eventually we'll be done with the old
+	updateErr := updateKubeAPIServer(c.oldKubeAPIServerOperatorClient, oldTargetKubeAPIServerOperatorConfig, ic)
+	if updateErr == nil {
+		return nil
+	}
+
+	updateErr = updateKubeAPIServer(c.kubeAPIServerOperatorClient, oldTargetKubeAPIServerOperatorConfig, ic)
+	if updateErr == nil {
+		return nil
+	}
+
+	updateErr = updateKubeAPIServer(c.oldKubeAPIServerOperatorClient, targetKubeAPIServerOperatorConfig, ic)
+	if updateErr == nil {
+		return nil
+	}
+
+	updateErr = updateKubeAPIServer(c.kubeAPIServerOperatorClient, targetKubeAPIServerOperatorConfig, ic)
+	if updateErr == nil {
+		return nil
+	}
+
+	return updateErr
+}
+
+func updateKubeAPIServer(kubeAPIServerOperatorClient dynamic.ResourceInterface, name string, ic *InstallConfig) error {
+	apiServerOperatorConfig, err := kubeAPIServerOperatorClient.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -99,6 +130,6 @@ func (c osinOperator) Sync(obj metav1.Object) error {
 	if err := out.UnmarshalJSON(mergedBytes); err != nil {
 		return err
 	}
-	_, updateErr := c.kubeAPIServerOperatorConfig.Update(out, metav1.UpdateOptions{})
+	_, updateErr := kubeAPIServerOperatorClient.Update(out, metav1.UpdateOptions{})
 	return updateErr
 }


### PR DESCRIPTION
the kubeapiserver API is moving and the name is changing. This updates to handle both changes.  Not super gracefully, but the whole thing is temporary.

/assign @enj 