### PR TITLE
Bug 1834852: Add make target to run operator with telepresence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ origin.iml
 tags
 .envrc
 authentication-operator
+telepresence.log

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/deps-gomod.mk \
 	targets/openshift/images.mk \
 	targets/openshift/bindata.mk \
+	targets/openshift/operator/telepresence.mk \
 )
 
 # Run core verification and all self contained tests.
@@ -53,3 +54,11 @@ test-e2e-encryption: GO_TEST_FLAGS += -p 1
 test-e2e-encryption: GO_TEST_FLAGS += -parallel 1
 test-e2e-encryption: test-unit
 .PHONY: test-e2e-encryption
+
+# Configure the 'telepresence' target
+# See vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh for usage and configuration details
+export TP_DEPLOYMENT_YAML ?=./manifests/07_deployment.yaml
+export TP_CMD_PATH ?=./cmd/authentication-operator
+export TP_CMD_ARGS ?=operator --config=/var/run/configmaps/config/operator-config.yaml --v=2 --terminate-on-files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt
+export TP_LOCK_CONFIGMAP ?=cluster-authentication-operator-lock
+export TP_BUILD_FLAGS ?=-tags ocp

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/openshift/api v0.0.0-20200424083944-0422dc17083e
-	github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc
+	github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
 	github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833
 	github.com/spf13/cobra v0.0.5
@@ -23,3 +23,5 @@ require (
 	k8s.io/klog v1.0.0
 	monis.app/go v0.0.0-20190702030534-c65526068664
 )
+
+replace github.com/openshift/build-machinery-go => github.com/marun/build-machinery-go v0.0.0-20200503165909-aca6df7a454a

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/marun/build-machinery-go v0.0.0-20200503165909-aca6df7a454a h1:vif6iiJLDImMMUg8pAVdeyAM4n7QYaVQilAlyje9YGY=
+github.com/marun/build-machinery-go v0.0.0-20200503165909-aca6df7a454a/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -284,10 +286,6 @@ github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5X
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/api v0.0.0-20200424083944-0422dc17083e h1:VDcwVyMEVbLyekLmtob1TEf8GfP454Afc2hO3FkgBps=
 github.com/openshift/api v0.0.0-20200424083944-0422dc17083e/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
-github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160 h1:V4E6yt4XWiBEPKnJbs/E8pgUq9AjZqzQfsL3eeT84Qs=
-github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
-github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc h1:Bu1p7+ItPqhJhmMve7sVluKCYV+o+x1Ede0WY2/BI8Q=
-github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833 h1:glEuGTvwkQJXfCzVfosZ3oq73L8QltO6Xyxo1oTf5Ig=

--- a/vendor/github.com/openshift/build-machinery-go/go.mod
+++ b/vendor/github.com/openshift/build-machinery-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/build-machinery-go
+
+go 1.13

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -6,6 +6,7 @@ clean-binaries
 help
 image-ocp-openshift-apiserver-operator
 images
