### PR TITLE
honor branding in authentication #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-authentication-operator
 COPY . .
-RUN go build -o authentication-operator ./cmd/authentication-operator
+RUN ADDITIONAL_GOTAGS="ocp" go build -o authentication-operator ./cmd/authentication-operator
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/authentication-operator /usr/bin/

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-authentication-operator
 COPY . .
-RUN go build -o authentication-operator ./cmd/authentication-operator
+RUN ADDITIONAL_GOTAGS="ocp" go build -o authentication-operator ./cmd/authentication-operator
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/authentication-operator /usr/bin/

--- a/pkg/operator2/managed_console_config.go
+++ b/pkg/operator2/managed_console_config.go
@@ -1,0 +1,17 @@
+package operator2
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+func (c *authOperator) handleManagedConfigMap() *corev1.ConfigMap {
+	managedConfig, err := c.configMaps.ConfigMaps(managedConfigNamespace).Get(managedConsoleConfig, metav1.GetOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		klog.Infof("error getting managed config: %v", err)
+		return nil
+	}
+	return managedConfig
+}

--- a/pkg/operator2/oauth_test.go
+++ b/pkg/operator2/oauth_test.go
@@ -1,0 +1,30 @@
+package operator2
+
+import (
+	"testing"
+)
+
+func TestInValidManagedConsoleConfig(t *testing.T) {
+	cm := getCliConfigMap([]byte(`
+kind: Console
+apiVersion: config.openshift.io/v1
+customization:
+  branding: okd
+  documentationBaseURL: https://docs.okd.io/4.0/
+`))
+	_, err := managedConsoleConfigBytes(cm)
+	if err != nil {
+		t.Fatal("Error in embedded object", err)
+	}
+}
+
+func TestValidManagedConsoleConfig(t *testing.T) {
+	cm := getCliConfigMap([]byte(`
+kind: FeatureGate
+apiVersion: config.openshift.io/v1
+`))
+	_, err := managedConsoleConfigBytes(cm)
+	if err == nil {
+		t.Fatal("Only Console objects are allowed")
+	}
+}

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -55,7 +55,8 @@ const (
 	operandImageEnvName    = "IMAGE"
 	apiHostEnvName         = "KUBERNETES_SERVICE_HOST"
 
-	machineConfigNamespace = "openshift-config-managed"
+	managedConfigNamespace = "openshift-config-managed"
+	managedConsoleConfig   = "console-config"
 	userConfigNamespace    = "openshift-config"
 
 	rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
@@ -317,7 +318,13 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	infrastructureConfig := c.handleInfrastructureConfig()
 	resourceVersions = append(resourceVersions, infrastructureConfig.GetResourceVersion())
 
-	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, routerSecret, service, consoleConfig, infrastructureConfig)
+	managedConsoleConfig := c.handleManagedConfigMap()
+	if err != nil {
+		return fmt.Errorf("failed fetching managed brand configuration: %v", err)
+	}
+	resourceVersions = append(resourceVersions, managedConsoleConfig.GetResourceVersion())
+
+	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, routerSecret, service, consoleConfig, infrastructureConfig, managedConsoleConfig)
 	if err != nil {
 		return fmt.Errorf("failed handling OAuth configuration: %v", err)
 	}

--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -78,7 +78,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		kubeClient,
 		targetNamespace,
 		userConfigNamespace,
-		machineConfigNamespace,
+		managedConfigNamespace,
 	)
 
 	operatorClient := &OperatorClient{
@@ -96,7 +96,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	// add syncing for the OAuth metadata ConfigMap
 	if err := resourceSyncer.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: machineConfigNamespace, Name: targetName},
+		resourcesynccontroller.ResourceLocation{Namespace: managedConfigNamespace, Name: targetName},
 		resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: oauthMetadataName},
 	); err != nil {
 		return err
@@ -105,7 +105,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	// add syncing for router certs for all cluster ingresses
 	if err := resourceSyncer.SyncSecret(
 		resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: routerCertsLocalName},
-		resourcesynccontroller.ResourceLocation{Namespace: machineConfigNamespace, Name: routerCertsSharedName},
+		resourcesynccontroller.ResourceLocation{Namespace: managedConfigNamespace, Name: routerCertsSharedName},
 	); err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 			{Group: configv1.GroupName, Resource: "infrastructures", Name: globalConfigName},
 			{Group: configv1.GroupName, Resource: "oauths", Name: globalConfigName},
 			{Resource: "namespaces", Name: userConfigNamespace},
-			{Resource: "namespaces", Name: machineConfigNamespace},
+			{Resource: "namespaces", Name: managedConfigNamespace},
 			{Resource: "namespaces", Name: targetNamespace},
 			{Resource: "namespaces", Name: targetNameOperator},
 		},


### PR DESCRIPTION
Extends out Sally's PR to validate the embedded object. The embedded object is a Console object, not a ConsoleConfig object, and adds a unit test.

The origin-branding ConfigMap does not reference the correct CRD for Consoles. 
PR here: https://github.com/openshift/origin-branding/pull/5

/cc @sallyom @sjenning @enj