### PR TITLE
pkg/operator2/operator_test: Add unit tests for handleVersion

### DIFF
--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -25,6 +25,7 @@ func defaultDeployment(
 	routerSecret *corev1.Secret,
 	proxyConfig *configv1.Proxy,
 	operatorDeployment *appsv1.Deployment,
+	image string,
 	resourceVersions ...string,
 ) *appsv1.Deployment {
 	replicas := int32(2) // TODO configurable?
@@ -115,7 +116,7 @@ func defaultDeployment(
 					ServiceAccountName: "oauth-openshift",
 					Containers: []corev1.Container{
 						{
-							Image:           oauthserverImage,
+							Image:           image,
 							ImagePullPolicy: getImagePullPolicy(operatorDeployment),
 							Name:            "oauth-openshift",
 							Command:         []string{"/bin/bash", "-ec"},

--- a/pkg/operator2/operator_test.go
+++ b/pkg/operator2/operator_test.go
@@ -1,0 +1,346 @@
+package operator2
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"regexp"
+	"sort"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	fakeoauth "github.com/openshift/client-go/oauth/clientset/versioned/fake"
+	"github.com/openshift/library-go/pkg/operator/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestHandleVersion(t *testing.T) {
+	mockRoundTripResponses["https://route.example.com/healthz"] = &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewBuffer(nil)),
+	}
+	mockRoundTripResponses["https://route-will-500.example.com/healthz"] = &http.Response{
+		Status:     "Internal Server Error",
+		StatusCode: http.StatusInternalServerError,
+		Body:       ioutil.NopCloser(bytes.NewBuffer(nil)),
+	}
+
+	for _, testCase := range []struct {
+		name                  string
+		deploymentAvailable   int
+		deploymentUnavailable int
+		deploymentUpdated     int
+		oauthClients          []string
+		routeHost             string
+		conditions            []operatorv1.OperatorCondition
+		versions              map[string]string
+		error                 string
+	}{
+		{
+			name:                  "route: invalid domain; OAuth: happy; deployment: 2 current, available replicas",
+			deploymentAvailable:   2,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     2,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "invalid-domain",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionTrue, Reason: "FailedGet", Message: "failed to GET route: no mock response for https://invalid-domain/healthz"},
+			},
+			error: "^unable to check route health: failed to GET route: no mock response for https://invalid-domain/healthz$",
+		},
+		{
+			name:                  "route: 500; OAuth: happy; deployment: 2 current, available replicas",
+			deploymentAvailable:   2,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     2,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route-will-500.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "RouteNotReady", Message: "route not yet available, /healthz returns 'Internal Server Error'"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: only 1 client; deployment: 2 current, available replicas",
+			deploymentAvailable:   2,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     2,
+			oauthClients:          []string{"openshift-browser-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthClientNotReady", Message: "challenging oauthclient does not exist"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 0 replicas",
+			deploymentAvailable:   0,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     0,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "AsExpected"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+			versions: map[string]string{
+				"oauth-openshift": "operand-version",
+				"operator":        "operator-version",
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 1 unavailable replica",
+			deploymentAvailable:   0,
+			deploymentUnavailable: 1,
+			deploymentUpdated:     0,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 2 unavailable replicas",
+			deploymentAvailable:   0,
+			deploymentUnavailable: 2,
+			deploymentUpdated:     0,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 1 stale, available replica",
+			deploymentAvailable:   1,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     0,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentHasAvailableReplica"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 1 current, available replica",
+			deploymentAvailable:   1,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     1,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "AsExpected"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+			versions: map[string]string{
+				"oauth-openshift": "operand-version",
+				"operator":        "operator-version",
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 1 stale, available replica and 2 unavailable",
+			deploymentAvailable:   1,
+			deploymentUnavailable: 2,
+			deploymentUpdated:     0,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentHasAvailableReplica"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 1 current, available replica and 2 unavailable",
+			deploymentAvailable:   1,
+			deploymentUnavailable: 2,
+			deploymentUpdated:     1,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentHasAvailableReplica"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 1 current, available replica and 1 stale, available replica",
+			deploymentAvailable:   2,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     1,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentHasAvailableReplica"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 2 current, available replicas",
+			deploymentAvailable:   2,
+			deploymentUnavailable: 0,
+			deploymentUpdated:     2,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "AsExpected"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+			versions: map[string]string{
+				"oauth-openshift": "operand-version",
+				"operator":        "operator-version",
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 1 current, available replica, 1 stale, available replica, and 1 unavailable",
+			deploymentAvailable:   2,
+			deploymentUnavailable: 1,
+			deploymentUpdated:     1,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentHasAvailableReplica"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+		{
+			name:                  "route: happy; OAuth: happy; deployment: 2 current, available replicas, 1 stale and 1 unavailable",
+			deploymentAvailable:   2,
+			deploymentUnavailable: 1,
+			deploymentUpdated:     2,
+			oauthClients:          []string{"openshift-browser-client", "openshift-challenging-client"},
+			routeHost:             "route.example.com",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentHasAvailableReplica"},
+				{Type: "OAuthClientsDegraded", Status: operatorv1.ConditionFalse},
+				{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue, Reason: "OAuthServerDeploymentNotReady", Message: "not all deployment replicas are ready"},
+				{Type: "RouteHealthDegraded", Status: operatorv1.ConditionFalse},
+				{Type: "WellKnownEndpointDegraded", Status: operatorv1.ConditionFalse},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			maxUnavailable := intstr.FromInt(1)
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "oauth-openshift",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxUnavailable: &maxUnavailable,
+						},
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            int32(testCase.deploymentAvailable + testCase.deploymentUnavailable),
+					AvailableReplicas:   int32(testCase.deploymentAvailable),
+					UnavailableReplicas: int32(testCase.deploymentUnavailable),
+					UpdatedReplicas:     int32(testCase.deploymentUpdated),
+				},
+			}
+
+			oauthClients := make([]runtime.Object, 0, len(testCase.oauthClients))
+			for _, name := range testCase.oauthClients {
+				oauthClients = append(oauthClients, &oauthv1.OAuthClient{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+				})
+			}
+
+			authOperator := &authOperator{
+				oauthClientClient:  fakeoauth.NewSimpleClientset(oauthClients...).OauthV1().OAuthClients(),
+				versionGetter:      status.NewVersionGetter(),
+				oauthServerVersion: "operand-version",
+				operatorVersion:    "operator-version",
+			}
+			operatorConfig := &operatorv1.Authentication{}
+			authConfig := &configv1.Authentication{}
+			route := &routev1.Route{
+				Spec: routev1.RouteSpec{Host: testCase.routeHost},
+			}
+			routeSecret := &corev1.Secret{}
+			ingress := &configv1.Ingress{}
+			err := authOperator.handleVersion(operatorConfig, authConfig, route, routeSecret, deployment, ingress)
+
+			// normalize the results
+			sort.Sort(ByType(operatorConfig.Status.Conditions))
+			var zeroTime metav1.Time
+			for i := range operatorConfig.Status.Conditions {
+				operatorConfig.Status.Conditions[i].LastTransitionTime = zeroTime
+			}
+
+			assertEqual(t, testCase.conditions, operatorConfig.Status.Conditions, "conditions")
+
+			if testCase.versions == nil {
+				testCase.versions = map[string]string{}
+			}
+			assertEqual(t, testCase.versions, authOperator.versionGetter.GetVersions(), "versions")
+
+			if testCase.error == "" {
+				if err != nil {
+					t.Error(err)
+				}
+			} else if !regexp.MustCompile(testCase.error).MatchString(err.Error()) {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual interface{}, message string) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("%s: expected %#v, got %#v", message, expected, actual)
+	}
+}
+
+// ByType implements sort.Interface for []OperatorCondition based on Type.
+type ByType []operatorv1.OperatorCondition
+
+func (a ByType) Len() int           { return len(a) }
+func (a ByType) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByType) Less(i, j int) bool { return a[i].Type < a[j].Type }


