### PR TITLE
fix(operator2/console): update console config resource name

### DIFF
--- a/pkg/operator2/console.go
+++ b/pkg/operator2/console.go
@@ -11,14 +11,9 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
-func (c *authOperator) handleConsoleConfig() *configv1.Console {
+func (c *authOperator) handleConsoleConfig() (*configv1.Console, error) {
 	// technically this should be an observed config loop
-	consoleConfig, err := c.console.Get(globalConfigName, metav1.GetOptions{})
-	if err != nil {
-		// FIXME: fix when the console team starts using this
-		return &configv1.Console{}
-	}
-	return consoleConfig
+	return c.console.Get(consoleConfigName, metav1.GetOptions{})
 }
 
 func consoleToDeploymentData(console *configv1.Console) (string, []string) {

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	targetName       = "openshift-authentication"
-	globalConfigName = "cluster"
+	targetName        = "openshift-authentication"
+	globalConfigName  = "cluster"
+	consoleConfigName = "console"
 
 	machineConfigNamespace = "openshift-config-managed"
 	userConfigNamespace    = "openshift-config"
@@ -210,7 +211,10 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	}
 	resourceVersions = append(resourceVersions, sessionSecret.GetResourceVersion())
 
-	consoleConfig := c.handleConsoleConfig()
+	consoleConfig, err := c.handleConsoleConfig()
+	if err != nil {
+		return err
+	}
 	resourceVersions = append(resourceVersions, consoleConfig.GetResourceVersion())
 
 	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, service, consoleConfig)


### PR DESCRIPTION
Console publishes its config under the name 'console' now.
Ref: https://github.com/openshift/console-operator/pull/134