### PR TITLE
Bug 1751147: operator: restart the operator pod on trusted-ca-bundle change

### DIFF
--- a/cmd/authentication-operator/main.go
+++ b/cmd/authentication-operator/main.go
@@ -13,6 +13,8 @@ import (
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 
+	"github.com/openshift/library-go/pkg/operator/watchdog"
+
 	"github.com/openshift/cluster-authentication-operator/pkg/cmd/operator2"
 )
 
@@ -43,6 +45,7 @@ func NewAuthenticationOperatorCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(operator2.NewOperator())
+	cmd.AddCommand(watchdog.NewFileWatcherWatchdog())
 
 	return cmd
 }

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: authentication-operator
     spec:
+      shareProcessNamespace: true
       serviceAccountName: authentication-operator
       containers:
       - name: operator
@@ -26,6 +27,13 @@ spec:
         command: ["/bin/bash", "-ec"]
         args:
         - |
+          echo $$$$ > /var/run/watchdog/pid
+          echo -n "Waiting for watchdog..."
+          while [ ! -f /var/run/watchdog/ready ]; do
+            echo -n "."
+            sleep 1
+          done
+          echo
           if [ -s /var/run/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
@@ -43,6 +51,8 @@ spec:
         - mountPath: /var/run/configmaps/trusted-ca-bundle
           name: trusted-ca-bundle
           readOnly: true
+        - mountPath: /var/run/watchdog
+          name: watchdog-dir
         env:
         - name: IMAGE
           value: quay.io/openshift/origin-oauth-server:v4.2
@@ -55,6 +65,39 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         terminationMessagePolicy: FallbackToLogsOnError
+      - name: authentication-operator-watchdog
+        command: ["authentication-operator", "file-watcher-watchdog"]
+        args:
+          - --namespace=$(POD_NAMESPACE)
+          - --termination-grace-period=60s
+          - --files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt
+          - --pid-file=/var/run/watchdog/pid
+          - --ready-file=/var/run/watchdog/ready
+        securityContext:
+          capabilities:
+            add:
+              - SYS_PTRACE
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        image: quay.io/openshift/origin-cluster-authentication-operator:v4.0
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - mountPath: /var/run/configmaps/trusted-ca-bundle/
+            name: trusted-ca-bundle
+          - mountPath: /var/run/watchdog
+            name: watchdog-dir
+        terminationMessagePolicy: FallbackToLogsOnError
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
       volumes:
       - name: config
         configMap:
@@ -68,6 +111,8 @@ spec:
         secret:
           secretName: serving-cert
           optional: true
+      - emptyDir: {}
+        name: watchdog-dir
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -530,7 +530,9 @@ func (c *authOperator) checkDeploymentReady(deployment *appsv1.Deployment, opera
 func (c *authOperator) checkRouteHealthy(route *routev1.Route, routerSecret *corev1.Secret, ingress *configv1.Ingress) (ready bool, msg, reason string, err error) {
 	caData := routerSecretToCA(route, routerSecret, ingress)
 
-	rt, err := transportFor("", caData, nil, nil)
+	// FIXME: this reads too often, either always merge system-trust store in transportForInner or keep this in memory
+	systemCaData, _ := ioutil.ReadFile("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+	rt, err := transportFor("", append(caData, systemCaData...), nil, nil)
 	if err != nil {
 		return false, "", "FailedTransport", fmt.Errorf("failed to build transport for route: %v", err)
 	}


### PR DESCRIPTION
Introduces the watchdog for operator deployment so that there is
a mechanism which guards changes to the trusted-ca-bundle CM and
these are refetched by having the operator pod restart.

cc @enj @sttts 