### PR TITLE
Move to OsinServerConfig

### DIFF
--- a/pkg/operator2/console.go
+++ b/pkg/operator2/console.go
@@ -15,7 +15,7 @@ func (c *authOperator) handleConsoleConfig() *configv1.Console {
 	// technically this should be an observed config loop
 	consoleConfig, err := c.console.Get(globalConfigName, metav1.GetOptions{})
 	if err != nil {
-		// FIXME: fix when the console team starts using this
+		glog.Infof("error getting console config: %v", err)
 		return &configv1.Console{}
 	}
 	return consoleConfig

--- a/pkg/operator2/infrastructure.go
+++ b/pkg/operator2/infrastructure.go
@@ -1,0 +1,19 @@
+package operator2
+
+import (
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func (c *authOperator) handleInfrastructureConfig() *configv1.Infrastructure {
+	infrastructureConfig, err := c.infrastructure.Get(globalConfigName, metav1.GetOptions{})
+	if err != nil {
+		glog.Infof("error getting infrastructure config: %v", err)
+		// have a placeholder that will at least look reasonable in the token request endpoint
+		return &configv1.Infrastructure{Status: configv1.InfrastructureStatus{APIServerURL: "<api_server_url>"}}
+	}
+	return infrastructureConfig
+}

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -90,6 +90,7 @@ type authOperator struct {
 	authentication configv1client.AuthenticationInterface
 	oauth          configv1client.OAuthInterface
 	console        configv1client.ConsoleInterface
+	infrastructure configv1client.InfrastructureInterface
 
 	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
@@ -120,6 +121,7 @@ func NewAuthenticationOperator(
 		authentication: configClient.ConfigV1().Authentications(),
 		oauth:          configClient.ConfigV1().OAuths(),
 		console:        configClient.ConfigV1().Consoles(),
+		infrastructure: configClient.ConfigV1().Infrastructures(),
 
 		resourceSyncer: resourceSyncer,
 	}
@@ -143,6 +145,7 @@ func NewAuthenticationOperator(
 		operator.WithInformer(configV1Informers.Authentications(), configNameFilter),
 		operator.WithInformer(configV1Informers.OAuths(), configNameFilter),
 		operator.WithInformer(configV1Informers.Consoles(), configNameFilter, controller.WithNoSync()),
+		operator.WithInformer(configV1Informers.Infrastructures(), configNameFilter, controller.WithNoSync()),
 	)
 }
 
@@ -235,7 +238,10 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	consoleConfig := c.handleConsoleConfig()
 	resourceVersions = append(resourceVersions, consoleConfig.GetResourceVersion())
 
-	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, service, consoleConfig)
+	infrastructureConfig := c.handleInfrastructureConfig()
+	resourceVersions = append(resourceVersions, infrastructureConfig.GetResourceVersion())
+
+	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, service, consoleConfig, infrastructureConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change moves to the OsinServerConfig struct.  This removes our dependence on the KubeAPIServerConfig.

It also wires the apiServerURL from the top level infrastructure config.  This allows us to provide the correct login url for the token request endpoint.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 

/hold

Blocked on https://github.com/openshift/origin/pull/21987