### PR TITLE
Bug 1809193: Resync auth operator informer every 30 sec to tighten sync loop for .well-known check

### DIFF
--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -74,7 +74,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		informers.WithNamespace("kube-system"),
 	)
 
-	authOperatorConfigInformers := authopinformer.NewSharedInformerFactoryWithOptions(authConfigClient, resync,
+	// short resync period as this drives the check frequency when checking the .well-known endpoint. 20 min is too slow for that.
+	authOperatorConfigInformers := authopinformer.NewSharedInformerFactoryWithOptions(authConfigClient, time.Second*30,
 		authopinformer.WithTweakListOptions(singleNameListOptions("cluster")),
 	)
 


### PR DESCRIPTION
The old resync period was 20 min, far too long to reliably check the .well-known endpoint.