### PR TITLE
Bug 1695244: Correctly determine operand version

### DIFF
--- a/manifests/cluster-authentication-operator_03_version-mapping.yaml
+++ b/manifests/cluster-authentication-operator_03_version-mapping.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: openshift-authentication-operator
-  name: version-mapping
-data:
-  "0.0.1-snapshot_openshift": "quay.io/openshift/origin-hypershift:v4.0"
-  "0.0.1-snapshot": "quay.io/openshift/origin-cluster-authentication-operator:v4.0"

--- a/manifests/cluster-authentication-operator_05_deploy.yaml
+++ b/manifests/cluster-authentication-operator_05_deploy.yaml
@@ -37,6 +37,8 @@ spec:
           value: quay.io/openshift/origin-hypershift:v4.0
         - name: OPERATOR_IMAGE_VERSION
           value: "0.0.1-snapshot"
+        - name: OPERAND_IMAGE_VERSION
+          value: "0.0.1-snapshot_openshift"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -106,7 +105,7 @@ func defaultDeployment(
 					SecurityContext:               &corev1.PodSecurityContext{},
 					Containers: []corev1.Container{
 						{
-							Image:           os.Getenv("IMAGE"),
+							Image:           osinImage,
 							ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
 							Name:            targetName,
 							Command: []string{


### PR DESCRIPTION
This change updates the operator deployment to include the operand
version as an environment variable.  Since we encode the operator
deployment RV into the operand deployment, we correctly gate on
changing the version until the new version has rolled out.

The VersionForOperand function uses a config map with a version to
image mapping to determine the operand version.  It does this by
reversing the mapping (image to version).  This has a serious flaw
in that it assumes that all versions point to distinct images
(which is not the case since an image may not change during a
release).  Since map iteration order is undefined, this can lead to
the operand version flapping back and forth as the reversed map
changes based on which image value was written last.

Remove version-mapping config map as it is no longer used.

All environment variable names and values are now stored as consts
and vars, respectively (the values are effectively runtime consts as
they cannot change once the operator is running).

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 
/assign @sallyom 