### PR TITLE
deployment: add env vars from the Proxy object

### DIFF
--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -173,6 +173,7 @@ type authOperator struct {
 	infrastructure configv1client.InfrastructureInterface
 	ingress        configv1client.IngressInterface
 	apiserver      configv1client.APIServerInterface
+	proxy          configv1client.ProxyInterface
 
 	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
@@ -212,6 +213,7 @@ func NewAuthenticationOperator(
 		infrastructure: configClient.ConfigV1().Infrastructures(),
 		ingress:        configClient.ConfigV1().Ingresses(),
 		apiserver:      configClient.ConfigV1().APIServers(),
+		proxy:          configClient.ConfigV1().Proxies(),
 
 		resourceSyncer: resourceSyncer,
 	}
@@ -238,6 +240,7 @@ func NewAuthenticationOperator(
 		operator.WithInformer(configV1Informers.Infrastructures(), configNameFilter, controller.WithNoSync()),
 		operator.WithInformer(configV1Informers.Ingresses(), configNameFilter, controller.WithNoSync()),
 		operator.WithInformer(configV1Informers.APIServers(), configNameFilter, controller.WithNoSync()),
+		operator.WithInformer(configV1Informers.Proxies(), configNameFilter, controller.WithNoSync()),
 	)
 }
 
@@ -400,6 +403,9 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 		return err
 	}
 
+	proxyConfig := c.handleProxyConfig()
+	resourceVersions = append(resourceVersions, proxyConfig.ResourceVersion)
+
 	operatorDeployment, err := c.deployments.Deployments(targetNamespaceOperator).Get(targetNameOperator, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -411,6 +417,7 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 		operatorConfig,
 		syncData,
 		routerSecret,
+		proxyConfig,
 		operatorDeployment,
 		resourceVersions...,
 	)

--- a/pkg/operator2/proxy.go
+++ b/pkg/operator2/proxy.go
@@ -1,0 +1,17 @@
+package operator2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func (c *authOperator) handleProxyConfig() *configv1.Proxy {
+	proxyConfig, err := c.proxy.Get(globalConfigName, metav1.GetOptions{})
+	if err != nil {
+		klog.Infof("error getting proxy config: %v", err)
+		return &configv1.Proxy{}
+	}
+	return proxyConfig
+}


### PR DESCRIPTION
The Proxy object specifies certain http-proxy related environmnent
variables that we need setting for the operand's cotainer.

/cc @sttts @enj 