### PR TITLE
Don't error out if top level configs do not exist

### DIFF
--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -153,7 +153,10 @@ func (c *authOperator) Key() (metav1.Object, error) {
 func (c *authOperator) Sync(obj metav1.Object) error {
 	operatorConfig := obj.(*operatorv1.Authentication)
 
-	if operatorConfig.Spec.ManagementState != operatorv1.Managed {
+	switch operatorConfig.Spec.ManagementState {
+	// Handle "" as Managed, too
+	case operatorv1.Managed, "":
+	default:
 		return nil // TODO do something better for all states
 	}
 


### PR DESCRIPTION
When either or both the OAuth and Authentication objects is not found,
don't fail and assume the defaults.

-----

The operator's config itself is handled in https://github.com/openshift/cluster-authentication-operator/pull/65