### PR TITLE
Bug 1691488: Fix route healthz to tolerate custom wildcard certs

### DIFF
--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -167,7 +167,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		configInformers,
 		configClient,
 		versionGetter,
-		ctx.KubeConfig,
 		ctx.EventRecorder,
 		resourceSyncer,
 	)


### PR DESCRIPTION
This change builds a transport using the router-certs secret
provided by the ingress operator (this secret is expected to
contain both the CA and cert data).  If no CA data is found, it is
assumed that the admin has replaced the default wildcard certificate
with a globally valid cert.  To handle this, we fallback to the
default transport.

Remove use of rest.Config in favor of building custom transports.
This prevents us from emitting our service account token
unnecessarily.

Properly check well-known (we incorrectly skipped it).

Generally improve our readiness error reporting.

Bug 1691488

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 