### PR TITLE
Bug 1706894: Make oauth-openshift.<ingress_domain> the permanent issuer of the OAuth server

### DIFF
--- a/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: integrated-oauth-server
+  name: oauth-openshift
   namespace: openshift-authentication
 spec:
   endpoints:
@@ -44,8 +44,8 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: integrated-oauth-server.openshift-authentication.svc
+      serverName: oauth-openshift.openshift-authentication.svc
   jobLabel: component
   selector:
     matchLabels:
-      app: integrated-oauth-server
+      app: oauth-openshift

--- a/manifests/04_roles.yaml
+++ b/manifests/04_roles.yaml
@@ -11,4 +11,4 @@ subjects:
   name: authentication-operator
 - kind: ServiceAccount
   namespace: openshift-authentication
-  name: integrated-oauth-server
+  name: oauth-openshift

--- a/manifests/05_serviceaccount.yaml
+++ b/manifests/05_serviceaccount.yaml
@@ -10,6 +10,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: openshift-authentication
-  name: integrated-oauth-server
+  name: oauth-openshift
   labels:
-    app: integrated-oauth-server
+    app: oauth-openshift

--- a/manifests/08_clusteroperator.yaml
+++ b/manifests/08_clusteroperator.yaml
@@ -6,5 +6,5 @@ status:
   versions:
   - name: operator
     version: "0.0.1-snapshot"
-  - name: integrated-oauth-server
+  - name: oauth-openshift
     version: "0.0.1-snapshot_openshift"

--- a/pkg/operator2/ingress.go
+++ b/pkg/operator2/ingress.go
@@ -1,0 +1,20 @@
+package operator2
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func (c *authOperator) handleIngress() (*configv1.Ingress, error) {
+	ingress, err := c.ingress.Get(globalConfigName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if len(ingress.Spec.Domain) == 0 {
+		return nil, fmt.Errorf("ingress has empty spec.domain: %#v", ingress)
+	}
+	return ingress, nil
+}


### PR DESCRIPTION
We need a permanently stable issuer URL for the OAuth server - both
in terms of the OAuth spec and so that OAuth callbacks from OAuth
IDPs continue to work indefinitely (we have no way to reconcile the
external IDP on a change).

oauth-openshift is the shortest namespaced value we can use (we do
not want to use a value that a customer may want to use).  This is a
best effort attempt to make the external API "nice" to use.

To keep things consistent, everything that was previously exposed as
"integrated-oauth-server" is now "oauth-openshift" (this does make
us slightly inconsistent with the top level Authentication config
and the binary of the OAuth server - we can at least update the
latter in the future for consistency).

Bug 1706894

Signed-off-by: Monis Khan <mkhan@redhat.com>