### PR TITLE
Bug 1694818: remove emoji from event logs

### DIFF
--- a/pkg/boilerplate/operator/option.go
+++ b/pkg/boilerplate/operator/option.go
@@ -6,27 +6,19 @@ import (
 	"github.com/openshift/cluster-authentication-operator/pkg/boilerplate/controller"
 )
 
-// key is the singleton key shared by all events
-// the value is irrelevant, but pandas are awesome
-const key = "🐼"
-
 type Option func(*operator)
 
 func WithInformer(getter controller.InformerGetter, filter controller.Filter, opts ...controller.InformerOption) Option {
-	return toAppendOpt(
-		controller.WithInformer(getter, controller.FilterFuncs{
-			ParentFunc: func(obj v1.Object) (namespace, name string) {
-				return key, key // return our singleton key for all events
-			},
-			AddFunc:    filter.Add,
-			UpdateFunc: filter.Update,
-			DeleteFunc: filter.Delete,
-		}, opts...),
-	)
-}
-
-func toAppendOpt(opt controller.Option) Option {
 	return func(o *operator) {
-		o.opts = append(o.opts, opt)
+		o.opts = append(o.opts,
+			controller.WithInformer(getter, controller.FilterFuncs{
+				ParentFunc: func(obj v1.Object) (namespace, name string) {
+					return o.name, o.name // return our singleton key for all events
+				},
+				AddFunc:    filter.Add,
+				UpdateFunc: filter.Update,
+				DeleteFunc: filter.Delete,
+			}, opts...),
+		)
 	}
 }


### PR DESCRIPTION
Cause: operator used an emoji as the operator informer key

Consequence: error logs contain emoji character, confusing users

Fix: change key to more boring but informative value

Result: errors from operator controller shows "authentication-operator"
instead of emoji