### PR TITLE
fix template synced secret names

### DIFF
--- a/pkg/operator2/configsync.go
+++ b/pkg/operator2/configsync.go
@@ -236,7 +236,8 @@ func getIDPPath(i int, resource, name string) string {
 }
 
 func getTemplateName(name, key string) string {
-	return fmt.Sprintf("%s-%s-%s", userConfigPrefixTemplate, name, key)
+	newKey := strings.Replace(strings.ToLower(key), ".", "-", -1)
+	return fmt.Sprintf("%s-%s-%s", userConfigPrefixTemplate, name, newKey)
 }
 
 func getTemplatePath(name, key string) string {


### PR DESCRIPTION
For some reason I did not think I'd need the dots replace when I started doing it and later I forgot to add it.

I did not test this yet, I bricked my cluster before I get to do it.