### PR TITLE
Run single replica of authentication operator

### DIFF
--- a/manifests/cluster-authentication-operator_05_deploy.yaml
+++ b/manifests/cluster-authentication-operator_05_deploy.yaml
@@ -46,7 +46,7 @@ metadata:
   labels:
     app: origin-cluster-authentication-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: origin-cluster-authentication-operator


### PR DESCRIPTION
There is no need to run 3 replicas of the operator.