### PR TITLE
Tighten APIs

### DIFF
--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -61,19 +61,19 @@ func (c *authOperator) handleOAuthConfig(
 
 	identityProviders := make([]osinv1.IdentityProvider, 0, len(oauthConfig.Spec.IdentityProviders))
 	for i, idp := range oauthConfig.Spec.IdentityProviders {
-		providerConfigBytes, err := convertProviderConfigToOsinBytes(&idp.IdentityProviderConfig, &syncData, i)
+		data, err := convertProviderConfigToIDPData(&idp.IdentityProviderConfig, &syncData, i)
 		if err != nil {
-			glog.Error(err)
+			glog.Errorf("failed to honor IDP %#v: %v", idp, err)
 			continue
 		}
 		identityProviders = append(identityProviders,
 			osinv1.IdentityProvider{
 				Name:            idp.Name,
-				UseAsChallenger: idp.UseAsChallenger,
-				UseAsLogin:      idp.UseAsLogin,
+				UseAsChallenger: data.challenge,
+				UseAsLogin:      data.login,
 				MappingMethod:   string(idp.MappingMethod),
 				Provider: runtime.RawExtension{
-					Raw: providerConfigBytes,
+					Raw: encodeOrDie(data.provider),
 				},
 			},
 		)

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -120,7 +120,7 @@ func (c *authOperator) handleOAuthConfig(
 			AlwaysShowProviderSelection: false,
 			IdentityProviders:           identityProviders,
 			GrantConfig: osinv1.GrantConfig{
-				Method:               osinv1.GrantHandlerPrompt, // TODO check
+				Method:               osinv1.GrantHandlerDeny, // force denial as this field must be set per OAuth client
 				ServiceAccountMethod: osinv1.GrantHandlerPrompt,
 			},
 			SessionConfig: &osinv1.SessionConfig{

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -61,7 +61,7 @@ func (c *authOperator) handleOAuthConfig(
 
 	identityProviders := make([]osinv1.IdentityProvider, 0, len(oauthConfig.Spec.IdentityProviders))
 	for i, idp := range oauthConfig.Spec.IdentityProviders {
-		data, err := convertProviderConfigToIDPData(&idp.IdentityProviderConfig, &syncData, i)
+		data, err := c.convertProviderConfigToIDPData(&idp.IdentityProviderConfig, &syncData, i)
 		if err != nil {
 			glog.Errorf("failed to honor IDP %#v: %v", idp, err)
 			continue

--- a/pkg/operator2/transport.go
+++ b/pkg/operator2/transport.go
@@ -1,0 +1,57 @@
+package operator2
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/net"
+	ktransport "k8s.io/client-go/transport"
+)
+
+// TODO move all this to library-go
+
+// transportFor returns an http.Transport for the given ca and client cert data (which may be empty)
+func transportFor(caData, certData, keyData []byte) (http.RoundTripper, error) {
+	transport, err := transportForInner(caData, certData, keyData)
+	if err != nil {
+		return nil, err
+	}
+	return ktransport.DebugWrappers(transport), nil
+}
+
+func transportForInner(caData, certData, keyData []byte) (http.RoundTripper, error) {
+	if len(caData) == 0 && len(certData) == 0 && len(keyData) == 0 {
+		return http.DefaultTransport, nil
+	}
+
+	if (len(certData) == 0) != (len(keyData) == 0) {
+		return nil, errors.New("cert and key data must be specified together")
+	}
+
+	// copy default transport
+	transport := net.SetTransportDefaults(&http.Transport{
+		TLSClientConfig: &tls.Config{},
+	})
+
+	if len(caData) != 0 {
+		roots := x509.NewCertPool()
+		if ok := roots.AppendCertsFromPEM(caData); !ok {
+			// avoid logging data that could contain keys
+			return nil, errors.New("error loading cert pool from ca data")
+		}
+		transport.TLSClientConfig.RootCAs = roots
+	}
+
+	if len(certData) != 0 {
+		cert, err := tls.X509KeyPair(certData, keyData)
+		if err != nil {
+			// avoid logging data that will contain keys
+			return nil, errors.New("error loading x509 keypair from cert and key data")
+		}
+		transport.TLSClientConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return transport, nil
+}

--- a/vendor/github.com/openshift/api/config/v1/types_oauth.go
+++ b/vendor/github.com/openshift/api/config/v1/types_oauth.go
@@ -516,6 +516,10 @@ type OpenIDIdentityProvider struct {
 	// +optional
 	ExtraAuthorizeParameters map[string]string `json:"extraAuthorizeParameters"`
 
+	// issuer is the URL that the OpenID Provider asserts as its Issuer Identifier.
+	// It must use the https scheme with no query or fragment component.
+	Issuer string `json:"issuer"`
+
 	// urls to use to authenticate
 	URLs OpenIDURLs `json:"urls"`
 


### PR DESCRIPTION
Make default grant method impossible to use

Set the default grant method to deny so that all OAuth clients are
forced to set it explicitly.  The validation in origin will be
updated to mark grant method as required.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Infer challenge and login based on IDP

These fields offer a level of flexibility that is not particularly
useful to admins.  In reality all IDPs have a correct configuration
for these fields based on the feature set that the IDP supports.  We
should avoid asking users questions that we already know the answer
to.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Add issuer to OpenIDIdentityProvider

This change adds an issuer field which can be used to perform
discovery via the /.well-known/openid-configuration endpoint.  This
makes the OpenIDURLs struct obsolete.  It will be removed when this
change is made to the openshift/api repo.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

OpenID: add discovery via /.well-known/openid-configuration

This change adds support for discovering OpenID configuration via
the issuer's /.well-known/openid-configuration endpoint.  This
reduces the config that is required (and the associated chance of
configuration errors) while preserving the same feature set.

Temporary fallback code was added to respect the old urls struct.
This allows an admin to migrate configuration and prevents upgrades
from breaking.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/assign @stlaz 