### PR TITLE
Inline all consts

### DIFF
--- a/pkg/operator2/apiserver.go
+++ b/pkg/operator2/apiserver.go
@@ -9,7 +9,7 @@ import (
 
 func (c *authOperator) handleAPIServerConfig() *configv1.APIServer {
 	// technically this should be an observed config loop
-	apiServerConfig, err := c.apiserver.Get(globalConfigName, metav1.GetOptions{})
+	apiServerConfig, err := c.apiserver.Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		klog.Infof("error getting API server config: %v", err)
 		return &configv1.APIServer{}

--- a/pkg/operator2/auth.go
+++ b/pkg/operator2/auth.go
@@ -22,7 +22,7 @@ import (
 func (c *authOperator) handleAuthConfigInner() (*configv1.Authentication, error) {
 	// always make sure this function does not rely on defaulting from defaultAuthConfig
 
-	authConfigNoDefaults, err := c.authentication.Get(globalConfigName, metav1.GetOptions{})
+	authConfigNoDefaults, err := c.authentication.Get("cluster", metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		authConfigNoDefaults, err = c.authentication.Create(&configv1.Authentication{
 			ObjectMeta: defaultGlobalConfigMeta(),
@@ -33,7 +33,7 @@ func (c *authOperator) handleAuthConfigInner() (*configv1.Authentication, error)
 	}
 
 	expectedReference := configv1.ConfigMapNameReference{
-		Name: targetName,
+		Name: "oauth-openshift",
 	}
 
 	if authConfigNoDefaults.Status.IntegratedOAuthMetadata == expectedReference {

--- a/pkg/operator2/branding.go
+++ b/pkg/operator2/branding.go
@@ -32,31 +32,31 @@ func (c *authOperator) handleBrandingTemplates(configTemplates configv1.OAuthTem
 	case ocpBrand, "dedicated", "online", "azure":
 		// all of these are equivalent to ocp
 		templates = osinv1.OAuthTemplates{
-			Login:             ocpBrandingLoginPath,
-			ProviderSelection: ocpBrandingProviderPath,
-			Error:             ocpBrandingErrorPath,
+			Login:             "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/login.html",
+			ProviderSelection: "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/providers.html",
+			Error:             "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/errors.html",
 		}
 
 	default:
 		if defaultBrand == ocpBrand {
 			// build-time ocp selection
 			templates = osinv1.OAuthTemplates{
-				Login:             ocpBrandingLoginPath,
-				ProviderSelection: ocpBrandingProviderPath,
-				Error:             ocpBrandingErrorPath,
+				Login:             "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/login.html",
+				ProviderSelection: "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/providers.html",
+				Error:             "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/errors.html",
 			}
 		}
 	}
 
 	// user-configured overrides everything else, individually.
 	if hasSecretRef(configTemplates.Login) {
-		templates.Login = syncData.addTemplateSecret(configTemplates.Login, loginField, configv1.LoginTemplateKey)
+		templates.Login = syncData.addTemplateSecret(configTemplates.Login, "login", configv1.LoginTemplateKey)
 	}
 	if hasSecretRef(configTemplates.ProviderSelection) {
-		templates.ProviderSelection = syncData.addTemplateSecret(configTemplates.ProviderSelection, providerSelectionField, configv1.ProviderSelectionTemplateKey)
+		templates.ProviderSelection = syncData.addTemplateSecret(configTemplates.ProviderSelection, "provider-selection", configv1.ProviderSelectionTemplateKey)
 	}
 	if hasSecretRef(configTemplates.Error) {
-		templates.Error = syncData.addTemplateSecret(configTemplates.Error, errorField, configv1.ErrorsTemplateKey)
+		templates.Error = syncData.addTemplateSecret(configTemplates.Error, "error", configv1.ErrorsTemplateKey)
 	}
 
 	empty := osinv1.OAuthTemplates{}
@@ -68,7 +68,7 @@ func (c *authOperator) handleBrandingTemplates(configTemplates configv1.OAuthTem
 }
 
 func (c *authOperator) getConsoleBranding() (string, error) {
-	cm, err := c.configMaps.ConfigMaps(targetNamespace).Get(consoleConfigMapLocalName, metav1.GetOptions{})
+	cm, err := c.configMaps.ConfigMaps("openshift-authentication").Get("v4-0-config-system-console-config", metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return "", nil
 	}
@@ -76,7 +76,7 @@ func (c *authOperator) getConsoleBranding() (string, error) {
 		return "", fmt.Errorf("error getting console-config: %v", err)
 	}
 
-	data := cm.Data[consoleConfigKey]
+	data := cm.Data["console-config.yaml"]
 	if len(data) == 0 {
 		return "", nil
 	}

--- a/pkg/operator2/configmap.go
+++ b/pkg/operator2/configmap.go
@@ -60,7 +60,7 @@ func getMetadata(route *routev1.Route) string {
 
 func getMetadataConfigMap(route *routev1.Route) *corev1.ConfigMap {
 	meta := defaultMeta()
-	meta.Name = oauthMetadataName
+	meta.Name = "v4-0-config-system-metadata"
 	return &corev1.ConfigMap{
 		ObjectMeta: meta,
 		Data: map[string]string{

--- a/pkg/operator2/configsync_test.go
+++ b/pkg/operator2/configsync_test.go
@@ -30,43 +30,43 @@ func Test_authOperator_handleConfigSync(t *testing.T) {
 				testConfigSyncConfigMap("b"),
 			},
 			idpConfigMaps: map[string]string{
-				userConfigPrefix + "dest-a": "src-a",
-				userConfigPrefix + "dest-b": "src-b",
+				"v4-0-config-user-dest-a": "src-a",
+				"v4-0-config-user-dest-b": "src-b",
 			},
 			idpSecrets: map[string]string{
-				userConfigPrefix + "dest-c": "src-c",
-				userConfigPrefix + "dest-d": "src-d",
+				"v4-0-config-user-dest-c": "src-c",
+				"v4-0-config-user-dest-d": "src-d",
 			},
 			tplSecrets: map[string]string{
-				userConfigPrefix + "dest-e": "src-e",
-				userConfigPrefix + "dest-f": "src-f",
+				"v4-0-config-user-dest-e": "src-e",
+				"v4-0-config-user-dest-f": "src-f",
 			},
 			wantConfigMaps: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-a"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-b"},
 				},
 			},
 			wantSecrets: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-c"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-d"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-e"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-f"},
 				},
 			},
 			wantErr: "config maps [v4-0-config-user-dest-a v4-0-config-user-dest-b] in openshift-authentication not synced",
@@ -77,46 +77,46 @@ func Test_authOperator_handleConfigSync(t *testing.T) {
 				testConfigSyncSecret("a"),
 				testConfigSyncConfigMap("b"),
 
-				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-a"),
 			},
 			idpConfigMaps: map[string]string{
-				userConfigPrefix + "dest-a": "src-a",
-				userConfigPrefix + "dest-b": "src-b",
+				"v4-0-config-user-dest-a": "src-a",
+				"v4-0-config-user-dest-b": "src-b",
 			},
 			idpSecrets: map[string]string{
-				userConfigPrefix + "dest-c": "src-c",
-				userConfigPrefix + "dest-d": "src-d",
+				"v4-0-config-user-dest-c": "src-c",
+				"v4-0-config-user-dest-d": "src-d",
 			},
 			tplSecrets: map[string]string{
-				userConfigPrefix + "dest-e": "src-e",
-				userConfigPrefix + "dest-f": "src-f",
+				"v4-0-config-user-dest-e": "src-e",
+				"v4-0-config-user-dest-f": "src-f",
 			},
 			wantConfigMaps: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-a"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-b"},
 				},
 			},
 			wantSecrets: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-c"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-d"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-e"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-f"},
 				},
 			},
 			wantErr: "config maps [v4-0-config-user-dest-b] in openshift-authentication not synced",
