### PR TITLE
Bug 1753886: Don't stomp on our own route

### DIFF
--- a/pkg/operator2/route.go
+++ b/pkg/operator2/route.go
@@ -58,14 +58,19 @@ func (c *authOperator) handleRoute(ingress *configv1.Ingress) (*routev1.Route, *
 }
 
 func defaultRoute(ingress *configv1.Ingress) *routev1.Route {
+	// emulates server-side defaulting as in https://github.com/openshift/openshift-apiserver/blob/master/pkg/route/apis/route/v1/defaults.go
+	// TODO: replace with server-side apply
+	var weightVal int32 = 100
+
 	return &routev1.Route{
 		ObjectMeta: defaultMeta(),
 		Spec: routev1.RouteSpec{
 			Host:      ingressToHost(ingress), // mimic the behavior of subdomain
 			Subdomain: "",                     // TODO once subdomain is functional, remove reliance on ingress config and just set subdomain=targetName
 			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: "oauth-openshift",
+				Kind:   "Service",
+				Name:   "oauth-openshift",
+				Weight: &weightVal,
 			},
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.FromInt(6443),
@@ -74,6 +79,7 @@ func defaultRoute(ingress *configv1.Ingress) *routev1.Route {
 				Termination:                   routev1.TLSTerminationPassthrough,
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 			},
+			WildcardPolicy: routev1.WildcardPolicyNone, // emulates server-side defaulting, see the link above
 		},
 	}
 }

--- a/pkg/operator2/route_test.go
+++ b/pkg/operator2/route_test.go
@@ -12,6 +12,7 @@ import (
 	testing2 "k8s.io/client-go/testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	v1 "github.com/openshift/api/route/v1"
 	routefake "github.com/openshift/client-go/route/clientset/versioned/fake"
 )
@@ -155,6 +156,8 @@ J+hyJVALyXVcxEiKZKuQsZ0rpc9pixzkExWrReDCPrn1Gb+XedY=
 `
 
 func Test_authOperator_handleRoute(t *testing.T) {
+	var routeWeightVal int32 = 100
+
 	var tests = map[string]struct {
 		ingress             *configv1.Ingress
 		expectedRoute       *v1.Route
@@ -178,8 +181,9 @@ func Test_authOperator_handleRoute(t *testing.T) {
 				Spec: v1.RouteSpec{
 					Host: "oauth-openshift.apps.example.com",
 					To: v1.RouteTargetReference{
-						Kind: "Service",
-						Name: "oauth-openshift",
+						Kind:   "Service",
+						Name:   "oauth-openshift",
+						Weight: &routeWeightVal,
 					},
 					Port: &v1.RoutePort{
 						TargetPort: intstr.FromInt(6443),
@@ -188,6 +192,7 @@ func Test_authOperator_handleRoute(t *testing.T) {
 						Termination:                   v1.TLSTerminationPassthrough,
 						InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 				Status: v1.RouteStatus{
 					Ingress: []v1.RouteIngress{
@@ -251,8 +256,9 @@ func Test_authOperator_handleRoute(t *testing.T) {
 				Spec: v1.RouteSpec{
 					Host: "oauth-openshift.apps.example.com",
 					To: v1.RouteTargetReference{
-						Kind: "Service",
-						Name: "oauth-openshift",
+						Kind:   "Service",
+						Name:   "oauth-openshift",
+						Weight: &routeWeightVal,
 					},
 					Port: &v1.RoutePort{
 						TargetPort: intstr.FromInt(6443),
@@ -261,6 +267,7 @@ func Test_authOperator_handleRoute(t *testing.T) {
 						Termination:                   v1.TLSTerminationPassthrough,
 						InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 				Status: v1.RouteStatus{
 					Ingress: []v1.RouteIngress{
@@ -304,8 +311,9 @@ func Test_authOperator_handleRoute(t *testing.T) {
 					Spec: v1.RouteSpec{
 						Host: "oauth-openshift.apps.example.com", // mimic the behavior of subdomain
 						To: v1.RouteTargetReference{
-							Kind: "Service",
-							Name: "oauth-openshift",
+							Kind:   "Service",
+							Name:   "oauth-openshift",
+							Weight: &routeWeightVal,
 						},
 						Port: &v1.RoutePort{
 							TargetPort: intstr.FromInt(6443),
@@ -314,6 +322,7 @@ func Test_authOperator_handleRoute(t *testing.T) {
 							Termination:                   v1.TLSTerminationPassthrough,
 							InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
 						},
+						WildcardPolicy: routev1.WildcardPolicyNone,
 					},
 					Status: v1.RouteStatus{
 						Ingress: []v1.RouteIngress{
@@ -342,8 +351,9 @@ func Test_authOperator_handleRoute(t *testing.T) {
 				Spec: v1.RouteSpec{
 					Host: "oauth-openshift.bar.example.com",
 					To: v1.RouteTargetReference{
-						Kind: "Service",
-						Name: "oauth-openshift",
+						Kind:   "Service",
+						Name:   "oauth-openshift",
+						Weight: &routeWeightVal,
 					},
 					Port: &v1.RoutePort{
 						TargetPort: intstr.FromInt(6443),
@@ -352,6 +362,7 @@ func Test_authOperator_handleRoute(t *testing.T) {
 						Termination:                   v1.TLSTerminationPassthrough,
 						InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 				Status: v1.RouteStatus{
 					Ingress: []v1.RouteIngress{
@@ -456,8 +467,9 @@ func Test_authOperator_handleRoute(t *testing.T) {
 				Spec: v1.RouteSpec{
 					Host: "oauth-openshift.apps.example.com",
 					To: v1.RouteTargetReference{
-						Kind: "Service",
-						Name: "oauth-openshift",
+						Kind:   "Service",
+						Name:   "oauth-openshift",
+						Weight: &routeWeightVal,
 					},
 					Port: &v1.RoutePort{
 						TargetPort: intstr.FromInt(6443),
@@ -466,6 +478,7 @@ func Test_authOperator_handleRoute(t *testing.T) {
 						Termination:                   v1.TLSTerminationPassthrough,
 						InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
 					},
+					WildcardPolicy: routev1.WildcardPolicyNone,
 				},
 				Status: v1.RouteStatus{
 					Ingress: []v1.RouteIngress{


### PR DESCRIPTION
It seems that new fields with non-nil default values were added to
routes, specifically .spec.to.weigh and .spec.wildcardPolicy.
Since we do not expect them in the route, it gets stomped on
all of the time.

-----

We may want to find a better way to ensure the substantial fields are configured the way we need them.

cc @mfojtik @enj 