### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: authentication-operator
   annotations:
     config.openshift.io/inject-proxy: operator
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/08_clusteroperator.yaml
+++ b/manifests/08_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: authentication
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 status:
   versions:
   - name: operator


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See openshift/cluster-version-operator#252