### PR TITLE
fix gosum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/stlaz/build-machinery-go v0.0.0-20200211120820-d30356ad1149 h1:smApEEOxzOe796BxueQRAJ9qnNV9GJVBH046Z//lQxE=
-github.com/stlaz/build-machinery-go v0.0.0-20200211120820-d30356ad1149/go.mod h1:9FbED3NvY8MfWzVJYlSZ0pv+JMoWUvhutW4qaMieg3Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=


### PR DESCRIPTION
somehow my private repo got to go.sum, fixing this should hopefully finally make it possible to run verify-deps to prevent this in the future