### PR TITLE
 Bug 1733978: Correct race between config sync loop and resource syncer [4.1]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ verify-commits:
 #   make test-unit
 #   make test-unit WHAT=pkg/build TESTFLAGS=-v
 test-unit:
-	GOTEST_FLAGS="$(TESTFLAGS)" hack/test-go.sh $(WHAT) $(TESTS)
+	GOTEST_FLAGS="$(TESTFLAGS)" GODEBUG=tls13 KUBERNETES_SERVICE_PORT_HTTPS=443 hack/test-go.sh $(WHAT) $(TESTS)
 .PHONY: test-unit
 
 # Run e2e tests.

--- a/pkg/operator2/branding.go
+++ b/pkg/operator2/branding.go
@@ -5,7 +5,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -66,10 +65,6 @@ func (c *authOperator) handleBrandingTemplates(configTemplates configv1.OAuthTem
 	}
 
 	return &templates, nil
-}
-
-func (c *authOperator) handleOCPBrandingSecret() (*corev1.Secret, error) {
-	return c.secrets.Secrets(targetNamespace).Get(ocpBrandingSecretName, metav1.GetOptions{})
 }
 
 func (c *authOperator) getConsoleBranding() (string, error) {

--- a/pkg/operator2/configsync_test.go
+++ b/pkg/operator2/configsync_test.go
@@ -1,0 +1,453 @@
+package operator2
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+)
+
+func Test_authOperator_handleConfigSync(t *testing.T) {
+	tests := []struct {
+		name           string
+		objects        []runtime.Object
+		idpConfigMaps  map[string]string
+		idpSecrets     map[string]string
+		tplSecrets     map[string]string
+		wantConfigMaps []location
+		wantSecrets    []location
+		wantErr        string
+	}{
+		{
+			name: "nothing synced yet",
+			objects: []runtime.Object{
+				testConfigSyncSecret("a"),
+				testConfigSyncConfigMap("b"),
+			},
+			idpConfigMaps: map[string]string{
+				userConfigPrefix + "dest-a": "src-a",
+				userConfigPrefix + "dest-b": "src-b",
+			},
+			idpSecrets: map[string]string{
+				userConfigPrefix + "dest-c": "src-c",
+				userConfigPrefix + "dest-d": "src-d",
+			},
+			tplSecrets: map[string]string{
+				userConfigPrefix + "dest-e": "src-e",
+				userConfigPrefix + "dest-f": "src-f",
+			},
+			wantConfigMaps: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+				},
+			},
+			wantSecrets: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+				},
+			},
+			wantErr: "config maps [v4-0-config-user-dest-a v4-0-config-user-dest-b] in openshift-authentication not synced",
+		},
+		{
+			name: "some config maps synced",
+			objects: []runtime.Object{
+				testConfigSyncSecret("a"),
+				testConfigSyncConfigMap("b"),
+
+				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
+			},
+			idpConfigMaps: map[string]string{
+				userConfigPrefix + "dest-a": "src-a",
+				userConfigPrefix + "dest-b": "src-b",
+			},
+			idpSecrets: map[string]string{
+				userConfigPrefix + "dest-c": "src-c",
+				userConfigPrefix + "dest-d": "src-d",
+			},
+			tplSecrets: map[string]string{
+				userConfigPrefix + "dest-e": "src-e",
+				userConfigPrefix + "dest-f": "src-f",
+			},
+			wantConfigMaps: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+				},
+			},
+			wantSecrets: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+				},
+			},
+			wantErr: "config maps [v4-0-config-user-dest-b] in openshift-authentication not synced",
+		},
+		{
+			name: "all config maps synced",
+			objects: []runtime.Object{
+				testConfigSyncSecret("a"),
+				testConfigSyncConfigMap("b"),
+
+				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
+				testConfigSyncConfigMap(userConfigPrefix + "dest-b"),
+			},
+			idpConfigMaps: map[string]string{
+				userConfigPrefix + "dest-a": "src-a",
+				userConfigPrefix + "dest-b": "src-b",
+			},
+			idpSecrets: map[string]string{
+				userConfigPrefix + "dest-c": "src-c",
+				userConfigPrefix + "dest-d": "src-d",
+			},
+			tplSecrets: map[string]string{
+				userConfigPrefix + "dest-e": "src-e",
+				userConfigPrefix + "dest-f": "src-f",
+			},
+			wantConfigMaps: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+				},
+			},
+			wantSecrets: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+				},
+			},
+			wantErr: "secrets [v4-0-config-user-dest-c v4-0-config-user-dest-d v4-0-config-user-dest-e v4-0-config-user-dest-f] in openshift-authentication not synced",
+		},
+		{
+			name: "all config maps and secrets synced",
+			objects: []runtime.Object{
+				testConfigSyncSecret("a"),
+				testConfigSyncConfigMap("b"),
+
+				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
+				testConfigSyncConfigMap(userConfigPrefix + "dest-b"),
+
+				testConfigSyncSecret(userConfigPrefix + "dest-c"),
+				testConfigSyncSecret(userConfigPrefix + "dest-d"),
+				testConfigSyncSecret(userConfigPrefix + "dest-e"),
+				testConfigSyncSecret(userConfigPrefix + "dest-f"),
+			},
+			idpConfigMaps: map[string]string{
+				userConfigPrefix + "dest-a": "src-a",
+				userConfigPrefix + "dest-b": "src-b",
+			},
+			idpSecrets: map[string]string{
+				userConfigPrefix + "dest-c": "src-c",
+				userConfigPrefix + "dest-d": "src-d",
+			},
+			tplSecrets: map[string]string{
+				userConfigPrefix + "dest-e": "src-e",
+				userConfigPrefix + "dest-f": "src-f",
+			},
+			wantConfigMaps: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+				},
+			},
+			wantSecrets: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "all config maps and secrets synced with old data",
+			objects: []runtime.Object{
+				testConfigSyncSecret("a"),
+				testConfigSyncConfigMap("b"),
+
+				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
+				testConfigSyncConfigMap(userConfigPrefix + "dest-b"),
+
+				testConfigSyncSecret(userConfigPrefix + "dest-c"),
+				testConfigSyncSecret(userConfigPrefix + "dest-d"),
+				testConfigSyncSecret(userConfigPrefix + "dest-e"),
+				testConfigSyncSecret(userConfigPrefix + "dest-f"),
+
+				testConfigSyncSecret(userConfigPrefix + "dest-g"),
+				testConfigSyncConfigMap(userConfigPrefix + "dest-h"),
+
+				testConfigSyncConfigMap(systemConfigPrefix + "dest-i"),
+				testConfigSyncConfigMap(systemConfigPrefix + "dest-j"),
+			},
+			idpConfigMaps: map[string]string{
+				userConfigPrefix + "dest-a": "src-a",
+				userConfigPrefix + "dest-b": "src-b",
+			},
+			idpSecrets: map[string]string{
+				userConfigPrefix + "dest-c": "src-c",
+				userConfigPrefix + "dest-d": "src-d",
+			},
+			tplSecrets: map[string]string{
+				userConfigPrefix + "dest-e": "src-e",
+				userConfigPrefix + "dest-f": "src-f",
+			},
+			wantConfigMaps: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-h"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
+				},
+			},
+			wantSecrets: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-g"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "all config maps and secrets synced with old data and duplicate sources",
+			objects: []runtime.Object{
+				testConfigSyncSecret("panda"),
+				testConfigSyncConfigMap("bear"),
+
+				testConfigSyncConfigMap(userConfigPrefix + "dest-0"),
+				testConfigSyncConfigMap(userConfigPrefix + "dest-1"),
+
+				testConfigSyncSecret(userConfigPrefix + "dest-2"),
+				testConfigSyncSecret(userConfigPrefix + "dest-3"),
+				testConfigSyncSecret(userConfigPrefix + "dest-4"),
+				testConfigSyncSecret(userConfigPrefix + "dest-5"),
+
+				testConfigSyncSecret(userConfigPrefix + "dest-6"),
+				testConfigSyncConfigMap(userConfigPrefix + "dest-7"),
+
+				testConfigSyncConfigMap(systemConfigPrefix + "dest-8"),
+				testConfigSyncSecret(systemConfigPrefix + "dest-9"),
+			},
+			idpConfigMaps: map[string]string{
+				userConfigPrefix + "dest-0": "src-0",
+				userConfigPrefix + "dest-1": "src-0",
+			},
+			idpSecrets: map[string]string{
+				userConfigPrefix + "dest-2": "src-1",
+				userConfigPrefix + "dest-3": "src-1",
+			},
+			tplSecrets: map[string]string{
+				userConfigPrefix + "dest-4": "src-1",
+				userConfigPrefix + "dest-5": "src-1",
+			},
+			wantConfigMaps: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-0"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-0"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-1"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-0"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-7"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
+				},
+			},
+			wantSecrets: []location{
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-2"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-3"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-4"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-5"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+				},
+				{
+					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-6"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
+				},
+			},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tt.objects...)
+			r := &recordingResourceSyncer{}
+			c := &authOperator{
+				secrets:        client.CoreV1(),
+				configMaps:     client.CoreV1(),
+				resourceSyncer: r,
+			}
+			data := &configSyncData{
+				idpConfigMaps: testSourceData(tt.idpConfigMaps),
+				idpSecrets:    testSourceData(tt.idpSecrets),
+				tplSecrets:    testSourceData(tt.tplSecrets),
+			}
+			if err := c.handleConfigSync(data); errString(err) != tt.wantErr {
+				t.Errorf("handleConfigSync() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(r.configMaps, tt.wantConfigMaps) {
+				t.Errorf("handleConfigSync() config maps got = %v, want %v", r.configMaps, tt.wantConfigMaps)
+			}
+			if !reflect.DeepEqual(r.secrets, tt.wantSecrets) {
+				t.Errorf("handleConfigSync() secrets got = %v, want %v", r.secrets, tt.wantSecrets)
+			}
+		})
+	}
+}
+
+type location struct {
+	destination, source resourcesynccontroller.ResourceLocation
+}
+
+type recordingResourceSyncer struct {
+	configMaps []location
+	secrets    []location
+}
+
+func (r *recordingResourceSyncer) SyncConfigMap(destination, source resourcesynccontroller.ResourceLocation) error {
+	r.configMaps = append(r.configMaps, location{destination: destination, source: source})
+	return nil
+}
+
+func (r *recordingResourceSyncer) SyncSecret(destination, source resourcesynccontroller.ResourceLocation) error {
+	r.secrets = append(r.secrets, location{destination: destination, source: source})
+	return nil
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	errStr := err.Error()
+	if len(errStr) == 0 {
+		panic("invalid error")
+	}
+	return errStr
+}
+
+func testSourceData(destToSrc map[string]string) map[string]sourceData {
+	out := map[string]sourceData{}
+	for dest, src := range destToSrc {
+		out[dest] = sourceData{src: src}
+	}
+	return out
+}
+
+func testConfigSyncSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: targetNamespace,
+		},
+	}
+}
+
+func testConfigSyncConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: targetNamespace,
+		},
+	}
+}

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -26,7 +26,6 @@ func (c *authOperator) handleOAuthConfig(
 	consoleConfig *configv1.Console,
 	infrastructureConfig *configv1.Infrastructure,
 ) (
-	*configv1.OAuth,
 	*corev1.ConfigMap,
 	*configSyncData,
 	error,
@@ -38,7 +37,7 @@ func (c *authOperator) handleOAuthConfig(
 		})
 	}
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 	oauthConfig := defaultOAuthConfig(oauthConfigNoDefaults)
 
