### PR TITLE
Add CORS support for console public hostname

### DIFF
--- a/pkg/operator2/console.go
+++ b/pkg/operator2/console.go
@@ -1,0 +1,46 @@
+package operator2
+
+import (
+	"net/url"
+	"regexp"
+
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func (c *authOperator) handleConsoleConfig() *configv1.Console {
+	// technically this should be an observed config loop
+	consoleConfig, err := c.console.Get(globalConfigName, metav1.GetOptions{})
+	if err != nil {
+		// FIXME: fix when the console team starts using this
+		return &configv1.Console{}
+	}
+	return consoleConfig
+}
+
+func consoleToDeploymentData(console *configv1.Console) (string, []string) {
+	host := console.Status.PublicHostname
+
+	if len(host) == 0 {
+		return "", nil
+	}
+
+	assetPublicURL := "https://" + host  // needs to be a valid URL
+	corsAllowedOrigins := []string{host} // needs to be valid regexps
+
+	if _, err := url.Parse(assetPublicURL); err != nil { // should never happen
+		glog.Errorf("failed to parse assetPublicURL %s: %v", assetPublicURL, err)
+		return "", nil
+	}
+	for _, corsAllowedOrigin := range corsAllowedOrigins {
+		if _, err := regexp.Compile(corsAllowedOrigin); err != nil { // also should never happen
+			glog.Errorf("failed to parse corsAllowedOrigin %s: %v", corsAllowedOrigin, err)
+			return "", nil
+		}
+	}
+
+	return assetPublicURL, corsAllowedOrigins
+}

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -201,7 +201,9 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 		return err
 	}
 
-	oauthConfig, consoleConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, service)
+	consoleConfig := c.handleConsoleConfig()
+
+	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, service, consoleConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change allows the console to use Javascript to interact with
the OAuth server.  This is required for JS to easily perform certain
actions such as logout.  Note that the console was always in the
allowed CORS list for all 3.x releases.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @stlaz 