### PR TITLE
Update operator and operand manifests for priority and imagePolicy

### DIFF
--- a/manifests/cluster-authentication-operator_05_deploy.yaml
+++ b/manifests/cluster-authentication-operator_05_deploy.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: operator
         image: quay.io/openshift/origin-cluster-authentication-operator:v4.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["authentication-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/operator-config.yaml"

--- a/manifests/cluster-authentication-operator_05_deploy.yaml
+++ b/manifests/cluster-authentication-operator_05_deploy.yaml
@@ -49,5 +49,6 @@ spec:
           name: openshift-authentication-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists

--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -140,6 +140,7 @@ func defaultDeployment(
 					NodeSelector: map[string]string{
 						"node-role.kubernetes.io/master": "",
 					},
+					PriorityClassName: "system-cluster-critical",
 					Tolerations: []corev1.Toleration{{
 						Operator: corev1.TolerationOpExists,
 					}},


### PR DESCRIPTION
Operators deployed via the CVO should have system-cluster-critical priority.
Operators that use shas for images should use IfNotPresent pull policy.