### PR TITLE
Default mapping method to claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ metadata:
 spec:
   identityProviders:
   - name: htpassidp
-    mappingMethod: claim
     type: HTPasswd
     htpasswd:
       fileData:

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -179,6 +179,12 @@ func getMasterCA() *string {
 func defaultOAuthConfig(oauthConfig *configv1.OAuth) *configv1.OAuth {
 	out := oauthConfig.DeepCopy() // do not mutate informer cache
 
+	for i := range out.Spec.IdentityProviders {
+		if out.Spec.IdentityProviders[i].MappingMethod == "" {
+			out.Spec.IdentityProviders[i].MappingMethod = configv1.MappingMethodClaim
+		}
+	}
+
 	if out.Spec.TokenConfig.AccessTokenMaxAgeSeconds == 0 {
 		out.Spec.TokenConfig.AccessTokenMaxAgeSeconds = 24 * 60 * 60 // 1 day
 	}


### PR DESCRIPTION
This allows the mapping method value to be left unset and defaulted.

This is primarily for consistency with the rest of the config APIs as we likely never change the default to anything else.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@stlaz you validation needs to tolerate this (I do not know if it does or not).
@spadgett @benjaminapetersen FYI so that you can remove the mapping method from the console.