### PR TITLE
Bug 1853278: observe console-config config map without using a resource sync controller.

### DIFF
--- a/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
@@ -28,6 +28,7 @@ func NewConfigObserver(
 	interestingNamespaces := []string{
 		"openshift-authentication",
 		"openshift-config",
+		"openshift-config-managed",
 	}
 
 	preRunCacheSynced := []cache.InformerSynced{

--- a/pkg/controllers/configobservation/oauth/template_conversions.go
+++ b/pkg/controllers/configobservation/oauth/template_conversions.go
@@ -82,7 +82,7 @@ func convertTemplatesWithBranding(cmLister corelistersv1.ConfigMapLister, config
 }
 
 func getConsoleBranding(cmLister corelistersv1.ConfigMapLister) (string, error) {
-	cm, err := cmLister.ConfigMaps("openshift-authentication").Get("v4-0-config-system-console-config")
+	cm, err := cmLister.ConfigMaps("openshift-config-managed").Get("console-config")
 	if errors.IsNotFound(err) {
 		return "", nil
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -76,9 +76,10 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	}
 
 	kubeInformersNamespaced := v1helpers.NewKubeInformersForNamespaces(kubeClient,
+		"kube-system",
 		"openshift-authentication",
 		"openshift-config",
-		"kube-system",
+		"openshift-config-managed",
 	)
 
 	// short resync period as this drives the check frequency when checking the .well-known endpoint. 20 min is too slow for that.
@@ -151,14 +152,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err := resourceSyncer.SyncSecret(
 		resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-system-router-certs"},
 		resourcesynccontroller.ResourceLocation{Namespace: "openshift-config-managed", Name: "router-certs"},
-	); err != nil {
-		return err
-	}
-
-	// add syncing for the console-config ConfigMap (indirect watch for changes)
-	if err := resourceSyncer.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-system-console-config"},
-		resourcesynccontroller.ResourceLocation{Namespace: "openshift-config-managed", Name: "console-config"},
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
As `v4-0-config-system-console-config` config map is not mounted in oauth-server pod, maybe using a resource sync controller to synchronize with `console-config` config map from `openshift-config-managed` is not fully beneficial. Instead, the observer could directly watch for any changes in `console-config`. This would reduce the number of `DELETE` requests made to kube-apiserver.