### PR TITLE
manifests: split configmaps

### DIFF
--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -7,23 +7,3 @@ data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: openshift-authentication-operator
-  name: trusted-ca-bundle
-  annotations:
-    release.openshift.io/create-only: "true"
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: openshift-authentication
-  name: v4-0-config-system-trusted-ca-bundle
-  annotations:
-    release.openshift.io/create-only: "true"
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/03_operand_trusted_ca.yaml
+++ b/manifests/03_operand_trusted_ca.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-authentication
+  name: v4-0-config-system-trusted-ca-bundle
+  annotations:
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/03_operator_trusted_ca.yaml
+++ b/manifests/03_operator_trusted_ca.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-authentication-operator
+  name: trusted-ca-bundle
+  annotations:
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
It seems that during upgrade, CVO might be applying whole files,
not just objects, which would cause it to remove the contents of
trusted-ca-bundle configmap in loop with CNO.