### PR TITLE
console and kube api server operator informers: skip cache sync

### DIFF
--- a/pkg/boilerplate/controller/controller.go
+++ b/pkg/boilerplate/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -47,7 +48,7 @@ type controller struct {
 }
 
 func (c *controller) Run(workers int, stopCh <-chan struct{}) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrash(crash)
 	defer c.queue.ShutDown()
 
 	glog.Infof("Starting %s", c.name)
@@ -58,9 +59,8 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 		opt(c)
 	}
 
-	if !cache.WaitForCacheSync(stopCh, c.cacheSyncs...) {
-		utilruntime.HandleError(fmt.Errorf("%s: timed out waiting for caches to sync", c.name))
-		return
+	if !c.waitForCacheSyncWithTimeout() {
+		panic(die(fmt.Sprintf("%s: timed out waiting for caches to sync", c.name)))
 	}
 
 	for i := 0; i < workers; i++ {
@@ -70,8 +70,20 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
+func (c *controller) waitForCacheSyncWithTimeout() bool {
+	// prevent us from blocking forever due to a broken informer
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	return cache.WaitForCacheSync(ctx.Done(), c.cacheSyncs...)
+}
+
 func (c *controller) add(filter ParentFilter, object v1.Object) {
 	namespace, name := filter.Parent(object)
+	c.addKey(namespace, name)
+}
+
+func (c *controller) addKey(namespace, name string) {
 	qKey := queueKey{namespace: namespace, name: name}
 	c.queue.Add(qKey)
 }

--- a/pkg/boilerplate/controller/die.go
+++ b/pkg/boilerplate/controller/die.go
@@ -1,0 +1,10 @@
+package controller
+
+type die string
+
+func crash(i interface{}) {
+	mustDie, ok := i.(die)
+	if ok {
+		panic(string(mustDie))
+	}
+}

--- a/pkg/boilerplate/controller/informer.go
+++ b/pkg/boilerplate/controller/informer.go
@@ -1,0 +1,39 @@
+package controller
+
+// TODO decide how to best express changes of behavior for WithInformer
+
+type InformerOption func() informerOptionCase // public so it can be referenced out of this package
+
+type informerOptionCase int // private so the set of cases is sealed
+
+// all cases are private
+const (
+	syncDefault informerOptionCase = iota
+	noSync
+)
+
+// public opt-out of sync
+func WithNoSync() InformerOption {
+	return func() informerOptionCase {
+		return noSync
+	}
+}
+
+// private default
+// will need to be exposed when more options are added
+func withSync() InformerOption {
+	return func() informerOptionCase {
+		return syncDefault
+	}
+}
+
+func informerOptionToOption(opt InformerOption, getter InformerGetter) Option {
+	switch opt() {
+	case syncDefault:
+		return WithInformerSynced(getter) // safe default
+	case noSync:
+		return func(*controller) {} // do nothing
+	default:
+		panic(opt)
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -42,8 +42,8 @@ func NewOsinOperator(cmi v1.ConfigMapInformer, cm coreclientv1.ConfigMapsGetter,
 
 	return operator.New("OsinOperator", c,
 		operator.WithInformer(cmi, operator.FilterByNames(targetConfigMap)),
-		operator.WithInformer(oldOperatorConfigInformer, operator.FilterByNames(oldTargetKubeAPIServerOperatorConfig, targetKubeAPIServerOperatorConfig)),
-		operator.WithInformer(kubeAPIServerOperatorConfigInformer, operator.FilterByNames(oldTargetKubeAPIServerOperatorConfig, targetKubeAPIServerOperatorConfig)),
+		operator.WithInformer(oldOperatorConfigInformer, operator.FilterByNames(oldTargetKubeAPIServerOperatorConfig, targetKubeAPIServerOperatorConfig), controller.WithNoSync()),
+		operator.WithInformer(kubeAPIServerOperatorConfigInformer, operator.FilterByNames(oldTargetKubeAPIServerOperatorConfig, targetKubeAPIServerOperatorConfig), controller.WithNoSync()),
 	)
 }
 

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -143,7 +143,7 @@ func NewAuthenticationOperator(
 		operator.WithInformer(authOpConfigInformer, configNameFilter),
 		operator.WithInformer(configV1Informers.Authentications(), configNameFilter),
 		operator.WithInformer(configV1Informers.OAuths(), configNameFilter),
-		// operator.WithInformer(configV1Informers.Consoles(), configNameFilter),
+		operator.WithInformer(configV1Informers.Consoles(), configNameFilter, controller.WithNoSync()),
 	)
 }
 


### PR DESCRIPTION
Enhance controller boilerplate

1. Be strict on how long we wait for caches to sync
2. Add support for opting out of informer cache sync
3. Add support for initial event to prime sync loop

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

console and kube api server operator informers: skip cache sync

The CRDs backing these resources may not exist.  We do not want to wedge the operator on them.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/assign @mrogers950 