### PR TITLE
Add version to (cluster)operator status

### DIFF
--- a/manifests/cluster-authentication-operator_05_deploy.yaml
+++ b/manifests/cluster-authentication-operator_05_deploy.yaml
@@ -37,6 +37,8 @@ spec:
           value: quay.io/openshift/origin-hypershift:v4.0
         - name: OPERATOR_IMAGE
           value: docker.io/openshift/origin-cluster-authentication-operator:v4.0  # I believe this is supposed to exist
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/cluster-authentication-operator_06_clusteroperator.yaml
+++ b/manifests/cluster-authentication-operator_06_clusteroperator.yaml
@@ -1,0 +1,4 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: authentication

--- a/manifests/cluster-authentication-operator_06_clusteroperator.yaml
+++ b/manifests/cluster-authentication-operator_06_clusteroperator.yaml
@@ -2,3 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: authentication
+status:
+  versions:
+  - name: operator
+    version: "0.0.1-snapshot"

--- a/pkg/operator2/status.go
+++ b/pkg/operator2/status.go
@@ -5,54 +5,40 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-func (c *authOperator) setFailingStatus(operatorConfig *operatorv1.Authentication, reason, message string) error {
-	failStatusFunc := func(status *operatorv1.OperatorStatus) error {
-		v1helpers.SetOperatorCondition(&status.Conditions,
-			operatorv1.OperatorCondition{
-				Type:    operatorv1.OperatorStatusTypeFailing,
-				Status:  operatorv1.ConditionTrue,
-				Reason:  reason,
-				Message: message,
-			})
-
-		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
-			Type:   operatorv1.OperatorStatusTypeProgressing,
-			Status: operatorv1.ConditionFalse,
+func (c *authOperator) setFailingStatus(operatorConfig *operatorv1.Authentication, reason, message string) {
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions,
+		operatorv1.OperatorCondition{
+			Type:    operatorv1.OperatorStatusTypeFailing,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  reason,
+			Message: message,
 		})
 
-		v1helpers.SetOperatorCondition(&status.Conditions,
-			operatorv1.OperatorCondition{
-				Type:   operatorv1.OperatorStatusTypeAvailable,
-				Status: operatorv1.ConditionFalse,
-			})
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeProgressing,
+		Status: operatorv1.ConditionFalse,
+	})
 
-		return nil
-	}
-
-	_, _, err := v1helpers.UpdateStatus(c.authOperatorConfigClient, failStatusFunc)
-	return err
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions,
+		operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeAvailable,
+			Status: operatorv1.ConditionFalse,
+		})
 }
 
-func (c *authOperator) setAvailableStatus(operatorConfig *operatorv1.Authentication) error {
-	availStatusFunc := func(status *operatorv1.OperatorStatus) error {
-		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
-			Type:   operatorv1.OperatorStatusTypeAvailable,
-			Status: operatorv1.ConditionTrue,
-		})
+func (c *authOperator) setAvailableStatus(operatorConfig *operatorv1.Authentication) {
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeAvailable,
+		Status: operatorv1.ConditionTrue,
+	})
 
-		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
-			Type:   operatorv1.OperatorStatusTypeProgressing,
-			Status: operatorv1.ConditionFalse,
-		})
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeProgressing,
+		Status: operatorv1.ConditionFalse,
+	})
 
-		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
-			Type:   operatorv1.OperatorStatusTypeFailing,
-			Status: operatorv1.ConditionFalse,
-		})
-
-		return nil
-	}
-
-	_, _, err := v1helpers.UpdateStatus(c.authOperatorConfigClient, availStatusFunc)
-	return err
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeFailing,
+		Status: operatorv1.ConditionFalse,
+	})
 }


### PR DESCRIPTION
Adds the version we get from the deployment to the clusteroperator
and authetnication.operator statuses. Also delays the authentication.operator
status updates to the end of Sync() so that we don't stomp on our own foot
should we want to be calling either of the set*Status() methods.

Also adds the clusteroperator to manifests.
