### PR TITLE
Bug 1694878: Confirm that all KAS have observed our OAuth metadata

### DIFF
--- a/pkg/operator2/idp.go
+++ b/pkg/operator2/idp.go
@@ -293,7 +293,7 @@ func (c *authOperator) discoverOpenIDURLs(issuer, key string, ca configv1.Config
 
 func (c *authOperator) transportForCARef(ca configv1.ConfigMapNameReference, key string) (http.RoundTripper, error) {
 	if len(ca.Name) == 0 {
-		return transportFor(nil, nil, nil)
+		return transportFor("", nil, nil, nil)
 	}
 	cm, err := c.configMaps.ConfigMaps(userConfigNamespace).Get(ca.Name, metav1.GetOptions{})
 	if err != nil {
@@ -306,7 +306,7 @@ func (c *authOperator) transportForCARef(ca configv1.ConfigMapNameReference, key
 	if len(caData) == 0 {
 		return nil, fmt.Errorf("config map %s/%s has no ca data at key %s", userConfigNamespace, ca.Name, key)
 	}
-	return transportFor(caData, nil, nil)
+	return transportFor("", caData, nil, nil)
 }
 
 type openIDProviderJSON struct {

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -60,6 +60,7 @@ const (
 	userConfigNamespace    = "openshift-config"
 
 	kasServiceAndEndpointName = "kubernetes"
+	kasServiceFullName        = kasServiceAndEndpointName + "." + corev1.NamespaceDefault + ".svc"
 
 	rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
@@ -477,7 +478,7 @@ func (c *authOperator) checkDeploymentReady(deployment *appsv1.Deployment, opera
 func (c *authOperator) checkRouteHealthy(route *routev1.Route, routerSecret *corev1.Secret) (bool, string, error) {
 	caData := routerSecretToCA(route, routerSecret)
 
-	rt, err := transportFor(caData, nil, nil)
+	rt, err := transportFor("", caData, nil, nil)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to build transport for route: %v", err)
 	}
@@ -512,7 +513,8 @@ func (c *authOperator) checkWellknownEndpointsReady(authConfig *configv1.Authent
 		return false, "", fmt.Errorf("failed to read SA ca.crt: %v", err)
 	}
 
-	rt, err := transportFor(caData, nil, nil)
+	// pass the KAS service name for SNI
+	rt, err := transportFor(kasServiceFullName, caData, nil, nil)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to build transport for SA ca.crt: %v", err)
 	}

--- a/pkg/operator2/transport.go
+++ b/pkg/operator2/transport.go
@@ -13,15 +13,15 @@ import (
 // TODO move all this to library-go
 
 // transportFor returns an http.Transport for the given ca and client cert data (which may be empty)
-func transportFor(caData, certData, keyData []byte) (http.RoundTripper, error) {
-	transport, err := transportForInner(caData, certData, keyData)
+func transportFor(serverName string, caData, certData, keyData []byte) (http.RoundTripper, error) {
+	transport, err := transportForInner(serverName, caData, certData, keyData)
 	if err != nil {
 		return nil, err
 	}
 	return ktransport.DebugWrappers(transport), nil
 }
 
-func transportForInner(caData, certData, keyData []byte) (http.RoundTripper, error) {
+func transportForInner(serverName string, caData, certData, keyData []byte) (http.RoundTripper, error) {
 	if len(caData) == 0 && len(certData) == 0 && len(keyData) == 0 {
 		return http.DefaultTransport, nil
 	}
@@ -32,7 +32,9 @@ func transportForInner(caData, certData, keyData []byte) (http.RoundTripper, err
 
 	// copy default transport
 	transport := net.SetTransportDefaults(&http.Transport{
-		TLSClientConfig: &tls.Config{},
+		TLSClientConfig: &tls.Config{
+			ServerName: serverName,
+		},
 	})
 
 	if len(caData) != 0 {


### PR DESCRIPTION
Confirm that all KAS have observed our OAuth metadata

This change updates the well known check to verify that all masters
have observed our metadata config.  The IP of the masters is
determined by their endpoints resource.

This prevents a race in CI where the install will report completed
and start running tests that fail with an "Unauthorized" error.
This error occurs because a request was sent to a master that had
not observed our OAuth metadata and thus had the logic the honors
OAuth tokens disabled.

Bug 1694878

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

SNI: Set ServerName to KAS for well-known

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Logs from testing:

```
I0426 17:58:26.235995       1 round_trippers.go:438] GET https://172.30.0.1:443/api/v1/namespaces/default/services/kubernetes 200 OK in 3 milliseconds
I0426 17:58:26.436188       1 round_trippers.go:438] GET https://172.30.0.1:443/api/v1/namespaces/default/endpoints/kubernetes 200 OK in 3 milliseconds
I0426 17:58:26.449164       1 round_trippers.go:438] GET https://10.0.143.207:6443/.well-known/oauth-authorization-server 200 OK in 12 milliseconds
I0426 17:58:26.455688       1 round_trippers.go:438] GET https://10.0.158.191:6443/.well-known/oauth-authorization-server 200 OK in 6 milliseconds
I0426 17:58:26.464259       1 round_trippers.go:438] GET https://10.0.160.230:6443/.well-known/oauth-authorization-server 200 OK in 8 milliseconds
```

```yaml
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2019-04-26T12:16:22Z"
  labels:
    component: apiserver
    provider: kubernetes
  name: kubernetes
  namespace: default
  resourceVersion: "175"
  selfLink: /api/v1/namespaces/default/services/kubernetes
  uid: 1b147e4c-681d-11e9-9061-0a8486f0fbd2
spec:
  clusterIP: 172.30.0.1
  ports:
  - name: https
    port: 443
    protocol: TCP
    targetPort: 6443
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```

```yaml
apiVersion: v1
kind: Endpoints
metadata:
  creationTimestamp: "2019-04-26T12:16:22Z"
  name: kubernetes
  namespace: default
  resourceVersion: "17018"
  selfLink: /api/v1/namespaces/default/endpoints/kubernetes
  uid: 1b17823a-681d-11e9-9061-0a8486f0fbd2
subsets:
- addresses:
  - ip: 10.0.143.207
  - ip: 10.0.158.191
  - ip: 10.0.160.230
  ports:
  - name: https
    port: 6443
    protocol: TCP
```

@openshift/sig-auth 