@@ -127,47 +127,47 @@ func Test_authOperator_handleConfigSync(t *testing.T) {
 				testConfigSyncSecret("a"),
 				testConfigSyncConfigMap("b"),
 
-				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
-				testConfigSyncConfigMap(userConfigPrefix + "dest-b"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-a"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-b"),
 			},
 			idpConfigMaps: map[string]string{
-				userConfigPrefix + "dest-a": "src-a",
-				userConfigPrefix + "dest-b": "src-b",
+				"v4-0-config-user-dest-a": "src-a",
+				"v4-0-config-user-dest-b": "src-b",
 			},
 			idpSecrets: map[string]string{
-				userConfigPrefix + "dest-c": "src-c",
-				userConfigPrefix + "dest-d": "src-d",
+				"v4-0-config-user-dest-c": "src-c",
+				"v4-0-config-user-dest-d": "src-d",
 			},
 			tplSecrets: map[string]string{
-				userConfigPrefix + "dest-e": "src-e",
-				userConfigPrefix + "dest-f": "src-f",
+				"v4-0-config-user-dest-e": "src-e",
+				"v4-0-config-user-dest-f": "src-f",
 			},
 			wantConfigMaps: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-a"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-b"},
 				},
 			},
 			wantSecrets: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-c"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-d"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-e"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-f"},
 				},
 			},
 			wantErr: "secrets [v4-0-config-user-dest-c v4-0-config-user-dest-d v4-0-config-user-dest-e v4-0-config-user-dest-f] in openshift-authentication not synced",
@@ -178,52 +178,52 @@ func Test_authOperator_handleConfigSync(t *testing.T) {
 				testConfigSyncSecret("a"),
 				testConfigSyncConfigMap("b"),
 
-				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
-				testConfigSyncConfigMap(userConfigPrefix + "dest-b"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-a"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-b"),
 
-				testConfigSyncSecret(userConfigPrefix + "dest-c"),
-				testConfigSyncSecret(userConfigPrefix + "dest-d"),
-				testConfigSyncSecret(userConfigPrefix + "dest-e"),
-				testConfigSyncSecret(userConfigPrefix + "dest-f"),
+				testConfigSyncSecret("v4-0-config-user-dest-c"),
+				testConfigSyncSecret("v4-0-config-user-dest-d"),
+				testConfigSyncSecret("v4-0-config-user-dest-e"),
+				testConfigSyncSecret("v4-0-config-user-dest-f"),
 			},
 			idpConfigMaps: map[string]string{
-				userConfigPrefix + "dest-a": "src-a",
-				userConfigPrefix + "dest-b": "src-b",
+				"v4-0-config-user-dest-a": "src-a",
+				"v4-0-config-user-dest-b": "src-b",
 			},
 			idpSecrets: map[string]string{
-				userConfigPrefix + "dest-c": "src-c",
-				userConfigPrefix + "dest-d": "src-d",
+				"v4-0-config-user-dest-c": "src-c",
+				"v4-0-config-user-dest-d": "src-d",
 			},
 			tplSecrets: map[string]string{
-				userConfigPrefix + "dest-e": "src-e",
-				userConfigPrefix + "dest-f": "src-f",
+				"v4-0-config-user-dest-e": "src-e",
+				"v4-0-config-user-dest-f": "src-f",
 			},
 			wantConfigMaps: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-a"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-b"},
 				},
 			},
 			wantSecrets: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-c"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-d"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-e"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-f"},
 				},
 			},
 			wantErr: "",
@@ -234,65 +234,65 @@ func Test_authOperator_handleConfigSync(t *testing.T) {
 				testConfigSyncSecret("a"),
 				testConfigSyncConfigMap("b"),
 
-				testConfigSyncConfigMap(userConfigPrefix + "dest-a"),
-				testConfigSyncConfigMap(userConfigPrefix + "dest-b"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-a"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-b"),
 
-				testConfigSyncSecret(userConfigPrefix + "dest-c"),
-				testConfigSyncSecret(userConfigPrefix + "dest-d"),
-				testConfigSyncSecret(userConfigPrefix + "dest-e"),
-				testConfigSyncSecret(userConfigPrefix + "dest-f"),
+				testConfigSyncSecret("v4-0-config-user-dest-c"),
+				testConfigSyncSecret("v4-0-config-user-dest-d"),
+				testConfigSyncSecret("v4-0-config-user-dest-e"),
+				testConfigSyncSecret("v4-0-config-user-dest-f"),
 
-				testConfigSyncSecret(userConfigPrefix + "dest-g"),
-				testConfigSyncConfigMap(userConfigPrefix + "dest-h"),
+				testConfigSyncSecret("v4-0-config-user-dest-g"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-h"),
 
-				testConfigSyncConfigMap(systemConfigPrefix + "dest-i"),
-				testConfigSyncConfigMap(systemConfigPrefix + "dest-j"),
+				testConfigSyncConfigMap(("v4-0-config-system-") + "dest-i"),
+				testConfigSyncConfigMap(("v4-0-config-system-") + "dest-j"),
 			},
 			idpConfigMaps: map[string]string{
-				userConfigPrefix + "dest-a": "src-a",
-				userConfigPrefix + "dest-b": "src-b",
+				"v4-0-config-user-dest-a": "src-a",
+				"v4-0-config-user-dest-b": "src-b",
 			},
 			idpSecrets: map[string]string{
-				userConfigPrefix + "dest-c": "src-c",
-				userConfigPrefix + "dest-d": "src-d",
+				"v4-0-config-user-dest-c": "src-c",
+				"v4-0-config-user-dest-d": "src-d",
 			},
 			tplSecrets: map[string]string{
-				userConfigPrefix + "dest-e": "src-e",
-				userConfigPrefix + "dest-f": "src-f",
+				"v4-0-config-user-dest-e": "src-e",
+				"v4-0-config-user-dest-f": "src-f",
 			},
 			wantConfigMaps: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-a"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-a"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-a"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-a"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-b"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-b"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-b"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-b"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-h"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-h"},
 					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
 				},
 			},
 			wantSecrets: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-c"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-c"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-c"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-c"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-d"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-d"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-d"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-d"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-e"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-e"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-e"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-e"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-f"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-f"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-f"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-f"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-g"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-g"},
 					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
 				},
 			},
