### PR TITLE
Make it easier to control operand image pull policy

### DIFF
--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -345,6 +345,7 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 		operatorConfig,
 		syncData,
 		routerSecret,
+		operatorDeployment,
 		resourceVersions...,
 	)
 	// TODO add support for spec.operandSpecs.unsupportedResourcePatches, like:


### PR DESCRIPTION
Tie the operand's image pull policy to the operator's image pull
policy.  This makes it easy during development to change both the
operator and operand's image once the CVO is configured to no longer
manage the operator.

Signed-off-by: Monis Khan <mkhan@redhat.com>