### PR TITLE
route: use getCanonicalHost for route healthy check

### DIFF
--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -530,7 +530,11 @@ func (c *authOperator) checkRouteHealthy(route *routev1.Route, routerSecret *cor
 		return false, "", fmt.Errorf("failed to build transport for route: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodHead, "https://"+route.Spec.Host+"/healthz", nil)
+	host := getCanonicalHost(route, ingress)
+	if len(host) == 0 {
+		return false, "", fmt.Errorf("failed to get canonical host from route")
+	}
+	req, err := http.NewRequest(http.MethodHead, "https://"+host+"/healthz", nil)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to build request to route: %v", err)
 	}


### PR DESCRIPTION
We should not use the `route.Spec` to get the hostname.