@@ -304,65 +304,65 @@ func Test_authOperator_handleConfigSync(t *testing.T) {
 				testConfigSyncSecret("panda"),
 				testConfigSyncConfigMap("bear"),
 
-				testConfigSyncConfigMap(userConfigPrefix + "dest-0"),
-				testConfigSyncConfigMap(userConfigPrefix + "dest-1"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-0"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-1"),
 
-				testConfigSyncSecret(userConfigPrefix + "dest-2"),
-				testConfigSyncSecret(userConfigPrefix + "dest-3"),
-				testConfigSyncSecret(userConfigPrefix + "dest-4"),
-				testConfigSyncSecret(userConfigPrefix + "dest-5"),
+				testConfigSyncSecret("v4-0-config-user-dest-2"),
+				testConfigSyncSecret("v4-0-config-user-dest-3"),
+				testConfigSyncSecret("v4-0-config-user-dest-4"),
+				testConfigSyncSecret("v4-0-config-user-dest-5"),
 
-				testConfigSyncSecret(userConfigPrefix + "dest-6"),
-				testConfigSyncConfigMap(userConfigPrefix + "dest-7"),
+				testConfigSyncSecret("v4-0-config-user-dest-6"),
+				testConfigSyncConfigMap("v4-0-config-user-dest-7"),
 
-				testConfigSyncConfigMap(systemConfigPrefix + "dest-8"),
-				testConfigSyncSecret(systemConfigPrefix + "dest-9"),
+				testConfigSyncConfigMap(("v4-0-config-system-") + "dest-8"),
+				testConfigSyncSecret(("v4-0-config-system-") + "dest-9"),
 			},
 			idpConfigMaps: map[string]string{
-				userConfigPrefix + "dest-0": "src-0",
-				userConfigPrefix + "dest-1": "src-0",
+				"v4-0-config-user-dest-0": "src-0",
+				"v4-0-config-user-dest-1": "src-0",
 			},
 			idpSecrets: map[string]string{
-				userConfigPrefix + "dest-2": "src-1",
-				userConfigPrefix + "dest-3": "src-1",
+				"v4-0-config-user-dest-2": "src-1",
+				"v4-0-config-user-dest-3": "src-1",
 			},
 			tplSecrets: map[string]string{
-				userConfigPrefix + "dest-4": "src-1",
-				userConfigPrefix + "dest-5": "src-1",
+				"v4-0-config-user-dest-4": "src-1",
+				"v4-0-config-user-dest-5": "src-1",
 			},
 			wantConfigMaps: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-0"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-0"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-0"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-0"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-1"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-0"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-1"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-0"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-7"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-7"},
 					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
 				},
 			},
 			wantSecrets: []location{
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-2"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-2"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-1"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-3"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-3"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-1"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-4"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-4"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-1"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-5"},
-					source:      resourcesynccontroller.ResourceLocation{Namespace: userConfigNamespace, Name: "src-1"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-5"},
+					source:      resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "src-1"},
 				},
 				{
-					destination: resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: userConfigPrefix + "dest-6"},
+					destination: resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-user-dest-6"},
 					source:      resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
 				},
 			},
@@ -438,7 +438,7 @@ func testConfigSyncSecret(name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: targetNamespace,
+			Namespace: "openshift-authentication",
 		},
 	}
 }
@@ -447,7 +447,7 @@ func testConfigSyncConfigMap(name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: targetNamespace,
+			Namespace: "openshift-authentication",
 		},
 	}
 }

