### PR TITLE
idp: add missing Teams attribute in GH IdP

### DIFF
--- a/pkg/operator2/idp.go
+++ b/pkg/operator2/idp.go
@@ -55,6 +55,7 @@ func convertProviderConfigToOsinBytes(providerConfig *configv1.IdentityProviderC
 			ClientID:      githubConfig.ClientID,
 			ClientSecret:  syncData.AddSecretStringSource(i, githubConfig.ClientSecret, configv1.ClientSecretKey, false),
 			Organizations: githubConfig.Organizations,
+			Teams:         githubConfig.Teams,
 			Hostname:      githubConfig.Hostname,
 			CA:            syncData.AddConfigMap(i, githubConfig.CA, corev1.ServiceAccountRootCAKey, true),
 		}


### PR DESCRIPTION
Hopefully last missing attribute.

This time I've gone through all of the IdPs in the file and checked with openshift/api that all the attributes from configv1 are taken into account for them, I did not find anything else to be missing.