### PR TITLE
Add support for default key in operator boilerplate

### DIFF
--- a/manifests/0000_09_cluster-authentication-operator_05_deploy.yaml
+++ b/manifests/0000_09_cluster-authentication-operator_05_deploy.yaml
@@ -24,7 +24,7 @@ spec:
         command: ["authentication-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/operator-config.yaml"
-        - "-v=2"
+        - "-v=100"
         resources:
           requests:
             memory: 50Mi

--- a/pkg/boilerplate/controller/informer.go
+++ b/pkg/boilerplate/controller/informer.go
@@ -28,12 +28,12 @@ func withSync() InformerOption {
 }
 
 func informerOptionToOption(opt InformerOption, getter InformerGetter) Option {
-	switch opt() {
+	switch o := opt(); o {
 	case syncDefault:
 		return WithInformerSynced(getter) // safe default
 	case noSync:
 		return func(*controller) {} // do nothing
 	default:
-		panic(opt)
+		panic(int(o))
 	}
 }

--- a/pkg/boilerplate/operator/operator.go
+++ b/pkg/boilerplate/operator/operator.go
@@ -21,7 +21,7 @@ func New(name string, sync KeySyncer, opts ...Option) Runner {
 
 type operator struct {
 	name string
-	sync controller.KeySyncer
+	sync *wrapper
 
 	opts []controller.Option
 }

--- a/pkg/boilerplate/operator/option.go
+++ b/pkg/boilerplate/operator/option.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/cluster-authentication-operator/pkg/boilerplate/controller"
@@ -23,6 +25,21 @@ func WithInformer(getter controller.InformerGetter, filter controller.Filter, op
 			DeleteFunc: filter.Delete,
 		}, opts...),
 	)
+}
+
+func WithInitialEvent() Option {
+	return toAppendOpt(
+		controller.WithInitialEvent(key, key), // use singleton key for initial event
+	)
+}
+
+type DefaultCopyFunc func(v1.Object) v1.Object
+
+func WithDefaulting(key v1.Object, defaultCopyFunc DefaultCopyFunc) Option {
+	return func(o *operator) {
+		o.sync.key = reflect.ValueOf(key).Elem()
+		o.sync.defaultCopyFunc = defaultCopyFunc
+	}
 }
 
 func toAppendOpt(opt controller.Option) Option {

--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -107,7 +107,7 @@ func defaultDeployment(
 								"hypershift",
 								"openshift-osinserver",
 								fmt.Sprintf("--config=%s", cliConfigPath),
-								fmt.Sprintf("--v=%d", getLogLevel(operatorConfig.Spec.LogLevel)),
+								fmt.Sprintf("--v=%d", getLogLevel(operatorConfig.Spec.LogLevel)+100),
 							},
 							Ports: []corev1.ContainerPort{
 								{

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -134,6 +134,9 @@ func NewAuthenticationOperator(
 	prefixFilter := getPrefixFilter()
 
 	return operator.New("AuthenticationOperator2", c,
+		operator.WithInitialEvent(),
+		operator.WithDefaulting(&operatorv1.Authentication{}, defaultCopyAuthenticationFunc),
+
 		operator.WithInformer(routeInformer, targetNameFilter),
 		operator.WithInformer(coreInformers.Services(), targetNameFilter),
 		operator.WithInformer(kubeInformersNamespaced.Apps().V1().Deployments(), targetNameFilter),
@@ -286,6 +289,14 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	glog.V(4).Infof("current deployment: %#v", deployment)
 
 	return nil
+}
+
+func defaultCopyAuthenticationFunc(in metav1.Object) metav1.Object {
+	out := in.(*operatorv1.Authentication).DeepCopy()
+	if len(out.Spec.ManagementState) == 0 {
+		out.Spec.ManagementState = operatorv1.Managed
+	}
+	return out
 }
 
 func defaultLabels() map[string]string {

--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -32,12 +32,10 @@ const (
 apiVersion: operator.openshift.io/v1
 kind: Authentication
 metadata:
-  name: ` + globalConfigName + `
-spec:
-  managementState: Managed
-`
+  name: ` + globalConfigName
 
-	// TODO figure out the permanent home for top level CRDs and default CRs
+	// TODO these should all be rendered empty and defaulted via code
+	// TODO if we rendered these in the installer it would allow auth overrides before cluster start
 	defaultAuthentication = `
 apiVersion: config.openshift.io/v1
 kind: Authentication


### PR DESCRIPTION
Add support for default key in operator boilerplate

This change allows us to support flows where the key of the operator
does not exist (i.e. in case it is deleted).

It also adds generic support for defaulting the key.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Add defaulting for operatorv1.Authentication

This change makes it so that we render an empty
operatorv1.Authentication on start.  This is then defaulted to the
managed state at runtime.  A missing Authentication resource is
treated as the same as an empty one.

The defaults are stored once in the defaultCopyAuthenticationFunc
function (they are not duplicated in any manifests).  They are also
applied regardless of if the resource exists in the API (any unset
field means "give me the default").

Signed-off-by: Monis Khan <mkhan@redhat.com>