### PR DESCRIPTION
I'm thinking about refactoring handleVersion to distinguish prereq stuff (the ingress route, etc.) from operand stuff (deployment), and unit tests will guard against accidental changes ;).

For folks like me who are unfamiliar with library-go's operator status handling, the prefixed conditions will eventually get collated into conditions with unprefixed names [here][1].

It's still not clear to me what, if anything, clears out stale conditions that don't get explicitly clobbered.  For example, say round 1 ended up like the test with:

    route: happy; OAuth: happy; deployment: 2 current, available replicas

which sets, among other conditions, `OAuthClientsDegraded=False`.  Then route health died and round 2 ended up like the test with:

    route: 500; OAuth: happy; deployment: 2 current, available replicas

which does nothing with `OAuthClientsDegraded`.  Would we still be setting `OAuthClientsDegraded=False` after round 2 despite calling [`setProgressingTrueAndAvailableFalse(operatorConfig, "RouteNotReady", routeMsg)` and bailing][2] before actually looking at the well-known endpoints in round 2?

[The `authConfig.Spec.Type != configv1.AuthenticationTypeIntegratedOAuth` condition][3] bypasses most of the `checkWellknownEndpointsReady` logic, but because that is attempting to load [a hard-coded `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`][4] from the local host, we'd have to make changes to get it reliably testing.

Run with:

```console
$ go test ./pkg/operator2/
```

Or with `make test-unit`.

[1]: https://github.com/openshift/library-go/blob/61ddf5cd7d9cba7ca5c548d5f1b9277f55f887db/pkg/operator/status/condition.go#L14-L78
[2]: https://github.com/openshift/cluster-authentication-operator/blob/3c3b1ed8b5e3de8efa516ab3a9368d75e87ec17c/pkg/operator2/operator.go#L381-L382
[3]: https://github.com/openshift/cluster-authentication-operator/blob/3c3b1ed8b5e3de8efa516ab3a9368d75e87ec17c/pkg/operator2/operator.go#L477-L480
[4]: https://github.com/openshift/cluster-authentication-operator/blob/3c3b1ed8b5e3de8efa516ab3a9368d75e87ec17c/pkg/operator2/operator.go#L483