@@ -58,7 +57,7 @@ func (c *authOperator) handleOAuthConfig(
 
 	templates, err := c.handleBrandingTemplates(oauthConfig.Spec.Templates, syncData)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	var errsIDP []error
@@ -148,11 +147,11 @@ func (c *authOperator) handleOAuthConfig(
 
 	completeConfigBytes, err := resourcemerge.MergeProcessConfig(nil, cliConfigBytes, operatorConfig.Spec.UnsupportedConfigOverrides.Raw)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to merge config with unsupportedConfigOverrides: %v", err)
+		return nil, nil, fmt.Errorf("failed to merge config with unsupportedConfigOverrides: %v", err)
 	}
 
 	// TODO update OAuth status
-	return oauthConfig, getCliConfigMap(completeConfigBytes), &syncData, nil
+	return getCliConfigMap(completeConfigBytes), &syncData, nil
 }
 
 func getCliConfigMap(completeConfigBytes []byte) *corev1.ConfigMap {

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -294,12 +294,6 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	// TODO move this hash from deployment meta to operatorConfig.status.generations.[...].hash
 	resourceVersions := []string{}
 
-	brandingSecret, err := c.handleOCPBrandingSecret()
-	if err != nil {
-		return fmt.Errorf("failed getting the OCP branding secret: %v", err)
-	}
-	resourceVersions = append(resourceVersions, brandingSecret.GetResourceVersion())
-
 	// The BLOCK sections are highly order dependent
 
 	// ==================================
@@ -309,26 +303,22 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	if err != nil {
 		return fmt.Errorf("failed getting the ingress config: %v", err)
 	}
-	resourceVersions = append(resourceVersions, ingress.GetResourceVersion())
 
 	route, routerSecret, err := c.handleRoute(ingress)
 	if err != nil {
 		return fmt.Errorf("failed handling the route: %v", err)
 	}
-	resourceVersions = append(resourceVersions, route.GetResourceVersion(), routerSecret.GetResourceVersion())
 
 	// make sure API server sees our metadata as soon as we've got a route with a host
-	metadata, _, err := resourceapply.ApplyConfigMap(c.configMaps, c.recorder, getMetadataConfigMap(route))
+	_, _, err = resourceapply.ApplyConfigMap(c.configMaps, c.recorder, getMetadataConfigMap(route))
 	if err != nil {
 		return fmt.Errorf("failure applying configMap for the .well-known endpoint: %v", err)
 	}
-	resourceVersions = append(resourceVersions, metadata.GetResourceVersion())
 
 	authConfig, err := c.handleAuthConfig()
 	if err != nil {
 		return fmt.Errorf("failed handling authentication config: %v", err)
 	}
-	resourceVersions = append(resourceVersions, authConfig.GetResourceVersion())
 
 	// ==================================
 	// BLOCK 2: service and service-ca data
@@ -339,13 +329,11 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	if err != nil {
 		return fmt.Errorf("failed applying service object: %v", err)
 	}
-	resourceVersions = append(resourceVersions, service.GetResourceVersion())
 
-	serviceCA, servingCert, err := c.handleServiceCA()
+	_, _, err = c.handleServiceCA()
 	if err != nil {
 		return fmt.Errorf("failed handling service CA: %v", err)
 	}
-	resourceVersions = append(resourceVersions, serviceCA.GetResourceVersion(), servingCert.GetResourceVersion())
 
 	// ==================================
 	// BLOCK 3: build cli config
@@ -355,35 +343,29 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	if err != nil {
 		return fmt.Errorf("failed obtaining session secret: %v", err)
 	}
-	sessionSecret, _, err := resourceapply.ApplySecret(c.secrets, c.recorder, expectedSessionSecret)
+	_, _, err = resourceapply.ApplySecret(c.secrets, c.recorder, expectedSessionSecret)
 	if err != nil {
 		return fmt.Errorf("failed applying session secret: %v", err)
 	}
-	resourceVersions = append(resourceVersions, sessionSecret.GetResourceVersion())
 
 	consoleConfig := c.handleConsoleConfig()
-	resourceVersions = append(resourceVersions, consoleConfig.GetResourceVersion())
 
 	infrastructureConfig := c.handleInfrastructureConfig()
-	resourceVersions = append(resourceVersions, infrastructureConfig.GetResourceVersion())
 
-	oauthConfig, expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, routerSecret, service, consoleConfig, infrastructureConfig)
+	expectedCLIconfig, syncData, err := c.handleOAuthConfig(operatorConfig, route, routerSecret, service, consoleConfig, infrastructureConfig)
 	if err != nil {
 		return fmt.Errorf("failed handling OAuth configuration: %v", err)
 	}
