### PR TITLE
Use config observer from library-go

### DIFF
--- a/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
+	configobserveroauth "github.com/openshift/library-go/pkg/operator/configobserver/oauth"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -68,6 +69,7 @@ func NewConfigObserver(
 		oauth.ObserveIdentityProviders,
 		oauth.ObserveTemplates,
 		oauth.ObserveTokenConfig,
+		configobserveroauth.ObserveAccessTokenInactivityTimeout,
 		routersecret.ObserveRouterSecret,
 	} {
 		oauthServerObservers = append(oauthServerObservers,
@@ -84,7 +86,7 @@ func NewConfigObserver(
 			APIServerLister_:     configInformer.Config().V1().APIServers().Lister(),
 			ConsoleLister:        configInformer.Config().V1().Consoles().Lister(),
 			InfrastructureLister: configInformer.Config().V1().Infrastructures().Lister(),
-			OAuthLister:          configInformer.Config().V1().OAuths().Lister(),
+			OAuthLister_:         configInformer.Config().V1().OAuths().Lister(),
 			ResourceSync:         resourceSyncer,
 			PreRunCachesSynced:   preRunCacheSynced,
 		},

--- a/pkg/controllers/configobservation/interfaces.go
+++ b/pkg/controllers/configobservation/interfaces.go
@@ -22,7 +22,7 @@ type Listers struct {
 	APIServerLister_     configlistersv1.APIServerLister
 	ConsoleLister        configlistersv1.ConsoleLister
 	InfrastructureLister configlistersv1.InfrastructureLister
-	OAuthLister          configlistersv1.OAuthLister
+	OAuthLister_         configlistersv1.OAuthLister
 
 	ResourceSync       resourcesynccontroller.ResourceSyncer
 	PreRunCachesSynced []cache.InformerSynced
@@ -34,6 +34,10 @@ func (l Listers) APIServerLister() configlistersv1.APIServerLister {
 
 func (l Listers) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
 	return l.ResourceSync
+}
+
+func (l Listers) OAuthLister() configlistersv1.OAuthLister {
+	return l.OAuthLister_
 }
 
 func (l Listers) PreRunHasSynced() []cache.InformerSynced {

--- a/pkg/controllers/configobservation/oauth/observe_idps.go
+++ b/pkg/controllers/configobservation/oauth/observe_idps.go
@@ -41,7 +41,7 @@ func ObserveIdentityProviders(genericlisters configobserver.Listers, recorder ev
 		return existingConfig, append(errs, err)
 	}
 
-	oauthConfig, err := listers.OAuthLister.Get("cluster")
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
 	if errors.IsNotFound(err) {
 		// revert to default state, meaning no IdPs
 		klog.Warning("oauth.config.openshift.io/cluster: not found")

--- a/pkg/controllers/configobservation/oauth/observe_idps_test.go
+++ b/pkg/controllers/configobservation/oauth/observe_idps_test.go
@@ -195,7 +195,7 @@ func TestObserveIdentityProviders(t *testing.T) {
 			listers := configobservation.Listers{
 				ConfigMapLister: corelistersv1.NewConfigMapLister(indexer),
 				SecretsLister:   corelistersv1.NewSecretLister(indexer),
-				OAuthLister:     configlistersv1.NewOAuthLister(indexer),
+				OAuthLister_:    configlistersv1.NewOAuthLister(indexer),
 				ResourceSync:    &mockResourceSyncer{t: t, synced: syncerData},
 			}
 			eventsRecorder := events.NewInMemoryRecorder(t.Name())

--- a/pkg/controllers/configobservation/oauth/observe_templates.go
+++ b/pkg/controllers/configobservation/oauth/observe_templates.go
@@ -33,7 +33,7 @@ func ObserveTemplates(genericlisters configobserver.Listers, recorder events.Rec
 	}
 
 	observedConfig := map[string]interface{}{}
-	oauthConfig, err := listers.OAuthLister.Get("cluster")
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
 	if errors.IsNotFound(err) {
 		// use the defauls for the platform set by `convertTemplatesWithBranding`
 		oauthConfig = &configv1.OAuth{}

--- a/pkg/controllers/configobservation/oauth/observe_templates_test.go
+++ b/pkg/controllers/configobservation/oauth/observe_templates_test.go
@@ -83,7 +83,7 @@ func TestObserveTemplates(t *testing.T) {
 			}
 			syncerData := map[string]string{}
 			listers := configobservation.Listers{
-				OAuthLister:     configlistersv1.NewOAuthLister(indexer),
+				OAuthLister_:    configlistersv1.NewOAuthLister(indexer),
 				ConfigMapLister: corelistersv1.NewConfigMapLister(indexer),
 				ResourceSync:    &mockResourceSyncer{t: t, synced: syncerData},
 			}

--- a/pkg/controllers/configobservation/oauth/observe_tokenconfig_test.go
+++ b/pkg/controllers/configobservation/oauth/observe_tokenconfig_test.go
@@ -61,14 +61,14 @@ func TestObserveTokenConfig(t *testing.T) {
 			errors: []error{},
 		},
 		{
-			name: "inactivity 0 means disabled",
+			name: "max age configured to non-default value",
 			config: &configv1.OAuth{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",
 				},
 				Spec: configv1.OAuthSpec{
 					TokenConfig: configv1.TokenConfig{
-						AccessTokenMaxAgeSeconds: 0,
+						AccessTokenMaxAgeSeconds: 172800,
 					},
 				},
 			},
@@ -76,57 +76,8 @@ func TestObserveTokenConfig(t *testing.T) {
 			expected: map[string]interface{}{
 				"oauthConfig": map[string]interface{}{
 					"tokenConfig": map[string]interface{}{
-						"accessTokenMaxAgeSeconds":    float64(86400),
+						"accessTokenMaxAgeSeconds":    float64(172800),
 						"authorizeTokenMaxAgeSeconds": float64(300),
-					},
-				},
-			},
-			errors: []error{},
-		},
-		{
-			name: "both fields configured",
-			config: &configv1.OAuth{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: configv1.OAuthSpec{
-					TokenConfig: configv1.TokenConfig{
-						AccessTokenMaxAgeSeconds:            172800,
-						AccessTokenInactivityTimeoutSeconds: 300,
-					},
-				},
-			},
-			previouslyObservedConfig: map[string]interface{}{},
-			expected: map[string]interface{}{
-				"oauthConfig": map[string]interface{}{
-					"tokenConfig": map[string]interface{}{
-						"accessTokenInactivityTimeoutSeconds": float64(300),
-						"accessTokenMaxAgeSeconds":            float64(172800),
-						"authorizeTokenMaxAgeSeconds":         float64(300),
-					},
-				},
-			},
-			errors: []error{},
-		},
-		{
-			name: "inactivitity enabled but only honored on oauthclients that set it",
-			config: &configv1.OAuth{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: configv1.OAuthSpec{
-					TokenConfig: configv1.TokenConfig{
-						AccessTokenInactivityTimeoutSeconds: -1,
-					},
-				},
-			},
-			previouslyObservedConfig: map[string]interface{}{},
-			expected: map[string]interface{}{
-				"oauthConfig": map[string]interface{}{
-					"tokenConfig": map[string]interface{}{
-						"accessTokenInactivityTimeoutSeconds": float64(0),
-						"accessTokenMaxAgeSeconds":            float64(86400),
-						"authorizeTokenMaxAgeSeconds":         float64(300),
 					},
 				},
 			},
@@ -165,7 +116,7 @@ func TestObserveTokenConfig(t *testing.T) {
 				}
 			}
 			listers := configobservation.Listers{
-				OAuthLister: configlistersv1.NewOAuthLister(indexer),
+				OAuthLister_: configlistersv1.NewOAuthLister(indexer),
 			}
 			got, errs := ObserveTokenConfig(listers, events.NewInMemoryRecorder(t.Name()), tt.previouslyObservedConfig)
 			if len(errs) > 0 {

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/oauth/observe_tokenconfig.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/oauth/observe_tokenconfig.go
@@ -1,0 +1,129 @@
+package oauth
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// OAuthLister lists OAuth information
+type OAuthLister interface {
+	OAuthLister() configlistersv1.OAuthLister
+}
+
+const (
+	defaultAccessTokenMaxAgeSeconds   = float64(86400) // a day
+	fieldAccessTokenMaxAgeSeconds     = "accessTokenMaxAgeSeconds"
+	fieldAccessTokenInactivityTimeout = "accessTokenInactivityTimeout"
+)
+
+// ObserveAccessTokenMaxAgeSeconds returns an unstructured fragment of KubeAPIServerConfig that changes the default value for access token max age,
+// if there is a valid value for it in OAuth cluster config.
+func ObserveAccessTokenMaxAgeSeconds(genericlisters configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+	errs = []error{}
+	tokenConfigPath := []string{"oauthConfig", "tokenConfig"}
+	tokenMaxAgePath := append(tokenConfigPath, fieldAccessTokenMaxAgeSeconds)
+	defer func() {
+		// Prune the observed config so that it only contains access token max age field.
+		ret = configobserver.Pruned(ret, tokenMaxAgePath)
+	}()
+
+	listers, ok := genericlisters.(OAuthLister)
+	if !ok {
+		return existingConfig, append(errs, fmt.Errorf("failed to assert: given lister does not implement an OAuth lister"))
+	}
+
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
+	if err != nil {
+		// Failed to read OAuth cluster config.
+		if errors.IsNotFound(err) {
+			klog.Warning("oauth.config.openshift.io/cluster: not found")
+		}
+		// return whatever is present in existing config.
+		return existingConfig, append(errs, err)
+	}
+
+	observedAccessTokenMaxAgeSeconds := float64(oauthConfig.Spec.TokenConfig.AccessTokenMaxAgeSeconds)
+	if observedAccessTokenMaxAgeSeconds == 0 {
+		// As the value 0 indicates that this field is not set or missing in OAuth cluster config, use the default value.
+		observedAccessTokenMaxAgeSeconds = defaultAccessTokenMaxAgeSeconds
+	}
+
+	existingAccessTokenMaxAgeSeconds, _, err := unstructured.NestedFloat64(existingConfig, tokenMaxAgePath...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if existingAccessTokenMaxAgeSeconds != observedAccessTokenMaxAgeSeconds {
+		recorder.Eventf("ObserveAccessTokenMaxAgeSeconds", "%s changed from %d to %d", fieldAccessTokenMaxAgeSeconds,
+			existingAccessTokenMaxAgeSeconds,
+			observedAccessTokenMaxAgeSeconds)
+	}
+
+	return buildUnstructuredTokenConfig(observedAccessTokenMaxAgeSeconds, tokenMaxAgePath), errs
+}
+
+// ObserveAccessTokenInactivityTimeout returns an unstructured fragment of KubeAPIServerConfig that has access token inactivity timeout,
+// if there is a valid value for it in OAuth cluster config.
+func ObserveAccessTokenInactivityTimeout(genericlisters configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+	errs = []error{}
+	tokenConfigPath := []string{"oauthConfig", "tokenConfig"}
+	tokenInactivityTimeoutPath := append(tokenConfigPath, fieldAccessTokenInactivityTimeout)
+	defer func() {
+		// Prune the observed config so that it only contains access token inactivity timeout field.
+		ret = configobserver.Pruned(ret, tokenInactivityTimeoutPath)
+	}()
+
+	listers, ok := genericlisters.(OAuthLister)
+	if !ok {
+		return existingConfig, append(errs, fmt.Errorf("failed to assert: given lister does not implement OAuth lister"))
+	}
+
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
+	if err != nil {
+		// Failed to read OAuth cluster config.
+		if errors.IsNotFound(err) {
+			klog.Warning("oauth.config.openshift.io/cluster: not found")
+		}
+		// Return whatever is present in existing config
+		return existingConfig, append(errs, err)
+	}
+
+	existingAccessTokenInactivityTimeout, _, err := unstructured.NestedString(existingConfig, tokenInactivityTimeoutPath...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	observedConfig := map[string]interface{}{}
+	observedAccessTokenInactivityTimeout := ""
+	if oauthConfig.Spec.TokenConfig.AccessTokenInactivityTimeout != nil {
+		observedAccessTokenInactivityTimeout = oauthConfig.Spec.TokenConfig.AccessTokenInactivityTimeout.Duration.String()
+		observedConfig = buildUnstructuredTokenConfig(observedAccessTokenInactivityTimeout, tokenInactivityTimeoutPath)
+	}
+
+	if existingAccessTokenInactivityTimeout != observedAccessTokenInactivityTimeout {
+		recorder.Eventf("ObserveAccessTokenInactivityTimeout", "%s changed from %v to %v", fieldAccessTokenInactivityTimeout,
+			existingAccessTokenInactivityTimeout,
+			observedAccessTokenInactivityTimeout)
+	}
+
+	return observedConfig, errs
+}
+
+func buildUnstructuredTokenConfig(val interface{}, fields []string) map[string]interface{} {
+	unstructuredConfig := map[string]interface{}{}
+
+	if err := unstructured.SetNestedField(unstructuredConfig, val, fields...); err != nil {
+		// SetNestedField can return an error if one of the nesting level is not map[string]interface{}.
+		// As unstructuredConfig is empty, this error must never happen.
+		klog.Warningf("failed to write unstructured config for fields %v: %v", fields, err)
+	}
+
+	return unstructuredConfig
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -221,6 +221,7 @@ github.com/openshift/library-go/pkg/operator/condition
 github.com/openshift/library-go/pkg/operator/configobserver
 github.com/openshift/library-go/pkg/operator/configobserver/apiserver
 github.com/openshift/library-go/pkg/operator/configobserver/etcd
+github.com/openshift/library-go/pkg/operator/configobserver/oauth
 github.com/openshift/library-go/pkg/operator/encryption
 github.com/openshift/library-go/pkg/operator/encryption/controllers
 github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators


### PR DESCRIPTION
Bumps openshift/api and openshift/library-go and reuses config observer from https://github.com/openshift/library-go/pull/816