### PR TITLE
Reduce log spam and turn off unneeded delegation

### DIFF
--- a/manifests/cluster-authentication-operator_03_cm.yaml
+++ b/manifests/cluster-authentication-operator_03_cm.yaml
@@ -7,3 +7,7 @@ data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig
+    authentication:
+      disabled: true
+    authorization:
+      disabled: true

--- a/manifests/cluster-authentication-operator_05_deploy.yaml
+++ b/manifests/cluster-authentication-operator_05_deploy.yaml
@@ -24,7 +24,7 @@ spec:
         command: ["authentication-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/operator-config.yaml"
-        - "-v=4"
+        - "-v=2"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
This change lowers the default log level of the operator to 2.  This prevents leader election spam (we still want leader election even with one replica to make sure we behave nicely during an upgrade).

It also disables delegated authentication and authorization as the operator does not expose any HTTP endpoints.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 