### PR TITLE
Bug 1824800: explicitly set oauth-server container's root file system to writable

### DIFF
--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -62,6 +62,8 @@ spec:
             - name: https
               containerPort: 6443
               protocol: TCP
+          securityContext:
+            readOnlyRootFilesystem: false # because of the `cp` in args
           volumeMounts:
             - name: v4-0-config-system-session
               readOnly: true

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -36,6 +36,8 @@ spec:
           requests:
             memory: 50Mi
             cpu: 10m
+        securityContext:
+          readOnlyRootFilesystem: false # because of the `cp` in args
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator2/assets/bindata.go
+++ b/pkg/operator2/assets/bindata.go
@@ -109,6 +109,8 @@ spec:
             - name: https
               containerPort: 6443
               protocol: TCP
+          securityContext:
+            readOnlyRootFilesystem: false # because of the ` + "`" + `cp` + "`" + ` in args
           volumeMounts:
             - name: v4-0-config-system-session
               readOnly: true


### PR DESCRIPTION
We are doing root write with the copying of the trusted cert bundle
so we unfortunately need the FS to be writable.

The SA running the pod has broad privileges and if there's a more
restrictive SCC with higher priority than what anyuid has, this
would make the container fail to start as it would choose to
default to non-writable root system.