### PR TITLE
Bug 1677587: Add openAPIV3Schema validation to operator config

### DIFF
--- a/manifests/cluster-authentication-operator_02_config.crd.yaml
+++ b/manifests/cluster-authentication-operator_02_config.crd.yaml
@@ -12,3 +12,149 @@ spec:
     singular: authentication
   subresources:
     status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: +required
+          properties:
+            logLevel:
+              description: logLevel is an intent based logging for an overall component.  It
+                does not give fine grained control, but it is a simple way to manage
+                coarse grained logging choices that operators have to interpret for
+                their operands.
+              type: string
+            managementState:
+              description: managementState indicates whether and how the operator
+                should manage the component
+              pattern: ^Managed|Unmanaged|Force|Removed$
+              type: string
+            observedConfig:
+              description: observedConfig holds a sparse config that controller has
+                observed from the cluster state.  It exists in spec because it is
+                an input to the level for the operator +nullable
+              type: object
+            operandSpecs:
+              description: operandSpecs provide customization for functional units
+                within the component
+              items:
+                properties:
+                  name:
+                    description: name is the name of this unit.  The operator must
+                      be aware of it.
+                    type: string
+                  operandContainerSpecs:
+                    description: operandContainerSpecs are per-container options
+                    items:
+                      properties:
+                        name:
+                          description: name is the name of the container to modify
+                          type: string
+                        resources:
+                          description: resources are the requests and limits to place
+                            in the container.  Nil means to accept the defaults.
+                          type: object
+                      type: object
+                    type: array
+                  unsupportedResourcePatches:
+                    description: 'unsupportedResourcePatches are applied to the workload
+                      resource for this unit. This is an unsupported workaround if
+                      anything needs to be modified on the workload that is not otherwise
+                      configurable. TODO Decide: alternatively, we could simply include
+                      a RawExtension which is used in place of the "normal" default
+                      manifest'
+                    items:
+                      properties:
+                        patch:
+                          description: patch the patch itself
+                          type: string
+                        type:
+                          description: 'type is the type of patch to apply: jsonmerge,
+                            strategicmerge'
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              type: array
+            unsupportedConfigOverrides:
+              description: 'unsupportedConfigOverrides holds a sparse config that
+                will override any previously set options.  It only needs to be the
+                fields to override it will end up overlaying in the following order:
+                1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides
+                +nullable'
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: conditions is a list of conditions and their status
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            generations:
+              description: generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              items:
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  hash:
+                    description: hash is an optional field set for resources without
+                      generation that are content sensitive like secrets and configmaps
+                    type: string
+                  lastGeneration:
+                    description: lastGeneration is the last generation of the workload
+                      controller involved
+                    format: int64
+                    type: integer
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+                type: object
+              type: array
+            observedGeneration:
+              description: observedGeneration is the last generation change you've
+                dealt with
+              format: int64
+              type: integer
+            readyReplicas:
+              description: readyReplicas indicates how many replicas are ready and
+                at the desired state
+              format: int32
+              type: integer
+            version:
+              description: version is the level this availability applies to
+              type: string
+          type: object


### PR DESCRIPTION
@enj  I used `library-go/cmd/crd-schema-gen` to generate the CRD validation

operator api has been updated recently, so had to bump deps to get the fancy crd-validation-gen.  however, that bump caused issues in auth-operator that I did not want to fix in this PR, so I  deleted the bump commits, will address those issues here: https://github.com/openshift/cluster-authentication-operator/pull/97