### PR TITLE
The oauth server should wait until it is out of rotation to shut down

### DIFF
--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: oauth-openshift
     spec:
+      terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift
       nodeSelector:
         node-role.kubernetes.io/master: ''
@@ -102,6 +103,16 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          lifecycle:
+            # delay shutdown by 25s to ensure existing connections are drained
+            # * 5s for endpoint propagation on delete
+            # * 5s for route reload
+            # * 15s for the longest running request to finish
+            preStop:
+              exec:
+                command:
+                - sleep
+                - "25"
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
             requests:

--- a/pkg/operator2/assets/bindata.go
+++ b/pkg/operator2/assets/bindata.go
@@ -64,6 +64,7 @@ spec:
       labels:
         app: oauth-openshift
     spec:
+      terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift
       nodeSelector:
         node-role.kubernetes.io/master: ''
@@ -149,6 +150,16 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          lifecycle:
+            # delay shutdown by 25s to ensure existing connections are drained
+            # * 5s for endpoint propagation on delete
+            # * 5s for route reload
+            # * 15s for the longest running request to finish
+            preStop:
+              exec:
+                command:
+                - sleep
+                - "25"
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
             requests:


### PR DESCRIPTION
When a pod is marked deleted, endpoints are updated instantly and
propagate to load balancers, routers, and nodes. A component that
wishes to remain available during upgrades must wait longer than
the default propagation interval for these changes to avoid having
requests delivered to pods that are shutting down.

Change the oauth server to wait 25s before terminating the serving
process and up to 40s on the node to ensure all front ends have
time to drain. The minimum interval here is how long an average
connection can take behind the router to drain, once new connections
stop getting created. I.e.

    wait = time to propagate endpoints (5s) +
           time for router reload (5s) +
           time for longest request to finish (15s)
         = 25s

This should result in the oauth route not reporting any downtime
during upgrade.

Downtime documented in https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/19447