### PR TITLE
pkg/operator2/operator: Check client and deployment operands each time

### DIFF
--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -407,7 +407,7 @@ func (c *authOperator) handleVersion(
 		return nil
 	}
 
-	oauthClientsReady, oauthClientsMsg, err := c.oauthClientsReady(ctx, route)
+	oauthClientsReady, oauthClientsMsg, err := c.oauthClientsReady(ctx)
 	conditions.handleDegraded("OAuthClients", err)
 	if err != nil {
 		return fmt.Errorf("unable to check OAuth clients' readiness: %v", err)
@@ -609,7 +609,7 @@ func (c *authOperator) checkWellknownEndpointReady(apiIP string, rt http.RoundTr
 	return true, "", nil
 }
 
-func (c *authOperator) oauthClientsReady(ctx context.Context, route *routev1.Route) (bool, string, error) {
+func (c *authOperator) oauthClientsReady(ctx context.Context) (bool, string, error) {
 	_, err := c.oauthClientClient.Get(ctx, "openshift-browser-client", metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Builds on #289; you may want to review that first.

Before this commit, the auth operator checked a few operands sequentially. That means that an earlier error like `RouteHealthDegraded` would leave later operands unchecked (e.g. still reporting `ProgressingOAuthServerDeploymentNotReady` despite the deployment being ready).  This commit pivots to checking each operand each time, with the one exception being that we still skip the well-known endpoint check if the route is not ready, because a ready-route is a prerequisite for a ready well-known endpoint.  The clients and deployment, on the other hand, do not depend on a healthy route or ready well-known endpoint.

I'm also pushing the `oauth-openshift` version setting down into `checkDeploymentReady`, because we can level that as soon as the deployment is ready, without blocking on the other operands.

Setting the operator version, clearing `Progressing`, and ensuring `Available=True` still require all operands to be ready, just as they did before this commit.