### PR TITLE
update README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machine
 check: | verify test-unit
 .PHONY: check
 
+IMAGE_REGISTRY?=registry.svc.ci.openshift.org
+
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name
 # $1 - target name
@@ -22,7 +24,7 @@ check: | verify test-unit
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,origin-cluster-$(go_build_binaries),quay.io/openshift/origin-cluster-$(go_build_binaries),./Dockerfile,.)
+$(call build-image,ocp-cluster-authentication-operator,$(IMAGE_REGISTRY)/ocp/4.3:cluster-authentication-operator,./Dockerfile.rhel7,.)
 
 clean:
 	$(RM) ./authentication-operator

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # cluster-authentication-operator
+The authentication operator is an 
+[OpenShift ClusterOperator](https://github.com/openshift/enhancements/blob/master/enhancements/operator-dev-doc.md#what-is-an-openshift-clusteroperator).    
+It installs and maintains the Authentication [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) in a cluster and can be viewed with:     
+```
+oc get clusteroperator authentication -o yaml
+```
 
-This is where the amazing cluster-authentication-operator lives.
+The [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
+`authentications.operator.openshift.io`    
+can be viewed in a cluster with:
+
+```console
+$ oc get crd authentications.operator.openshift.io -o yaml
+```
+
+Many OpenShift ClusterOperators share common build, test, deployment, and update methods.    
+For more information about how to build, deploy, test, update, and develop OpenShift ClusterOperators, see      
+[OpenShift ClusterOperator and Operand Developer Document](https://github.com/openshift/enhancements/blob/master/enhancements/operator-dev-doc.md#how-do-i-buildupdateverifyrun-unit-tests)
+
+This section explains how to deploy OpenShift with your test cluster-authentication-operator image:        
+[Testing a ClusterOperator/Operand image in a cluster](https://github.com/openshift/enhancements/blob/master/enhancements/operator-dev-doc.md#how-can-i-test-changes-to-an-openshift-operatoroperandrelease-component)
+
 
 ## Add a basic IdP to test your stuff
 The most common identity provider for demoing and testing is the HTPasswd IdP.


### PR DESCRIPTION
updates Makefile to allow a custom image registry like so:
`make IMAGE_REGISTRY=quay.io/sallyom images`

updates README to link common operator/operand info