### PR TITLE
Correctly handle OAuth templates

### DIFF
--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -53,9 +53,9 @@ func (c *authOperator) handleOAuthConfig(
 	emptyTemplates := configv1.OAuthTemplates{}
 	if configTemplates := oauthConfig.Spec.Templates; configTemplates != emptyTemplates {
 		templates = &osinv1.OAuthTemplates{
-			Login:             syncData.AddTemplateSecret(configTemplates.Login, configv1.LoginTemplateKey),
-			ProviderSelection: syncData.AddTemplateSecret(configTemplates.ProviderSelection, configv1.ProviderSelectionTemplateKey),
-			Error:             syncData.AddTemplateSecret(configTemplates.Error, configv1.ErrorsTemplateKey),
+			Login:             syncData.addTemplateSecret(configTemplates.Login, loginField, configv1.LoginTemplateKey),
+			ProviderSelection: syncData.addTemplateSecret(configTemplates.ProviderSelection, providerSelectionField, configv1.ProviderSelectionTemplateKey),
+			Error:             syncData.addTemplateSecret(configTemplates.Error, errorField, configv1.ErrorsTemplateKey),
 		}
 	}
 

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -47,6 +47,17 @@ const (
 
 	// secrets and config maps synced from openshift-config into our namespace have this prefix
 	userConfigPrefix = configVersionPrefix + "user-"
+	// idps that are synced have this prefix
+	userConfigPrefixIDP = userConfigPrefix + "idp-"
+	// templates that are synced have this prefix
+	userConfigPrefixTemplate = userConfigPrefix + "template-"
+
+	// secrets and config maps synced from openshift-config into our namespace have this path prefix
+	userConfigPath = "/var/config/user"
+	// root path for IDP data
+	userConfigPathPrefixIDP = userConfigPath + "/" + "idp"
+	// root path for template data
+	userConfigPathPrefixTemplate = userConfigPath + "/" + "template"
 
 	sessionNameAndKey = systemConfigPrefix + "session"
 	sessionMount      = systemConfigPathSecrets + "/" + sessionNameAndKey
@@ -72,8 +83,6 @@ const (
 	routerCertsSharedName = "router-certs"
 	routerCertsLocalName  = systemConfigPrefix + routerCertsSharedName
 	routerCertsLocalMount = systemConfigPathSecrets + "/" + routerCertsLocalName
-
-	userConfigPath = "/var/config/user"
 
 	servicePort   = 443
 	containerPort = 6443


### PR DESCRIPTION
This change fixes how we handle OAuth templates (we correctly build the secret name and path).

As part of the fix, end-user provided names are not used in any way to determine the destination secret or path.

AUTH-223

Signed-off-by: Monis Khan <mkhan@redhat.com>

This was tested with htpasswd, github and the login template.

/assign @stlaz 
cc @barleyer 