### PR TITLE
Redeploy when a secret/configmap from top-level config changes

### DIFF
--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -90,12 +90,6 @@ func (c *authOperator) handleOAuthConfig(
 		)
 	}
 
-	// TODO maybe move the OAuth stuff up one level
-	err = c.handleConfigSync(&syncData)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	assetPublicURL, corsAllowedOrigins := consoleToDeploymentData(consoleConfig)
 
 	// TODO this pretends this is an OsinServerConfig


### PR DESCRIPTION
Redeploys the osin server if any of the configMaps and secrets in the top-level config changed.

Manually tested.