### PR TITLE
Bug 1703502: Enable Auth for metrics endpoint

### DIFF
--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -7,7 +7,3 @@ data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig
-    authentication:
-      disabled: true
-    authorization:
-      disabled: true


### PR DESCRIPTION
Enable Auth for metrics endpoint for cluster-authentication-operator.
By default delegated authentication and authorization are enabled.
Currently the configmap explicitly disables delegated authentication
and authorization.
Remove the override to enable delegated authentication
and authorization.

Testing:
- Make sure that /metrics endpoint is not accessible for an
  unauthenticated user.
If I access the /metrics endpoint using curl as shown below I get the
following 403 error
curl -k https://$(kubectl get service metrics -o json | jq -r .spec.clusterIP)/metrics

"message": "forbidden: User \"system:anonymous\" cannot get path \"/metrics\"",
"reason": "Forbidden",

- I checked 'prometheus-k8s-openshift-monitoring', looks like all
  'AuthenticationOperator2_*' metrics are collected after delegated
  auth is turned on.

Jira: https://jira.coreos.com/browse/AUTH-298
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1703502