-	resourceVersions = append(resourceVersions, oauthConfig.GetResourceVersion())
 
-	configResourceVersions, err := c.handleConfigSync(syncData)
+	err = c.handleConfigSync(syncData)
 	if err != nil {
 		return fmt.Errorf("failed syncing configuration objects: %v", err)
 	}
-	resourceVersions = append(resourceVersions, configResourceVersions...)
 
-	cliConfig, _, err := resourceapply.ApplyConfigMap(c.configMaps, c.recorder, expectedCLIconfig)
+	_, _, err = resourceapply.ApplyConfigMap(c.configMaps, c.recorder, expectedCLIconfig)
 	if err != nil {
 		return fmt.Errorf("failed applying configMap for the CLI configuration: %v", err)
 	}
-	resourceVersions = append(resourceVersions, cliConfig.GetResourceVersion())
 
 	// ==================================
 	// BLOCK 4: deployment
@@ -393,7 +375,14 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	if err != nil {
 		return err
 	}
-	resourceVersions = append(resourceVersions, operatorDeployment.GetResourceVersion())
+	// prefix the RV to make it clear where it came from since each resource can be from different etcd
+	resourceVersions = append(resourceVersions, "deployments:"+operatorDeployment.ResourceVersion)
+
+	configResourceVersions, err := c.handleConfigResourceVersions()
+	if err != nil {
+		return err
+	}
+	resourceVersions = append(resourceVersions, configResourceVersions...)
 
 	// deployment, have RV of all resources
 	expectedDeployment := defaultDeployment(

--- a/pkg/operator2/resourceversion.go
+++ b/pkg/operator2/resourceversion.go
@@ -1,0 +1,35 @@
+package operator2
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (c *authOperator) handleConfigResourceVersions() ([]string, error) {
+	var configRVs []string
+
+	configMaps, err := c.configMaps.ConfigMaps(targetNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, cm := range configMaps.Items {
+		if strings.HasPrefix(cm.Name, configVersionPrefix) {
+			// prefix the RV to make it clear where it came from since each resource can be from different etcd
+			configRVs = append(configRVs, "configmaps:"+cm.ResourceVersion)
+		}
+	}
+
+	secrets, err := c.secrets.Secrets(targetNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, secret := range secrets.Items {
+		if strings.HasPrefix(secret.Name, configVersionPrefix) {
+			// prefix the RV to make it clear where it came from since each resource can be from different etcd
+			configRVs = append(configRVs, "secrets:"+secret.ResourceVersion)
+		}
+	}
+
+	return configRVs, nil
+}

--- a/pkg/operator2/resourceversion_test.go
+++ b/pkg/operator2/resourceversion_test.go
@@ -1,0 +1,118 @@
+package operator2
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		want    []string
+	}{
+		{
+			name:    "none",
+			objects: nil,
+			want:    nil,
+		},
+		{
+			name: "ignored",
+			objects: []runtime.Object{
+				testRVSecret("a", "1"),
+				testRVConfigMap("b", "2"),
+			},
+			want: nil,
+		},
+		{
+			name: "user config only",
+			objects: []runtime.Object{
+				testRVSecret(userConfigPrefix+"a", "1"),
+				testRVConfigMap(userConfigPrefix+"b", "2"),
+			},
+			want: []string{"configmaps:2", "secrets:1"},
+		},
+		{
+			name: "system config only",
+			objects: []runtime.Object{
+				testRVSecret(systemConfigPrefix+"c", "3"),
+				testRVConfigMap(systemConfigPrefix+"d", "4"),
+			},
+			want: []string{"configmaps:4", "secrets:3"},
+		},
+		{
+			name: "both config",
+			objects: []runtime.Object{
+				testRVSecret(userConfigPrefix+"a", "1"),
+				testRVConfigMap(userConfigPrefix+"b", "2"),
+				testRVSecret(systemConfigPrefix+"c", "3"),
+				testRVConfigMap(systemConfigPrefix+"d", "4"),
+			},
+			want: []string{"configmaps:2", "configmaps:4", "secrets:1", "secrets:3"},
+		},
+		{
+			name: "both config overlapping resource versions",
+			objects: []runtime.Object{
+				testRVSecret(userConfigPrefix+"a", "1"),
+				testRVConfigMap(userConfigPrefix+"b", "2"),
+				testRVSecret(systemConfigPrefix+"c", "2"),
+				testRVConfigMap(systemConfigPrefix+"d", "1"),
+			},
+			want: []string{"configmaps:2", "configmaps:1", "secrets:1", "secrets:2"},
+		},
+		{
+			name: "both config overlapping resource versions and ignored data",
+			objects: []runtime.Object{
+				testRVSecret("e", "5"),
+				testRVConfigMap("f", "6"),
+				testRVSecret(userConfigPrefix+"a", "3"),
+				testRVConfigMap(userConfigPrefix+"b", "2"),
+				testRVSecret(systemConfigPrefix+"c", "2"),
+				testRVConfigMap(systemConfigPrefix+"d", "3"),
+			},
+			want: []string{"configmaps:2", "configmaps:3", "secrets:3", "secrets:2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tt.objects...)
+			c := &authOperator{
+				secrets:    client.CoreV1(),
+				configMaps: client.CoreV1(),
+			}
+			got, err := c.handleConfigResourceVersions()
+			if err != nil {
+				t.Errorf("handleConfigResourceVersions() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleConfigResourceVersions() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testRVSecret(name, rv string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       targetNamespace,
+			ResourceVersion: rv,
+		},
+	}
+}
+
+func testRVConfigMap(name, rv string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       targetNamespace,
+			ResourceVersion: rv,
+		},
+	}
+}


### PR DESCRIPTION
This patch makes two primary changes:

1. Generically track resource versions:

We depend on the following state:
- The operator deployment itself
- The authentications.operator.openshift.io resource
- Config maps and secrets that are owned by the operator
- The current observed (CLI) config (stored in a config map)
- Config maps and secrets that are synced from openshift-config

Thus by tracking the:
- operator deployment resource version
- authentications.operator.openshift.io generation
- resource version of config maps and secrets with config prefix

we can guarantee that we redeploy when our state has changed.

2. Correct race between config sync loop and resource syncer

The code in master incorrectly assumed that the calls to List
contained all of the config maps and secrets that were being synced.
Since the resource syncer cannot instantaneously sync resources, the
List would race against it.  Thus the logic to determine what data
was in use and the corresponding resource versions would produce
incorrect results due to invalid input.  This change completely
removes the need for the config sync code to track any resource
versions.  It also moves the resource syncer calls up with
additional blocking code below it.  This blocking code will be
retried until the calls to List and resource syncer have caught up.
This guarantees that the logic to determine what data is in use does
not produce incorrect results from invalid input.

Adds unit tests for all of the above.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @enj 