### PR TITLE
Log inputs to operator.openshift.io/rvs-hash

### DIFF
--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -94,6 +95,7 @@ func defaultDeployment(
 	// need to sort first in order to get a stable array
 	sort.Strings(resourceVersions)
 	rvs := strings.Join(resourceVersions, ",")
+	klog.V(4).Infof("tracked resource versions: %s", rvs)
 	rvsHash := sha512.Sum512([]byte(rvs))
 	rvsHashStr := base64.RawURLEncoding.EncodeToString(rvsHash[:])
 

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -394,14 +394,14 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	}
 
 	proxyConfig := c.handleProxyConfig()
-	resourceVersions = append(resourceVersions, proxyConfig.ResourceVersion)
+	resourceVersions = append(resourceVersions, "proxy:"+proxyConfig.Name+":"+proxyConfig.ResourceVersion)
 
 	operatorDeployment, err := c.deployments.Deployments(targetNamespaceOperator).Get(targetNameOperator, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	// prefix the RV to make it clear where it came from since each resource can be from different etcd
-	resourceVersions = append(resourceVersions, "deployments:"+operatorDeployment.ResourceVersion)
+	resourceVersions = append(resourceVersions, "deployments:"+operatorDeployment.Name+":"+operatorDeployment.ResourceVersion)
 
 	configResourceVersions, err := c.handleConfigResourceVersions()
 	if err != nil {

--- a/pkg/operator2/resourceversion.go
+++ b/pkg/operator2/resourceversion.go
@@ -16,7 +16,7 @@ func (c *authOperator) handleConfigResourceVersions() ([]string, error) {
 	for _, cm := range configMaps.Items {
 		if strings.HasPrefix(cm.Name, configVersionPrefix) {
 			// prefix the RV to make it clear where it came from since each resource can be from different etcd
-			configRVs = append(configRVs, "configmaps:"+cm.ResourceVersion)
+			configRVs = append(configRVs, "configmaps:"+cm.Name+":"+cm.ResourceVersion)
 		}
 	}
 
@@ -27,7 +27,7 @@ func (c *authOperator) handleConfigResourceVersions() ([]string, error) {
 	for _, secret := range secrets.Items {
 		if strings.HasPrefix(secret.Name, configVersionPrefix) {
 			// prefix the RV to make it clear where it came from since each resource can be from different etcd
-			configRVs = append(configRVs, "secrets:"+secret.ResourceVersion)
+			configRVs = append(configRVs, "secrets:"+secret.Name+":"+secret.ResourceVersion)
 		}
 	}
 

--- a/pkg/operator2/resourceversion_test.go
+++ b/pkg/operator2/resourceversion_test.go
@@ -35,7 +35,10 @@ func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
 				testRVSecret(userConfigPrefix+"a", "1"),
 				testRVConfigMap(userConfigPrefix+"b", "2"),
 			},
-			want: []string{"configmaps:2", "secrets:1"},
+			want: []string{
+				testRVString("configmaps", userConfigPrefix+"b", "2"),
+				testRVString("secrets", userConfigPrefix+"a", "1"),
+			},
 		},
 		{
 			name: "system config only",
@@ -43,7 +46,10 @@ func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
 				testRVSecret(systemConfigPrefix+"c", "3"),
 				testRVConfigMap(systemConfigPrefix+"d", "4"),
 			},
-			want: []string{"configmaps:4", "secrets:3"},
+			want: []string{
+				testRVString("configmaps", systemConfigPrefix+"d", "4"),
+				testRVString("secrets", systemConfigPrefix+"c", "3"),
+			},
 		},
 		{
 			name: "both config",
@@ -53,7 +59,12 @@ func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
 				testRVSecret(systemConfigPrefix+"c", "3"),
 				testRVConfigMap(systemConfigPrefix+"d", "4"),
 			},
-			want: []string{"configmaps:2", "configmaps:4", "secrets:1", "secrets:3"},
+			want: []string{
+				testRVString("configmaps", userConfigPrefix+"b", "2"),
+				testRVString("configmaps", systemConfigPrefix+"d", "4"),
+				testRVString("secrets", userConfigPrefix+"a", "1"),
+				testRVString("secrets", systemConfigPrefix+"c", "3"),
+			},
 		},
 		{
 			name: "both config overlapping resource versions",
@@ -63,7 +74,12 @@ func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
 				testRVSecret(systemConfigPrefix+"c", "2"),
 				testRVConfigMap(systemConfigPrefix+"d", "1"),
 			},
-			want: []string{"configmaps:2", "configmaps:1", "secrets:1", "secrets:2"},
+			want: []string{
+				testRVString("configmaps", userConfigPrefix+"b", "2"),
+				testRVString("configmaps", systemConfigPrefix+"d", "1"),
+				testRVString("secrets", userConfigPrefix+"a", "1"),
+				testRVString("secrets", systemConfigPrefix+"c", "2"),
+			},
 		},
 		{
 			name: "both config overlapping resource versions and ignored data",
@@ -75,7 +91,12 @@ func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
 				testRVSecret(systemConfigPrefix+"c", "2"),
 				testRVConfigMap(systemConfigPrefix+"d", "3"),
 			},
-			want: []string{"configmaps:2", "configmaps:3", "secrets:3", "secrets:2"},
+			want: []string{
+				testRVString("configmaps", userConfigPrefix+"b", "2"),
+				testRVString("configmaps", systemConfigPrefix+"d", "3"),
+				testRVString("secrets", userConfigPrefix+"a", "3"),
+				testRVString("secrets", systemConfigPrefix+"c", "2"),
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -115,4 +136,8 @@ func testRVConfigMap(name, rv string) *corev1.ConfigMap {
 			ResourceVersion: rv,
 		},
 	}
+}
+
+func testRVString(prefix, name, rv string) string {
+	return prefix + ":" + name + ":" + rv
 }


### PR DESCRIPTION
When the operator is set in debug mode, this makes it much easier to understand what change is causing redeployments of the OAuth server.

The log statements look like:

```
tracked resource versions: configmaps:v4-0-config-system-cliconfig:12119,...,proxy:cluster:435,...,secrets:v4-0-config-system-session:12093
```

Signed-off-by: Monis Khan <mkhan@redhat.com>