### PR TITLE
Bug 1788135: Fix IPv6 Support

### DIFF
--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -7,3 +7,5 @@ data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig
+    servingInfo:
+      bindNetwork: "tcp"

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -93,7 +93,7 @@ func (c *authOperator) handleOAuthConfig(
 			ServingInfo: configv1.HTTPServingInfo{
 				ServingInfo: configv1.ServingInfo{
 					BindAddress: fmt.Sprintf("0.0.0.0:%d", 6443),
-					BindNetwork: "tcp4",
+					BindNetwork: "tcp",
 					// we have valid serving certs provided by service-ca
 					// this is our main server cert which is used if SNI does not match
 					CertInfo: configv1.CertInfo{

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
 	"reflect"
@@ -557,7 +558,7 @@ func (c *authOperator) getAPIServerIPs() ([]string, error) {
 
 		ips := make([]string, 0, len(subset.Addresses))
 		for _, address := range subset.Addresses {
-			ips = append(ips, fmt.Sprintf("%s:%d", address.IP, targetPort))
+			ips = append(ips, net.JoinHostPort(address.IP, strconv.Itoa(targetPort)))
 		}
 		return ips, nil
 	}


### PR DESCRIPTION
This PR includes the changes necessary to work in a cluster with IPv6 enabled (either IPv6-only or IPv4 and IPv6).

"bindNetwork: tcp" will always do the right thing, based on whether IPv4/IPv6/both are enabled.

One other fix was needed to more carefully join a host and port number together.