### PR TITLE
Bug 1740363: operator: improve the reason reporter for route

### DIFF
--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -311,8 +311,8 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 		return fmt.Errorf("failed getting the ingress config: %v", err)
 	}
 
-	route, routerSecret, err := c.handleRoute(ingress)
-	handleDegraded(operatorConfig, "RouteStatus", err)
+	route, routerSecret, reason, err := c.handleRoute(ingress)
+	handleDegraded(operatorConfig, reason, err)
 	if err != nil {
 		return fmt.Errorf("failed handling the route: %v", err)
 	}

--- a/pkg/operator2/route.go
+++ b/pkg/operator2/route.go
@@ -14,19 +14,19 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 )
 
-func (c *authOperator) handleRoute(ingress *configv1.Ingress) (*routev1.Route, *corev1.Secret, error) {
+func (c *authOperator) handleRoute(ingress *configv1.Ingress) (*routev1.Route, *corev1.Secret, string, error) {
 	route, err := c.route.Get(targetName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		route, err = c.route.Create(defaultRoute(ingress))
 	}
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "RouteCreate", err
 	}
 
 	host := getCanonicalHost(route, ingress)
 	if len(host) == 0 {
 		// be careful not to print route.spec as it many contain secrets
-		return nil, nil, fmt.Errorf("route is not available at canonical host %s: %+v", ingressToHost(ingress), route.Status.Ingress)
+		return nil, nil, "RouteCanonicalHost", fmt.Errorf("route is not available at canonical host %s: %+v", ingressToHost(ingress), route.Status.Ingress)
 	}
 
 	// assume it is unsafe to mutate route in case we go to a shared informer in the future
@@ -43,19 +43,19 @@ func (c *authOperator) handleRoute(ingress *configv1.Ingress) (*routev1.Route, *
 		if err := c.route.Delete(route.Name, opts); err != nil && !errors.IsNotFound(err) {
 			klog.Infof("failed to delete invalid route: %v", err)
 		}
-		return nil, nil, err
+		return nil, nil, "RouteInvalid", err
 	}
 
 	routerSecret, err := c.secrets.Secrets(targetNamespace).Get(routerCertsLocalName, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "RouterSecrets", err
 	}
 	if len(routerSecret.Data) == 0 {
 		// be careful not to print the routerSecret even when it is empty
-		return nil, nil, fmt.Errorf("router secret %s/%s is empty", routerSecret.Namespace, routerSecret.Name)
+		return nil, nil, "RouterSecretData", fmt.Errorf("router secret %s/%s is empty", routerSecret.Namespace, routerSecret.Name)
 	}
 
-	return route, routerSecret, nil
+	return route, routerSecret, "", nil
 }
 
 func isValidRoute(route *routev1.Route, ingress *configv1.Ingress) error {


### PR DESCRIPTION
There are 50+ degraded auth operators with reason being `RouteStatusDegradedError`. This PR provide more detailed reason string (as don't have access to the message yet). 

/cc @enj 
/cc @stlaz 