### PR TITLE
router-secrets: set named certificates to empty array instead of nil when none found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 #   make test-e2e
 test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
 test-e2e: GO_TEST_FLAGS += -v
+test-e2e: GO_TEST_FLAGS += -count 1
 test-e2e: test-unit
 .PHONY: test-e2e
 

--- a/pkg/operator2/configobservation/routersecret/observe_router_secret.go
+++ b/pkg/operator2/configobservation/routersecret/observe_router_secret.go
@@ -32,7 +32,7 @@ func ObserveRouterSecret(genericlisters configobserver.Listers, recorder events.
 	}
 
 	observedConfig := map[string]interface{}{}
-	if err := unstructured.SetNestedField(
+	if err := unstructured.SetNestedSlice(
 		observedConfig,
 		observedNamedCertificates,
 		namedCertificatesPath...,
@@ -54,7 +54,7 @@ func ObserveRouterSecret(genericlisters configobserver.Listers, recorder events.
 }
 
 func routerSecretToSNI(routerSecret *corev1.Secret) ([]interface{}, error) {
-	var certs []interface{}
+	certs := []interface{}{}
 	// make sure the output slice of named certs is sorted by domain so that the generated config is deterministic
 	for _, domain := range sets.StringKeySet(routerSecret.Data).List() {
 		certs = append(certs, map[string]interface{}{


### PR DESCRIPTION
This fixed a small-ish bug in the router-secrets observer:

when running the repository-local e2e test, one could observe the following:
```
E0605 10:01:58.163141       1 base_controller.go:180] "ConfigObserver" controller failed to sync "key", err: .servingInfo.namedCertificates accessor error: <nil> is of the type <nil>, expected []interface{}
I0605 10:01:58.164534       1 event.go:278] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-authentication-operator", Name:"authentication-operator", UID:"b7da59af-4c37-4be6-b870-c4810f2cd833", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ObservedConfigChanged' Writing updated observed config:   map[string]interface{}{
        "oauthServer": map[string]interface{}{
                "corsAllowedOrigins": []interface{}{string(`//127\.0\.0\.1(:|$)`), string("//localhost(:|$)")},
                "oauthConfig":        map[string]interface{}{"assetPublicURL": string("https://console-openshift-console.apps.sl-bn.group-b.devcluster.openshift.com"), "loginURL": string("https://api.sl-bn.group-b.devcluster.openshift.com:6443")},
                "servingInfo": map[string]interface{}{
                        "cipherSuites":      []interface{}{string("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"), string("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"), string("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"), string("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"), string("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"), string("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305")},
                        "minTLSVersion":     string("VersionTLS12"),
-                       "namedCertificates": nil,
+                       "namedCertificates": []interface{}(nil),
                },
        },
  }
```