--- a/pkg/operator2/console.go
+++ b/pkg/operator2/console.go
@@ -12,7 +12,7 @@ import (
 
 func (c *authOperator) handleConsoleConfig() *configv1.Console {
 	// technically this should be an observed config loop
-	consoleConfig, err := c.console.Get(globalConfigName, metav1.GetOptions{})
+	consoleConfig, err := c.console.Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		klog.Infof("error getting console config: %v", err)
 		return &configv1.Console{}

--- a/pkg/operator2/idp.go
+++ b/pkg/operator2/idp.go
@@ -27,23 +27,6 @@ import (
 // name looks like v4-0-config-user-idp-0-client-secret and the final path looks
 // like /var/config/user/idp/0/secret/v4-0-config-user-idp-0-client-secret/clientSecret
 // note how the end-user has no control over the structure of either value.
-const (
-	caField = "ca"
-
-	tlsClientCertField = "tls-client-cert"
-	tlsClientKeyField  = "tls-client-key"
-
-	clientSecretField = "client-secret"
-
-	fileDataField = "file-data"
-
-	bindPasswordField = "bind-password"
-
-	loginField             = "login"
-	providerSelectionField = "provider-selection"
-	errorField             = "error"
-)
-
 var (
 	scheme  = runtime.NewScheme()
 	codecs  = serializer.NewCodecFactory(scheme)
@@ -75,10 +58,10 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 		data.provider = &osinv1.BasicAuthPasswordIdentityProvider{
 			RemoteConnectionInfo: configv1.RemoteConnectionInfo{
 				URL: basicAuthConfig.URL,
-				CA:  syncData.addIDPConfigMap(i, basicAuthConfig.CA, caField, corev1.ServiceAccountRootCAKey),
+				CA:  syncData.addIDPConfigMap(i, basicAuthConfig.CA, "ca", corev1.ServiceAccountRootCAKey),
 				CertInfo: configv1.CertInfo{
-					CertFile: syncData.addIDPSecret(i, basicAuthConfig.TLSClientCert, tlsClientCertField, corev1.TLSCertKey),
-					KeyFile:  syncData.addIDPSecret(i, basicAuthConfig.TLSClientKey, tlsClientKeyField, corev1.TLSPrivateKeyKey),
+					CertFile: syncData.addIDPSecret(i, basicAuthConfig.TLSClientCert, "tls-client-cert", corev1.TLSCertKey),
+					KeyFile:  syncData.addIDPSecret(i, basicAuthConfig.TLSClientKey, "tls-client-key", corev1.TLSPrivateKeyKey),
 				},
 			},
 		}
@@ -92,11 +75,11 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 
 		data.provider = &osinv1.GitHubIdentityProvider{
 			ClientID:      githubConfig.ClientID,
-			ClientSecret:  createFileStringSource(syncData.addIDPSecret(i, githubConfig.ClientSecret, clientSecretField, configv1.ClientSecretKey)),
+			ClientSecret:  createFileStringSource(syncData.addIDPSecret(i, githubConfig.ClientSecret, "client-secret", configv1.ClientSecretKey)),
 			Organizations: githubConfig.Organizations,
 			Teams:         githubConfig.Teams,
 			Hostname:      githubConfig.Hostname,
-			CA:            syncData.addIDPConfigMap(i, githubConfig.CA, caField, corev1.ServiceAccountRootCAKey),
+			CA:            syncData.addIDPConfigMap(i, githubConfig.CA, "ca", corev1.ServiceAccountRootCAKey),
 		}
 		data.challenge = false
 
@@ -107,10 +90,10 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 		}
 
 		data.provider = &osinv1.GitLabIdentityProvider{
-			CA:           syncData.addIDPConfigMap(i, gitlabConfig.CA, caField, corev1.ServiceAccountRootCAKey),
+			CA:           syncData.addIDPConfigMap(i, gitlabConfig.CA, "ca", corev1.ServiceAccountRootCAKey),
 			URL:          gitlabConfig.URL,
 			ClientID:     gitlabConfig.ClientID,
-			ClientSecret: createFileStringSource(syncData.addIDPSecret(i, gitlabConfig.ClientSecret, clientSecretField, configv1.ClientSecretKey)),
+			ClientSecret: createFileStringSource(syncData.addIDPSecret(i, gitlabConfig.ClientSecret, "client-secret", configv1.ClientSecretKey)),
 			Legacy:       new(bool), // we require OIDC for GitLab now
 		}
 		data.challenge = true
@@ -123,7 +106,7 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 
 		data.provider = &osinv1.GoogleIdentityProvider{
 			ClientID:     googleConfig.ClientID,
-			ClientSecret: createFileStringSource(syncData.addIDPSecret(i, googleConfig.ClientSecret, clientSecretField, configv1.ClientSecretKey)),
+			ClientSecret: createFileStringSource(syncData.addIDPSecret(i, googleConfig.ClientSecret, "client-secret", configv1.ClientSecretKey)),
 			HostedDomain: googleConfig.HostedDomain,
 		}
 		data.challenge = false
@@ -134,7 +117,7 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 		}
 
 		data.provider = &osinv1.HTPasswdPasswordIdentityProvider{
-			File: syncData.addIDPSecret(i, providerConfig.HTPasswd.FileData, fileDataField, configv1.HTPasswdDataKey),
+			File: syncData.addIDPSecret(i, providerConfig.HTPasswd.FileData, "file-data", configv1.HTPasswdDataKey),
 		}
 		data.challenge = true
 
@@ -147,10 +130,10 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 		data.provider = &osinv1.KeystonePasswordIdentityProvider{
 			RemoteConnectionInfo: configv1.RemoteConnectionInfo{
 				URL: keystoneConfig.URL,
-				CA:  syncData.addIDPConfigMap(i, keystoneConfig.CA, caField, corev1.ServiceAccountRootCAKey),
+				CA:  syncData.addIDPConfigMap(i, keystoneConfig.CA, "ca", corev1.ServiceAccountRootCAKey),
 				CertInfo: configv1.CertInfo{
-					CertFile: syncData.addIDPSecret(i, keystoneConfig.TLSClientCert, tlsClientCertField, corev1.TLSCertKey),
-					KeyFile:  syncData.addIDPSecret(i, keystoneConfig.TLSClientKey, tlsClientKeyField, corev1.TLSPrivateKeyKey),
+					CertFile: syncData.addIDPSecret(i, keystoneConfig.TLSClientCert, "tls-client-cert", corev1.TLSCertKey),
+					KeyFile:  syncData.addIDPSecret(i, keystoneConfig.TLSClientKey, "tls-client-key", corev1.TLSPrivateKeyKey),
 				},
 			},
 			DomainName:          keystoneConfig.DomainName,
@@ -167,9 +150,9 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 		data.provider = &osinv1.LDAPPasswordIdentityProvider{
 			URL:          ldapConfig.URL,
 			BindDN:       ldapConfig.BindDN,
-			BindPassword: createFileStringSource(syncData.addIDPSecret(i, ldapConfig.BindPassword, bindPasswordField, configv1.BindPasswordKey)),
+			BindPassword: createFileStringSource(syncData.addIDPSecret(i, ldapConfig.BindPassword, "bind-password", configv1.BindPasswordKey)),
 			Insecure:     ldapConfig.Insecure,
-			CA:           syncData.addIDPConfigMap(i, ldapConfig.CA, caField, corev1.ServiceAccountRootCAKey),
+			CA:           syncData.addIDPConfigMap(i, ldapConfig.CA, "ca", corev1.ServiceAccountRootCAKey),
 			Attributes: osinv1.LDAPAttributeMapping{
 				ID:                ldapConfig.Attributes.ID,
 				PreferredUsername: ldapConfig.Attributes.PreferredUsername,
@@ -191,9 +174,9 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 		}
 
 		data.provider = &osinv1.OpenIDIdentityProvider{
-			CA:                       syncData.addIDPConfigMap(i, openIDConfig.CA, caField, corev1.ServiceAccountRootCAKey),
+			CA:                       syncData.addIDPConfigMap(i, openIDConfig.CA, "ca", corev1.ServiceAccountRootCAKey),
 			ClientID:                 openIDConfig.ClientID,
-			ClientSecret:             createFileStringSource(syncData.addIDPSecret(i, openIDConfig.ClientSecret, clientSecretField, configv1.ClientSecretKey)),
+			ClientSecret:             createFileStringSource(syncData.addIDPSecret(i, openIDConfig.ClientSecret, "client-secret", configv1.ClientSecretKey)),
 			ExtraScopes:              openIDConfig.ExtraScopes,
 			ExtraAuthorizeParameters: openIDConfig.ExtraAuthorizeParameters,
 			URLs:                     *urls,
@@ -216,7 +199,7 @@ func (c *authOperator) convertProviderConfigToIDPData(providerConfig *configv1.I
 		data.provider = &osinv1.RequestHeaderIdentityProvider{
 			LoginURL:                 requestHeaderConfig.LoginURL,
 			ChallengeURL:             requestHeaderConfig.ChallengeURL,
-			ClientCA:                 syncData.addIDPConfigMap(i, requestHeaderConfig.ClientCA, caField, corev1.ServiceAccountRootCAKey),
+			ClientCA:                 syncData.addIDPConfigMap(i, requestHeaderConfig.ClientCA, "ca", corev1.ServiceAccountRootCAKey),
 			ClientCommonNames:        requestHeaderConfig.ClientCommonNames,
 			Headers:                  requestHeaderConfig.Headers,
 			PreferredUsernameHeaders: requestHeaderConfig.PreferredUsernameHeaders,
@@ -295,7 +278,7 @@ func (c *authOperator) transportForCARef(ca configv1.ConfigMapNameReference, key
 	if len(ca.Name) == 0 {
 		return transportFor("", nil, nil, nil)
 	}
-	cm, err := c.configMaps.ConfigMaps(userConfigNamespace).Get(ca.Name, metav1.GetOptions{})
+	cm, err := c.configMaps.ConfigMaps("openshift-config").Get(ca.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +287,7 @@ func (c *authOperator) transportForCARef(ca configv1.ConfigMapNameReference, key
 		caData = cm.BinaryData[key]
 	}
 	if len(caData) == 0 {
-		return nil, fmt.Errorf("config map %s/%s has no ca data at key %s", userConfigNamespace, ca.Name, key)
+		return nil, fmt.Errorf("config map %s/%s has no ca data at key %s", "openshift-config", ca.Name, key)
 	}
 	return transportFor("", caData, nil, nil)
 }

--- a/pkg/operator2/infrastructure.go
+++ b/pkg/operator2/infrastructure.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *authOperator) handleInfrastructureConfig() *configv1.Infrastructure {
-	infrastructureConfig, err := c.infrastructure.Get(globalConfigName, metav1.GetOptions{})
+	infrastructureConfig, err := c.infrastructure.Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		klog.Infof("error getting infrastructure config: %v", err)
 		// have a placeholder that will at least look reasonable in the token request endpoint

--- a/pkg/operator2/ingress.go
+++ b/pkg/operator2/ingress.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *authOperator) handleIngress() (*configv1.Ingress, error) {
-	ingress, err := c.ingress.Get(globalConfigName, metav1.GetOptions{})
+	ingress, err := c.ingress.Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator2/oauthclients.go
+++ b/pkg/operator2/oauthclients.go
@@ -17,7 +17,7 @@ import (
 // ensureBootstrappedOAuthClients creates or updates the bootstrap oauth clients that openshift relies upon.
 func (c *authOperator) ensureBootstrappedOAuthClients(masterPublicURL string) error {
 	browserClient := oauthv1.OAuthClient{
-		ObjectMeta:            metav1.ObjectMeta{Name: oauthBrowserClientName},
+		ObjectMeta:            metav1.ObjectMeta{Name: "openshift-browser-client"},
 		Secret:                random256BitsString(),
 		RespondWithChallenges: false,
 		RedirectURIs:          []string{oauthdiscovery.OpenShiftOAuthTokenDisplayURL(masterPublicURL)},
@@ -28,7 +28,7 @@ func (c *authOperator) ensureBootstrappedOAuthClients(masterPublicURL string) er
 	}
 
 	cliClient := oauthv1.OAuthClient{
-		ObjectMeta:            metav1.ObjectMeta{Name: oauthChallengingClientName},
+		ObjectMeta:            metav1.ObjectMeta{Name: "openshift-challenging-client"},
 		Secret:                "",
 		RespondWithChallenges: true,
 		RedirectURIs:          []string{oauthdiscovery.OpenShiftOAuthTokenImplicitURL(masterPublicURL)},

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -41,106 +41,21 @@ import (
 )
 
 const (
-	clusterOperatorName     = "authentication"
-	targetName              = "oauth-openshift" // this value must be "namespaced" to avoid using a route host that a customer may want
-	targetNamespace         = "openshift-authentication"
-	targetNameOperator      = "authentication-operator"
-	targetNamespaceOperator = "openshift-authentication-operator"
-	globalConfigName        = "cluster"
-
 	deploymentVersionHashKey = "operator.openshift.io/rvs-hash"
-
-	operatorSelfName       = "operator"
-	operatorVersionEnvName = "OPERATOR_IMAGE_VERSION"
-	operandVersionEnvName  = "OPERAND_IMAGE_VERSION"
-	operandImageEnvName    = "IMAGE"
-	kasServicePortEnvName  = "KUBERNETES_SERVICE_PORT_HTTPS"
-
-	machineConfigNamespace = "openshift-config-managed"
-	userConfigNamespace    = "openshift-config"
-
-	kasServiceAndEndpointName = "kubernetes"
-	kasServiceFullName        = "kubernetes.default.svc"
-
-	rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-
-	configVersionPrefix = "v4-0-config-"
-
-	// secrets and config maps that we manually managed have this prefix
-	systemConfigPrefix = "v4-0-config-system-"
-
-	// secrets and config maps synced from openshift-config into our namespace have this prefix
-	userConfigPrefix = "v4-0-config-user-"
-	// idps that are synced have this prefix
-	userConfigPrefixIDP = "v4-0-config-user-idp-"
-	// templates that are synced have this prefix
-	userConfigPrefixTemplate = "v4-0-config-user-template-"
-
-	// root path for IDP data
-	userConfigPathPrefixIDP = "/var/config/user/idp"
-	// root path for template data
-	userConfigPathPrefixTemplate = "/var/config/user/template"
-
-	sessionNameAndKey = "v4-0-config-system-session"
-	sessionMount      = "/var/config/system/secrets/v4-0-config-system-session"
-	sessionPath       = "/var/config/system/secrets/v4-0-config-system-session/v4-0-config-system-session"
-
-	serviceCAName  = "v4-0-config-system-service-ca"
-	serviceCAKey   = "service-ca.crt"
-	serviceCAMount = "/var/config/system/configmaps/v4-0-config-system-service-ca"
-	serviceCAPath  = "/var/config/system/configmaps/v4-0-config-system-service-ca/service-ca.crt"
-
-	servingCertName     = "v4-0-config-system-serving-cert"
-	servingCertMount    = "/var/config/system/secrets/v4-0-config-system-serving-cert"
-	servingCertPathCert = "/var/config/system/secrets/v4-0-config-system-serving-cert/tls.crt"
-	servingCertPathKey  = "/var/config/system/secrets/v4-0-config-system-serving-cert/tls.key"
-
-	consoleConfigMapSharedName = "console-config"
-	consoleConfigMapLocalName  = "v4-0-config-system-console-config"
-	consoleConfigKey           = "console-config.yaml"
-
-	// trustedCABundleName is part of manifests so the names must be kept in sync
-	trustedCABundleName  = "v4-0-config-system-trusted-ca-bundle"
-	trustedCABundleMount = "/var/config/system/configmaps/v4-0-config-system-trusted-ca-bundle"
-	trustedCABundlePath  = "/var/config/system/configmaps/v4-0-config-system-trusted-ca-bundle/ca-bundle.crt"
-
-	ocpBrandingSecretName   = "v4-0-config-system-ocp-branding-template"
-	ocpBrandingSecretMount  = "/var/config/system/secrets/v4-0-config-system-ocp-branding-template"
-	ocpBrandingLoginPath    = "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/login.html"
-	ocpBrandingProviderPath = "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/providers.html"
-	ocpBrandingErrorPath    = "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/errors.html"
-
-	cliConfigNameAndKey = "v4-0-config-system-cliconfig"
-	cliConfigMount      = "/var/config/system/configmaps/v4-0-config-system-cliconfig"
-	cliConfigPath       = "/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig"
-
-	oauthMetadataName        = "v4-0-config-system-metadata"
-	oauthMetadataAPIEndpoint = "/.well-known/oauth-authorization-server"
-
-	oauthBrowserClientName     = "openshift-browser-client"
-	oauthChallengingClientName = "openshift-challenging-client"
-
-	routerCertsSharedName = "router-certs"
-	routerCertsLocalName  = "v4-0-config-system-router-certs"
-	routerCertsLocalMount = "/var/config/system/secrets/v4-0-config-system-router-certs"
-
-	servicePort   = 443
-	containerPort = 6443
 )
 
 // static environment variables from operator deployment
 var (
-	oauthserverImage   = os.Getenv(operandImageEnvName)
-	oauthserverVersion = os.Getenv(operandVersionEnvName)
-
-	operatorVersion = os.Getenv(operatorVersionEnvName)
+	oauthserverImage   = os.Getenv("IMAGE")
+	oauthserverVersion = os.Getenv("OPERAND_IMAGE_VERSION")
+	operatorVersion    = os.Getenv("OPERATOR_IMAGE_VERSION")
 
 	kasServicePort int
 )
 
 func init() {
 	var err error
-	kasServicePort, err = strconv.Atoi(os.Getenv(kasServicePortEnvName))
+	kasServicePort, err = strconv.Atoi(os.Getenv("KUBERNETES_SERVICE_PORT_HTTPS"))
 	if err != nil {
 		klog.Infof("defaulting KAS service port to 443 due to parsing error: %v", err)
 		kasServicePort = 443
@@ -193,7 +108,7 @@ func NewAuthenticationOperator(
 		versionGetter: versionGetter,
 		recorder:      recorder,
 
-		route: routeClient.Routes(targetNamespace),
+		route: routeClient.Routes("openshift-authentication"),
 
 		oauthClientClient: oauthClientClient.OAuthClients(),
 
@@ -217,8 +132,8 @@ func NewAuthenticationOperator(
 	coreInformers := kubeInformersNamespaced.Core().V1()
 	configV1Informers := configInformers.Config().V1()
 
-	targetNameFilter := operator.FilterByNames(targetName)
-	configNameFilter := operator.FilterByNames(globalConfigName)
+	targetNameFilter := operator.FilterByNames("oauth-openshift")
+	configNameFilter := operator.FilterByNames("cluster")
 	prefixFilter := getPrefixFilter()
 
 	return operator.New("AuthenticationOperator2", c,
@@ -241,7 +156,7 @@ func NewAuthenticationOperator(
 }
 
 func (c *authOperator) Key() (metav1.Object, error) {
-	return c.authOperatorConfigClient.Client.Authentications().Get(globalConfigName, metav1.GetOptions{})
+	return c.authOperatorConfigClient.Client.Authentications().Get("cluster", metav1.GetOptions{})
 }
 
 func (c *authOperator) Sync(obj metav1.Object) error {
@@ -384,7 +299,7 @@ func (c *authOperator) handleSync(operatorConfig *operatorv1.Authentication) err
 	proxyConfig := c.handleProxyConfig()
 	resourceVersions = append(resourceVersions, "proxy:"+proxyConfig.Name+":"+proxyConfig.ResourceVersion)
 
-	operatorDeployment, err := c.deployments.Deployments(targetNamespaceOperator).Get(targetNameOperator, metav1.GetOptions{})
+	operatorDeployment, err := c.deployments.Deployments("openshift-authentication-operator").Get("authentication-operator", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -485,8 +400,8 @@ func (c *authOperator) handleVersion(
 	// we have achieved our desired level
 	setProgressingFalse(operatorConfig)
 	setAvailableTrue(operatorConfig, "AsExpected")
-	c.setVersion(operatorSelfName, operatorVersion)
-	c.setVersion(targetName, oauthserverVersion)
+	c.setVersion("operator", operatorVersion)
+	c.setVersion("oauth-openshift", oauthserverVersion)
 
 	return nil
 }
@@ -551,13 +466,13 @@ func (c *authOperator) checkWellknownEndpointsReady(authConfig *configv1.Authent
 		return true, "", nil
 	}
 
-	caData, err := ioutil.ReadFile(rootCAFile)
+	caData, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 	if err != nil {
 		return false, "", fmt.Errorf("failed to read SA ca.crt: %v", err)
 	}
 
 	// pass the KAS service name for SNI
-	rt, err := transportFor(kasServiceFullName, caData, nil, nil)
+	rt, err := transportFor("kubernetes.default.svc", caData, nil, nil)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to build transport for SA ca.crt: %v", err)
 	}
@@ -578,7 +493,7 @@ func (c *authOperator) checkWellknownEndpointsReady(authConfig *configv1.Authent
 }
 
 func (c *authOperator) getAPIServerIPs() ([]string, error) {
-	kasService, err := c.services.Services(corev1.NamespaceDefault).Get(kasServiceAndEndpointName, metav1.GetOptions{})
+	kasService, err := c.services.Services(corev1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kube api server service: %v", err)
 	}
@@ -588,7 +503,7 @@ func (c *authOperator) getAPIServerIPs() ([]string, error) {
 		return nil, fmt.Errorf("unable to find kube api server service target port: %#v", kasService)
 	}
 
-	kasEndpoint, err := c.endpoints.Endpoints(corev1.NamespaceDefault).Get(kasServiceAndEndpointName, metav1.GetOptions{})
+	kasEndpoint, err := c.endpoints.Endpoints(corev1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kube api server endpoints: %v", err)
 	}
@@ -631,7 +546,7 @@ func subsetHasKASTargetPort(subset corev1.EndpointSubset, targetPort int) bool {
 }
 
 func (c *authOperator) checkWellknownEndpointReady(apiIP string, rt http.RoundTripper, route *routev1.Route) (bool, string, error) {
-	wellKnown := "https://" + apiIP + oauthMetadataAPIEndpoint
+	wellKnown := "https://" + apiIP + "/.well-known/oauth-authorization-server"
 
 	req, err := http.NewRequest(http.MethodGet, wellKnown, nil)
 	if err != nil {
@@ -666,7 +581,7 @@ func (c *authOperator) checkWellknownEndpointReady(apiIP string, rt http.RoundTr
 }
 
 func (c *authOperator) oauthClientsReady(route *routev1.Route) (bool, string, error) {
-	_, err := c.oauthClientClient.Get(oauthBrowserClientName, metav1.GetOptions{})
+	_, err := c.oauthClientClient.Get("openshift-browser-client", metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, "browser oauthclient does not exist", nil
@@ -674,7 +589,7 @@ func (c *authOperator) oauthClientsReady(route *routev1.Route) (bool, string, er
 		return false, "", err
 	}
 
-	_, err = c.oauthClientClient.Get(oauthChallengingClientName, metav1.GetOptions{})
+	_, err = c.oauthClientClient.Get("openshift-challenging-client", metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, "challenging oauthclient does not exist", nil
@@ -693,14 +608,14 @@ func (c *authOperator) setVersion(operandName, version string) {
 
 func defaultLabels() map[string]string {
 	return map[string]string{
-		"app": targetName,
+		"app": "oauth-openshift",
 	}
 }
 
 func defaultMeta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:            targetName,
-		Namespace:       targetNamespace,
+		Name:            "oauth-openshift",
+		Namespace:       "openshift-authentication",
 		Labels:          defaultLabels(),
 		Annotations:     map[string]string{},
 		OwnerReferences: nil, // TODO
@@ -709,7 +624,7 @@ func defaultMeta() metav1.ObjectMeta {
 
 func defaultGlobalConfigMeta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:   globalConfigName,
+		Name:   "cluster",
 		Labels: map[string]string{},
 		Annotations: map[string]string{
 			"release.openshift.io/create-only": "true",
@@ -718,9 +633,9 @@ func defaultGlobalConfigMeta() metav1.ObjectMeta {
 }
 
 func getPrefixFilter() controller.Filter {
-	names := operator.FilterByNames(targetName)
+	names := operator.FilterByNames("oauth-openshift")
 	prefix := func(obj metav1.Object) bool { // TODO add helper to combine filters
-		return names.Add(obj) || strings.HasPrefix(obj.GetName(), configVersionPrefix)
+		return names.Add(obj) || strings.HasPrefix(obj.GetName(), "v4-0-config-")
 	}
 	return controller.FilterFuncs{
 		AddFunc: prefix,

--- a/pkg/operator2/operatorclient.go
+++ b/pkg/operator2/operatorclient.go
@@ -19,7 +19,7 @@ func (c OperatorClient) Informer() cache.SharedIndexInformer {
 }
 
 func (c OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
-	instance, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
+	instance, err := c.Informers.Operator().V1().Authentications().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -28,7 +28,7 @@ func (c OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv
 }
 
 func (c OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
-	original, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
+	original, err := c.Informers.Operator().V1().Authentications().Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
 	}
@@ -45,7 +45,7 @@ func (c OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operato
 }
 
 func (c OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
-	original, err := c.Informers.Operator().V1().Authentications().Lister().Get(globalConfigName)
+	original, err := c.Informers.Operator().V1().Authentications().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator2/proxy.go
+++ b/pkg/operator2/proxy.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *authOperator) handleProxyConfig() *configv1.Proxy {
-	proxyConfig, err := c.proxy.Get(globalConfigName, metav1.GetOptions{})
+	proxyConfig, err := c.proxy.Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		klog.Infof("error getting proxy config: %v", err)
 		return &configv1.Proxy{}

--- a/pkg/operator2/resourceversion.go
+++ b/pkg/operator2/resourceversion.go
@@ -9,23 +9,23 @@ import (
 func (c *authOperator) handleConfigResourceVersions() ([]string, error) {
 	var configRVs []string
 
-	configMaps, err := c.configMaps.ConfigMaps(targetNamespace).List(metav1.ListOptions{})
+	configMaps, err := c.configMaps.ConfigMaps("openshift-authentication").List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	for _, cm := range configMaps.Items {
-		if strings.HasPrefix(cm.Name, configVersionPrefix) {
+		if strings.HasPrefix(cm.Name, "v4-0-config-") {
 			// prefix the RV to make it clear where it came from since each resource can be from different etcd
 			configRVs = append(configRVs, "configmaps:"+cm.Name+":"+cm.ResourceVersion)
 		}
 	}
 
-	secrets, err := c.secrets.Secrets(targetNamespace).List(metav1.ListOptions{})
+	secrets, err := c.secrets.Secrets("openshift-authentication").List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	for _, secret := range secrets.Items {
-		if strings.HasPrefix(secret.Name, configVersionPrefix) {
+		if strings.HasPrefix(secret.Name, "v4-0-config-") {
 			// prefix the RV to make it clear where it came from since each resource can be from different etcd
 			configRVs = append(configRVs, "secrets:"+secret.Name+":"+secret.ResourceVersion)
 		}

--- a/pkg/operator2/resourceversion_test.go
+++ b/pkg/operator2/resourceversion_test.go
@@ -32,53 +32,53 @@ func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
 		{
 			name: "user config only",
 			objects: []runtime.Object{
-				testRVSecret(userConfigPrefix+"a", "1"),
-				testRVConfigMap(userConfigPrefix+"b", "2"),
+				testRVSecret("v4-0-config-user-a", "1"),
+				testRVConfigMap("v4-0-config-user-b", "2"),
 			},
 			want: []string{
-				testRVString("configmaps", userConfigPrefix+"b", "2"),
-				testRVString("secrets", userConfigPrefix+"a", "1"),
+				testRVString("configmaps", "v4-0-config-user-b", "2"),
+				testRVString("secrets", "v4-0-config-user-a", "1"),
 			},
 		},
 		{
 			name: "system config only",
 			objects: []runtime.Object{
-				testRVSecret(systemConfigPrefix+"c", "3"),
-				testRVConfigMap(systemConfigPrefix+"d", "4"),
+				testRVSecret("v4-0-config-system-c", "3"),
+				testRVConfigMap("v4-0-config-system-d", "4"),
 			},
 			want: []string{
-				testRVString("configmaps", systemConfigPrefix+"d", "4"),
-				testRVString("secrets", systemConfigPrefix+"c", "3"),
+				testRVString("configmaps", "v4-0-config-system-d", "4"),
+				testRVString("secrets", "v4-0-config-system-c", "3"),
 			},
 		},
 		{
 			name: "both config",
 			objects: []runtime.Object{
-				testRVSecret(userConfigPrefix+"a", "1"),
-				testRVConfigMap(userConfigPrefix+"b", "2"),
-				testRVSecret(systemConfigPrefix+"c", "3"),
-				testRVConfigMap(systemConfigPrefix+"d", "4"),
+				testRVSecret("v4-0-config-user-a", "1"),
+				testRVConfigMap("v4-0-config-user-b", "2"),
+				testRVSecret("v4-0-config-system-c", "3"),
+				testRVConfigMap("v4-0-config-system-d", "4"),
 			},
 			want: []string{
-				testRVString("configmaps", userConfigPrefix+"b", "2"),
-				testRVString("configmaps", systemConfigPrefix+"d", "4"),
-				testRVString("secrets", userConfigPrefix+"a", "1"),
-				testRVString("secrets", systemConfigPrefix+"c", "3"),
+				testRVString("configmaps", "v4-0-config-user-b", "2"),
+				testRVString("configmaps", "v4-0-config-system-d", "4"),
+				testRVString("secrets", "v4-0-config-user-a", "1"),
+				testRVString("secrets", "v4-0-config-system-c", "3"),
 			},
 		},
 		{
 			name: "both config overlapping resource versions",
 			objects: []runtime.Object{
-				testRVSecret(userConfigPrefix+"a", "1"),
-				testRVConfigMap(userConfigPrefix+"b", "2"),
-				testRVSecret(systemConfigPrefix+"c", "2"),
-				testRVConfigMap(systemConfigPrefix+"d", "1"),
+				testRVSecret("v4-0-config-user-a", "1"),
+				testRVConfigMap("v4-0-config-user-b", "2"),
+				testRVSecret("v4-0-config-system-c", "2"),
+				testRVConfigMap("v4-0-config-system-d", "1"),
 			},
 			want: []string{
-				testRVString("configmaps", userConfigPrefix+"b", "2"),
-				testRVString("configmaps", systemConfigPrefix+"d", "1"),
-				testRVString("secrets", userConfigPrefix+"a", "1"),
-				testRVString("secrets", systemConfigPrefix+"c", "2"),
+				testRVString("configmaps", "v4-0-config-user-b", "2"),
+				testRVString("configmaps", "v4-0-config-system-d", "1"),
+				testRVString("secrets", "v4-0-config-user-a", "1"),
+				testRVString("secrets", "v4-0-config-system-c", "2"),
 			},
 		},
 		{
@@ -86,16 +86,16 @@ func Test_authOperator_handleConfigResourceVersions(t *testing.T) {
 			objects: []runtime.Object{
 				testRVSecret("e", "5"),
 				testRVConfigMap("f", "6"),
-				testRVSecret(userConfigPrefix+"a", "3"),
-				testRVConfigMap(userConfigPrefix+"b", "2"),
-				testRVSecret(systemConfigPrefix+"c", "2"),
-				testRVConfigMap(systemConfigPrefix+"d", "3"),
+				testRVSecret("v4-0-config-user-a", "3"),
+				testRVConfigMap("v4-0-config-user-b", "2"),
+				testRVSecret("v4-0-config-system-c", "2"),
+				testRVConfigMap("v4-0-config-system-d", "3"),
 			},
 			want: []string{
-				testRVString("configmaps", userConfigPrefix+"b", "2"),
-				testRVString("configmaps", systemConfigPrefix+"d", "3"),
-				testRVString("secrets", userConfigPrefix+"a", "3"),
-				testRVString("secrets", systemConfigPrefix+"c", "2"),
+				testRVString("configmaps", "v4-0-config-user-b", "2"),
+				testRVString("configmaps", "v4-0-config-system-d", "3"),
+				testRVString("secrets", "v4-0-config-user-a", "3"),
+				testRVString("secrets", "v4-0-config-system-c", "2"),
 			},
 		},
 	}
@@ -122,7 +122,7 @@ func testRVSecret(name, rv string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
-			Namespace:       targetNamespace,
+			Namespace:       "openshift-authentication",
 			ResourceVersion: rv,
 		},
 	}
@@ -132,7 +132,7 @@ func testRVConfigMap(name, rv string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
-			Namespace:       targetNamespace,
+			Namespace:       "openshift-authentication",
 			ResourceVersion: rv,
 		},
 	}

--- a/pkg/operator2/route_test.go
+++ b/pkg/operator2/route_test.go
@@ -179,10 +179,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 					Host: "oauth-openshift.apps.example.com",
 					To: v1.RouteTargetReference{
 						Kind: "Service",
-						Name: targetName,
+						Name: "oauth-openshift",
 					},
 					Port: &v1.RoutePort{
-						TargetPort: intstr.FromInt(containerPort),
+						TargetPort: intstr.FromInt(6443),
 					},
 					TLS: &v1.TLSConfig{
 						Termination:                   v1.TLSTerminationPassthrough,
@@ -205,8 +205,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			},
 			expectedSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      routerCertsLocalName,
-					Namespace: targetNamespace,
+					Name:      "v4-0-config-system-router-certs",
+					Namespace: "openshift-authentication",
 				},
 				Data: map[string][]byte{
 					"apps.example.com": []byte(appCert),
@@ -216,8 +216,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			objects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      routerCertsLocalName,
-						Namespace: targetNamespace,
+						Name:      "v4-0-config-system-router-certs",
+						Namespace: "openshift-authentication",
 					},
 					Data: map[string][]byte{
 						"apps.example.com": []byte(appCert),
@@ -252,10 +252,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 					Host: "oauth-openshift.apps.example.com",
 					To: v1.RouteTargetReference{
 						Kind: "Service",
-						Name: targetName,
+						Name: "oauth-openshift",
 					},
 					Port: &v1.RoutePort{
-						TargetPort: intstr.FromInt(containerPort),
+						TargetPort: intstr.FromInt(6443),
 					},
 					TLS: &v1.TLSConfig{
 						Termination:                   v1.TLSTerminationPassthrough,
@@ -278,8 +278,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			},
 			expectedSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      routerCertsLocalName,
-					Namespace: targetNamespace,
+					Name:      "v4-0-config-system-router-certs",
+					Namespace: "openshift-authentication",
 				},
 				Data: map[string][]byte{
 					"apps.example.com": []byte(appCert),
@@ -289,8 +289,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			objects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      routerCertsLocalName,
-						Namespace: targetNamespace,
+						Name:      "v4-0-config-system-router-certs",
+						Namespace: "openshift-authentication",
 					},
 					Data: map[string][]byte{
 						"apps.example.com": []byte(appCert),
@@ -305,10 +305,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 						Host: "oauth-openshift.apps.example.com", // mimic the behavior of subdomain
 						To: v1.RouteTargetReference{
 							Kind: "Service",
-							Name: targetName,
+							Name: "oauth-openshift",
 						},
 						Port: &v1.RoutePort{
-							TargetPort: intstr.FromInt(containerPort),
+							TargetPort: intstr.FromInt(6443),
 						},
 						TLS: &v1.TLSConfig{
 							Termination:                   v1.TLSTerminationPassthrough,
@@ -343,10 +343,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 					Host: "oauth-openshift.bar.example.com",
 					To: v1.RouteTargetReference{
 						Kind: "Service",
-						Name: targetName,
+						Name: "oauth-openshift",
 					},
 					Port: &v1.RoutePort{
-						TargetPort: intstr.FromInt(containerPort),
+						TargetPort: intstr.FromInt(6443),
 					},
 					TLS: &v1.TLSConfig{
 						Termination:                   v1.TLSTerminationPassthrough,
@@ -383,8 +383,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			},
 			expectedSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      routerCertsLocalName,
-					Namespace: targetNamespace,
+					Name:      "v4-0-config-system-router-certs",
+					Namespace: "openshift-authentication",
 				},
 				Data: map[string][]byte{
 					"bar.example.com": []byte(barCert),
@@ -394,8 +394,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			objects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      routerCertsLocalName,
-						Namespace: targetNamespace,
+						Name:      "v4-0-config-system-router-certs",
+						Namespace: "openshift-authentication",
 					},
 					Data: map[string][]byte{
 						"bar.example.com": []byte(barCert),
@@ -410,10 +410,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 						Host: "oauth-openshift.apps.example.com", // mimic the behavior of subdomain
 						To: v1.RouteTargetReference{
 							Kind: "Service",
-							Name: targetName,
+							Name: "oauth-openshift",
 						},
 						Port: &v1.RoutePort{
-							TargetPort: intstr.FromInt(containerPort),
+							TargetPort: intstr.FromInt(6443),
 						},
 						TLS: &v1.TLSConfig{
 							Termination:                   v1.TLSTerminationPassthrough,
@@ -444,10 +444,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			},
 			expectedRoute: &v1.Route{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      targetName,
-					Namespace: targetNamespace,
+					Name:      "oauth-openshift",
+					Namespace: "openshift-authentication",
 					Labels: map[string]string{
-						"app": targetName,
+						"app": "oauth-openshift",
 					},
 					Annotations: map[string]string{
 						"annotationToPreserve": "foo",
@@ -457,10 +457,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 					Host: "oauth-openshift.apps.example.com",
 					To: v1.RouteTargetReference{
 						Kind: "Service",
-						Name: targetName,
+						Name: "oauth-openshift",
 					},
 					Port: &v1.RoutePort{
-						TargetPort: intstr.FromInt(containerPort),
+						TargetPort: intstr.FromInt(6443),
 					},
 					TLS: &v1.TLSConfig{
 						Termination:                   v1.TLSTerminationPassthrough,
@@ -497,8 +497,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			},
 			expectedSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      routerCertsLocalName,
-					Namespace: targetNamespace,
+					Name:      "v4-0-config-system-router-certs",
+					Namespace: "openshift-authentication",
 				},
 				Data: map[string][]byte{
 					"apps.example.com": []byte(appCert),
@@ -508,8 +508,8 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			objects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      routerCertsLocalName,
-						Namespace: targetNamespace,
+						Name:      "v4-0-config-system-router-certs",
+						Namespace: "openshift-authentication",
 					},
 					Data: map[string][]byte{
 						"apps.example.com": []byte(appCert),
@@ -520,10 +520,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			routeObjects: []runtime.Object{
 				&v1.Route{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      targetName,
-						Namespace: targetNamespace,
+						Name:      "oauth-openshift",
+						Namespace: "openshift-authentication",
 						Labels: map[string]string{
-							"app": targetName,
+							"app": "oauth-openshift",
 						},
 						Annotations: map[string]string{
 							"annotationToPreserve": "foo",
@@ -533,10 +533,10 @@ func Test_authOperator_handleRoute(t *testing.T) {
 						Host: "oauth-openshift.apps.example.com", // mimic the behavior of subdomain
 						To: v1.RouteTargetReference{
 							Kind: "Service",
-							Name: targetName,
+							Name: "oauth-openshift",
 						},
 						Port: &v1.RoutePort{
-							TargetPort: intstr.FromInt(containerPort),
+							TargetPort: intstr.FromInt(6443),
 						},
 						TLS: nil, // This invalidates the route
 					},
@@ -579,7 +579,7 @@ func Test_authOperator_handleRoute(t *testing.T) {
 			c := &authOperator{
 				secrets:    client.CoreV1(),
 				configMaps: client.CoreV1(),
-				route:      routeClient.RouteV1().Routes(targetNamespace),
+				route:      routeClient.RouteV1().Routes("openshift-authentication"),
 			}
 
 			route, secret, _, err := c.handleRoute(tt.ingress)

--- a/pkg/operator2/secret.go
+++ b/pkg/operator2/secret.go
@@ -15,9 +15,9 @@ import (
 )
 
 func (c *authOperator) expectedSessionSecret() (*corev1.Secret, error) {
-	secret, err := c.secrets.Secrets(targetNamespace).Get(sessionNameAndKey, metav1.GetOptions{})
+	secret, err := c.secrets.Secrets("openshift-authentication").Get("v4-0-config-system-session", metav1.GetOptions{})
 	if err != nil || !isValidSessionSecret(secret) {
-		klog.V(4).Infof("failed to get secret %s: %v", sessionNameAndKey, err)
+		klog.V(4).Infof("failed to get secret %s: %v", "v4-0-config-system-session", err)
 		generatedSessionSecret, err := randomSessionSecret()
 		if err != nil {
 			return nil, err
@@ -58,11 +58,11 @@ func randomSessionSecret() (*corev1.Secret, error) {
 		return nil, err
 	}
 	meta := defaultMeta()
-	meta.Name = sessionNameAndKey
+	meta.Name = "v4-0-config-system-session"
 	return &corev1.Secret{
 		ObjectMeta: meta,
 		Data: map[string][]byte{
-			sessionNameAndKey: skey,
+			"v4-0-config-system-session": skey,
 		},
 	}, nil
 }

--- a/pkg/operator2/secret_test.go
+++ b/pkg/operator2/secret_test.go
@@ -42,7 +42,7 @@ func secret(sessionSecret []byte) *v1.Secret {
 	return &v1.Secret{
 		ObjectMeta: defaultMeta(),
 		Data: map[string][]byte{
-			sessionNameAndKey: sessionSecret,
+			"v4-0-config-system-session": sessionSecret,
 		},
 	}
 }

--- a/pkg/operator2/service.go
+++ b/pkg/operator2/service.go
@@ -7,7 +7,7 @@ import (
 
 func defaultService() *v1.Service {
 	meta := defaultMeta()
-	meta.Annotations["service.alpha.openshift.io/serving-cert-secret-name"] = servingCertName
+	meta.Annotations["service.alpha.openshift.io/serving-cert-secret-name"] = "v4-0-config-system-serving-cert"
 	return &v1.Service{
 		ObjectMeta: meta,
 		Spec: v1.ServiceSpec{
@@ -15,8 +15,8 @@ func defaultService() *v1.Service {
 				{
 					Name:       "https",
 					Protocol:   v1.ProtocolTCP,
-					Port:       servicePort,
-					TargetPort: intstr.FromInt(containerPort),
+					Port:       443,
+					TargetPort: intstr.FromInt(6443),
 				},
 			},
 			Selector:        defaultLabels(),


### PR DESCRIPTION
Using consts everywhere makes it impossible to grep the code for strings. These strings will never change and if they do it will be when we will rewrite this operator.

/cc @enj 
/cc @deads2k 