### PR TITLE
Use CVO for management of operator config resource

### DIFF
--- a/manifests/02_config.cr.yaml
+++ b/manifests/02_config.cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+  annotations:
+    release.openshift.io/create-only: "true"
+spec:
+  managementState: Managed


### PR DESCRIPTION
Change the reference to EnsureOperatorConfigExists helper, which is being removed, to instead create the operator resource with the other manifests and tag it to be managed by the CVO