### PR TITLE
Remove conditions that are no longer set

### DIFF
--- a/pkg/operator2/legacyconditions/legacyconditions.go
+++ b/pkg/operator2/legacyconditions/legacyconditions.go
@@ -1,0 +1,29 @@
+package legacyconditions
+
+import (
+	"monis.app/go/openshift/operator"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-authentication-operator/pkg/operator2/nokey"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// NewLegacyConditions is a control loop that allows us to remove conditions that we no longer set.
+// This is important as we do not want to leave an orphaned FooDegraded condition behind (ex: we remove
+// a control loop or change the type of the condition to have a better name).  Otherwise we risk the
+// ClusterOperatorStatusController's union logic permanently setting Degraded due to the orphaned condition.
+// Note that this applies to all condition types such as Available, Progressing, etc.
+func NewLegacyConditions(client v1helpers.OperatorClient, conditionTypes ...string) operator.Runner {
+	return operator.New("LegacyConditions",
+		nokey.SyncFunc(func() error {
+			_, _, updateError := v1helpers.UpdateStatus(client, func(status *operatorv1.OperatorStatus) error {
+				for _, conditionType := range conditionTypes {
+					v1helpers.RemoveOperatorCondition(&status.Conditions, conditionType)
+				}
+				return nil
+			})
+			return updateError
+		}),
+		operator.WithInformer(client, operator.FilterByNames("cluster")),
+	)
+}

--- a/pkg/operator2/nokey/nokey.go
+++ b/pkg/operator2/nokey/nokey.go
@@ -1,0 +1,20 @@
+package nokey
+
+import (
+	"monis.app/go/openshift/operator"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ operator.KeySyncer = SyncFunc(nil)
+
+// TODO move this into boilerplate library if it ends up being reusable
+type SyncFunc func() error
+
+func (f SyncFunc) Key() (metav1.Object, error) {
+	return nil, nil
+}
+
+func (f SyncFunc) Sync(_ metav1.Object) error {
+	return f()
+}

--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -18,6 +18,7 @@ import (
 	authopinformer "github.com/openshift/client-go/operator/informers/externalversions"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	routeinformer "github.com/openshift/client-go/route/informers/externalversions"
+	"github.com/openshift/cluster-authentication-operator/pkg/operator2/legacyconditions"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/management"
@@ -137,6 +138,11 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		resourceSyncer,
 	)
 
+	legacyConditions := legacyconditions.NewLegacyConditions(
+		operatorClient,
+		operatorv1.OperatorStatusTypeDegraded,
+	)
+
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		clusterOperatorName,
 		[]configv1.ObjectReference{
@@ -189,6 +195,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	}
 
 	go operator.Run(ctx.Done())
+	go legacyConditions.Run(ctx.Done())
 
 	<-ctx.Done()
 


### PR DESCRIPTION
This change adds a generic control loop to remove conditions that we no longer set.  This prevents orphaned conditions from confusing the ClusterOperatorStatusController's union logic.

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: #142 

@stlaz @crawford @smarterclayton 