### PR TITLE
[4.3] Bug 1842465: explicitly set operator's and operand's  container's root file system…

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -36,6 +36,8 @@ spec:
           requests:
             memory: 50Mi
             cpu: 10m
+        securityContext:
+          readOnlyRootFilesystem: false # because of the `cp` in args
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator2/deployment.go
+++ b/pkg/operator2/deployment.go
@@ -29,6 +29,7 @@ func defaultDeployment(
 ) *appsv1.Deployment {
 	replicas := int32(2) // TODO configurable?
 	tolerationSeconds := int64(120)
+	readOnlyFileSystem := false
 
 	var (
 		volumes []corev1.Volume
@@ -135,6 +136,9 @@ exec oauth-server osinserver --config=%s --v=%d
 									Protocol:      corev1.ProtocolTCP,
 									ContainerPort: 6443,
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: &readOnlyFileSystem, // false because of the `cp` in args
 							},
 							VolumeMounts:   mounts,
 							Env:            proxyConfigToEnvVars(proxyConfig),


### PR DESCRIPTION
… to writable

We are doing root write with the copying of the trusted cert bundle
so we unfortunately need the FS to be writable.

The SA running the pod has broad privileges and if there's a more
restrictive SCC with higher priority than what anyuid has, this
would make the container fail to start as it would choose to
default to non-writable root system.