+telepresence
 test
 test-unit
 update

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
@@ -1,0 +1,12 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+scripts_dir :=$(shell realpath $(self_dir)../../../../scripts)
+
+telepresence:
+	$(info Running operator locally against a remote cluster using telepresence (https://telepresence.io))
+	$(info )
+	$(info To override the operator log level, set TP_VERBOSITY=<log level>)
+	$(info To debug the operator, set TP_DEBUG=y (requires the delve debugger))
+	$(info See the run-telepresence.sh script for more usage and configuration details)
+	$(info )
+	bash $(scripts_dir)/run-telepresence.sh
+.PHONY: telepresence

--- a/vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh
+++ b/vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script executes telepresence against an operator deployment.
+#
+#   KUBECONFIG=... TP_DEPLOYMENT_YAML=... TP_CMD_PATH=... run-telepresence.sh
+#
+# The script is parameterized by env vars prefixed with 'TP_'.
+#
+# Dependencies:
+#
+# - oc
+# - jq (fedora: dnf install jq; macos: brew install jq)
+# - telepresence (https://www.telepresence.io/reference/install)
+#   - >= 0.105 is compatible with OCP
+# - delve (go get github.com/go-delve/delve/cmd/dlv)
+
+KUBECONFIG="${KUBECONFIG:-}"
+if [[ "${KUBECONFIG}" == "" ]]; then
+  >&2 echo "KUBECONFIG is not set"
+  exit 1
+fi
+
+# The yaml defining the operator's deployment resource. Will be parsed
+# for configuration like resource name, namespace, and command.
+TP_DEPLOYMENT_YAML="${TP_DEPLOYMENT_YAML:-}"
+if [[ ! "${TP_DEPLOYMENT_YAML}" ]]; then
+  >&2 echo "TP_DEPLOYMENT_YAML is not set"
+  exit 1
+fi
+
+# The path to the golang package to run or debug
+# (e.g. `/my/project/cmd/operator`)
+TP_CMD_PATH="${TP_CMD_PATH:-}"
+if [[ ! "${TP_CMD_PATH}" ]]; then
+  >&2 echo "TP_CMD_PATH is not set"
+  exit 1
+fi
+
+# By default the operator will be run via 'go run'. Providing TP_DEBUG=y
+# will run `dlv debug` instead.
+TP_DEBUG="${TP_DEBUG:-}"
+
+# Whether to add an entry in /etc/hosts for the api server host. This
+# is necessary if targeting a cluster deployed in aws.
+TP_ADD_AWS_HOST_ENTRY="${TP_ADD_AWS_HOST_ENTRY:-y}"
+
+# The arguments for the command that will be executed will be parsed
+# from the deployment by default, but can be overridden by setting
+# this var. The name of the command itself is implicitly determined by
+# `go run` or `dlv debug` from TP_CMD_PATH.
+TP_CMD_ARGS="${TP_CMD_ARGS:-}"
+
+# Will add a -v=<value> argument to the command to set the logging
+# verbosity. If a verbosity argument was already supplied, this value
+# will override it.
+TP_VERBOSITY="${TP_VERBOSITY:-}"
+
+# The command telepresence should run in the local deployment
+# environment. By default it will run or debug the operator but it can
+# be useful to run a shell (e.g. `bash`) for troubleshooting.
+TP_RUN_CMD="${TP_RUN_CMD:-}"
+if [[ ! "${TP_RUN_CMD}" ]]; then
+  # Default to a recursive call
+  TP_RUN_CMD="${0}"
+  if [[ ! -x "${TP_RUN_CMD}" ]]; then
+    # Prefix the recursive call with bash if the script is not
+    # executable as will be the case when build-machinery-go is
+    # vendored.
+    TP_RUN_CMD="bash ${TP_RUN_CMD}"
+  fi
+fi
+
+# Whether this script should run telepresence or is being run by
+# telepresence. Used as an internal control var, not necessary to set
+# manually.
+_TP_INTERNAL_RUN="${_TP_INTERNAL_RUN:-}"
+
+# Some operators (e.g. auth operator) specify build flags to generate
+# different binaries for ocp or okd.
+TP_BUILD_FLAGS="${TP_BUILD_FLAGS:-}"
+
+# Simplify querying the deployment yaml with jq
+function jq_deployment () {
+  local jq_arg="${1}"
+  cat "${TP_DEPLOYMENT_YAML}"\
+    | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))'\
+    | jq -r "${jq_arg}"
+}
+
+NAMESPACE="$(jq_deployment '.metadata.namespace')"
+NAME="$(jq_deployment '.metadata.name')"
+
+# If not provided, the lock configmap will be defaulted to the name of
+# the deployment suffixed by `-lock`.
+TP_LOCK_CONFIGMAP="${TP_LOCK_CONFIGMAP:-${NAME}-lock}"
+
+if [ "${_TP_INTERNAL_RUN}" ]; then
+  # Delete the leader election lock to ensure that the local process
+  # becomes the leader as quickly as possible.
+  oc delete configmap "${TP_LOCK_CONFIGMAP}" --namespace "${NAMESPACE}" --ignore-not-found=true
+
+  if [[ ! "${TP_CMD_ARGS}" ]]; then
+    # Parse the arguments from the deployment
+    TP_CMD_ARGS="$(jq_deployment '.spec.template.spec.containers[0].command[1:] | join(" ")' )"
+    TP_CMD_ARGS+=" $(jq_deployment '.spec.template.spec.containers[0].args | join(" ")' )"
+  fi
+
+  if [[ "${TP_VERBOSITY}" ]]; then
+    # Setting log level last ensures that any existing -v argument will be overridden.
+    TP_CMD_ARGS+=" -v=${TP_VERBOSITY}"
+  fi
+
+  pushd "${TP_CMD_PATH}" > /dev/null
+    if [[ "${TP_DEBUG}" ]]; then
+      if [[ "${TP_BUILD_FLAGS}" ]]; then
+        TP_BUILD_FLAGS="--build-flags=${TP_BUILD_FLAGS}"
+      fi
+      dlv debug ${TP_BUILD_FLAGS} -- ${TP_CMD_ARGS}
+    else
+      go run ${TP_BUILD_FLAGS} . ${TP_CMD_ARGS}
+    fi
+  popd > /dev/null
+else
+  if [[ "${TP_ADD_AWS_HOST_ENTRY}" ]]; then
+    # Add an entry in /etc/hosts for the api endpoint in the configured
+    # KUBECONFIG (which is assumed to have at most one server).
+    #
+    # This supports using telepresence with kube clusters running in
+    # aws. telepresence will proxy dns requests to the cluster and will
+    # return an internal aws address for the api endpoint otherwise.
+    SERVER_HOST="$(grep server "${KUBECONFIG}" | sed -e 's+    server: https://\(.*\):.*+\1+')"
+    SERVER_IP="$(dig "${SERVER_HOST}" +short | head -n 1)"
+    ENTRY="${SERVER_IP} ${SERVER_HOST}"
+    if ! grep "${ENTRY}" /etc/hosts > /dev/null; then
+      >&2 echo "Attempting to add '${ENTRY}' to /etc/hosts to ensure access to an aws cluster. This requires sudo."
+      >&2 echo "If this cluster is not in aws, specify TP_ADD_AWS_HOST_ENTRY="
+      grep -q "${SERVER_HOST}" /etc/hosts && \
+        (cp -f /etc/hosts /tmp/etc-hosts && \
+           sed -i 's+.*'"${SERVER_HOST}"'$+'"${ENTRY}"'+' /tmp/etc-hosts && \
+           sudo cp /tmp/etc-hosts /etc/hosts)\
+          || echo "${ENTRY}" | sudo tee -a /etc/hosts > /dev/null
+    fi
+  fi
+
+  # Ensure pod volumes are symlinked to the expected location
+  if [[ ! -L '/var/run/configmaps' ]]; then
+     >&2 echo "Attempting to symlink /tmp/tel_root/var/run/configmaps to /var/run/configmaps. This requires sudo."
+     sudo ln -s /tmp/tel_root/var/run/configmaps /var/run/configmaps
+  fi
+  if [[ ! -L '/var/run/secrets' ]]; then
+    >&2 echo "Attempting to symlink /tmp/tel_root/var/run/secrets to /var/run/secrets. This requires sudo."
+    sudo ln -s /tmp/tel_root/var/run/secrets /var/run/secrets
+  fi
+
+  KIND="$(jq_deployment '.kind')"
+  GROUP="$(jq_deployment '.apiVersion')"
+
+  # Ensure the operator is not managed by CVO
+  oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
+spec:
+  overrides:
+  - group: ${GROUP}
+    kind: ${KIND}
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    unmanaged: true
+EOF
+)"
+
+  # Ensure the operator is managed again on shutdown
+  function cleanup {
+    oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
+spec:
+  overrides:
+  - group: ${GROUP}
+    kind: ${KIND}
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    unmanaged: false
+EOF
+)"
+  }
+  trap cleanup EXIT
+
+  # Ensure that traffic for all machines in the cluster is also
+  # proxied so that the local operator will be able to access them.
+  ALSO_PROXY="$(oc get machines -A -o json | jq -jr '.items[] | .status.addresses[0].address | @text "--also-proxy=\(.) "')"
+
+  TELEPRESENCE_USE_OCP_IMAGE=NO _TP_INTERNAL_RUN=y telepresence --namespace="${NAMESPACE}"\
+    --swap-deployment "${NAME}" ${ALSO_PROXY} --mount=/tmp/tel_root --run ${TP_RUN_CMD}
+fi

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,7 +136,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc
+# github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131 => github.com/marun/build-machinery-go v0.0.0-20200503165909-aca6df7a454a
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib


### PR DESCRIPTION
**NOTE** https://github.com/openshift/build-machinery-go/pull/14 needs to merge before this PR.

Once telepresence has been installed (see the run-telepresence.sh script for instructions), `make telepresence` will replace the operator's pod with a local process that has access to the same environment as the pod. This can speed up development since iteration doesn't require cycles of image build/push/pull. See https://telepresence.io for more details.