### PR TITLE
redeploy on operatorConfig.spec changes

### DIFF
--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -199,7 +199,7 @@ func toVolumesAndMounts(data map[string]sourceData, volumes []corev1.Volume, mou
 
 func getLogLevel(logLevel operatorv1.LogLevel) int {
 	switch logLevel {
-	case operatorv1.Normal:
+	case operatorv1.Normal, "": // treat empty string to mean the default
 		return 2
 	case operatorv1.Debug:
 		return 4


### PR DESCRIPTION
logLevel: treat empty string to mean the default

We do not have strong validation for the logLevel field today.  Yet
we want to make sure OAuth failures are apparent in the OAuth
server's logs.  Thus for now we will treat empty string as the same
as Normal.  This translates to glog level 2 which captures OAuth
failures.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

redeploy on operatorConfig.spec changes

Since we no longer track the resource version of operatorConfig in
the OAuth server's deployment, a change to operatorConfig.spec will
not cause ApplyDeployment to issue an update.  Because we track the
generation in operatorConfig.status, we can compare it to determine
if a force redeploy is required.  This is effectively the same as if
we used the operatorConfig.generation as its "resource version."

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/assign @stlaz 