### PR TITLE
follow up changes to clean up endpoint accessible controller

### DIFF
--- a/pkg/controllers/common/route.go
+++ b/pkg/controllers/common/route.go
@@ -1,129 +1,15 @@
 package common
 
 import (
-	"bytes"
-	"crypto/x509"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 
-	"github.com/davecgh/go-spew/spew"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
-
-	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	routev1lister "github.com/openshift/client-go/route/listers/route/v1"
 
-	"github.com/openshift/cluster-authentication-operator/pkg/transport"
+	corev1 "k8s.io/api/core/v1"
 )
-
-func CheckRouteHealthy(route *routev1.Route, routerSecret *corev1.Secret, systemCABundle []byte, ingress *configv1.Ingress, conditionPrefix string) []operatorv1.OperatorCondition {
-	if !RouteHasCanonicalHost(route, route.Spec.Host) {
-		msg := spew.Sdump(route.Status.Ingress)
-		if len(route.Status.Ingress) == 0 {
-			msg = "route status ingress is empty"
-		}
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    conditionPrefix + "Progressing",
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "WaitingForRoute",
-				Message: fmt.Sprintf("Route %q was not admitted yet", route.Name),
-			},
-			{
-				Type:    conditionPrefix + "Available",
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "RouteNotReady",
-				Message: fmt.Sprintf("Route is not available at canonical host %s: %+v", route.Spec.Host, msg),
-			},
-		}
-	}
-	caData := routerSecretToCA(route, routerSecret, ingress)
-
-	// if systemCABundle is not empty, append the new line to the caData
-	if len(systemCABundle) > 0 {
-		caData = append(bytes.TrimSpace(caData), []byte("\n")...)
-	}
-
-	rt, err := transport.TransportFor("", append(caData, systemCABundle...), nil, nil)
-	if err != nil {
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    conditionPrefix + "Progressing",
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "WaitingForRoute",
-				Message: fmt.Sprintf("Transport not ready yet to check route %s", route.Name),
-			},
-			{
-				Type:    conditionPrefix + "Available",
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "TransportFailed",
-				Message: fmt.Sprintf("Failed to build transport for route %s: %v (caData=%d)", route.Name, err, len(caData)),
-			},
-		}
-	}
-
-	req, err := http.NewRequest(http.MethodHead, "https://"+route.Spec.Host+"/healthz", nil)
-	if err != nil {
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    conditionPrefix + "Progressing",
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "WaitingForRoute",
-				Message: fmt.Sprintf("Making HTTP request to %q not successfull yet", "https://"+route.Spec.Host+"/healthz"),
-			},
-			{
-				Type:    conditionPrefix + "Available",
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "RequestFailed",
-				Message: fmt.Sprintf("Failed to construct HTTP request to %q: %v", "https://"+route.Spec.Host+"/healthz", err),
-			},
-		}
-	}
-
-	resp, err := rt.RoundTrip(req)
-	if err != nil {
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    conditionPrefix + "Progressing",
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "WaitingForRoute",
-				Message: fmt.Sprintf("Request to %q not successfull yet", "https://"+route.Spec.Host+"/healthz"),
-			},
-			{
-				Type:    conditionPrefix + "Available",
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "RequestFailed",
-				Message: fmt.Sprintf("HTTP request to %q failed: %v", "https://"+route.Spec.Host+"/healthz", err),
-			},
-		}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
-		klog.V(4).Infof("Route check failed with %q:\n%s\n", resp.Status, string(bodyBytes))
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    conditionPrefix + "Progressing",
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "WaitingForRoute",
-				Message: fmt.Sprintf("Request to %q have not returned 200 (HTTP_OK) yet", "https://"+route.Spec.Host+"/healthz"),
-			},
-			{
-				Type:    conditionPrefix + "Available",
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "RequestFailed",
-				Message: fmt.Sprintf("HTTP request to %q returned %q instead of 200", "https://"+route.Spec.Host+"/healthz", resp.Status),
-			},
-		}
-	}
-
-	return nil
-}
 
 func GetOAuthServerRoute(routeLister routev1lister.RouteLister, conditionPrefix string) (*routev1.Route, []operatorv1.OperatorCondition) {
 	route, err := routeLister.Routes("openshift-authentication").Get("oauth-openshift")
@@ -160,29 +46,4 @@ func RouteHasCanonicalHost(route *routev1.Route, canonicalHost string) bool {
 		}
 	}
 	return false
-}
-
-func routerSecretToCA(route *routev1.Route, routerSecret *corev1.Secret, ingress *configv1.Ingress) []byte {
-	var caData []byte
-
-	// find the domain that matches our route
-	if certs, ok := routerSecret.Data[ingress.Spec.Domain]; ok {
-		caData = certs
-	}
-
-	// if we have no CA, use system roots (or more correctly, if we have no CERTIFICATE block)
-	// TODO so this branch is effectively never taken, because the value of caData
-	// is the concatenation of tls.crt and tls.key - the .crt data gets parsed
-	// as a valid cert by AppendCertsFromPEM meaning ok is always true.
-	// because Go is weird with how it validates TLS connections, having the actual
-	// peer cert loaded in the transport is totally fine with the connection even
-	// without having the CA loaded.  this is weird but it lets us tolerate scenarios
-	// where we do not have the CA (i.e. admin is using a cert from an internal company CA).
-	// thus the only way we take this branch is if len(caData) == 0
-	if ok := x509.NewCertPool().AppendCertsFromPEM(caData); !ok {
-		klog.Infof("using global CAs for %s, ingress domain=%s, cert data len=%d", route.Spec.Host, ingress.Spec.Domain, len(caData))
-		return nil
-	}
-
-	return caData
 }

--- a/pkg/controllers/ingressstate/ingress_state_controller_test.go
+++ b/pkg/controllers/ingressstate/ingress_state_controller_test.go
@@ -2,7 +2,6 @@ package ingressstate
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -89,20 +88,6 @@ func TestCheckAddresses(t *testing.T) {
 		unhealthyPods      []string
 		conditionCount     int
 	}{
-		"Healthy with 1 unhealthy endpoint": {
-			addresses: []corev1.EndpointAddress{
-				{IP: "127.0.0.1"},
-			},
-			unhealthyEndpoints: []string{"127.0.0.1"},
-		},
-		"Degraded with 2 unhealthy endpoints": {
-			addresses: []corev1.EndpointAddress{
-				{IP: "127.0.0.1"},
-				{IP: "127.0.0.2"},
-			},
-			unhealthyEndpoints: []string{"127.0.0.1", "127.0.0.2"},
-			conditionCount:     1,
-		},
 		"Healthy with 1 unhealthy pod": {
 			addresses: []corev1.EndpointAddress{
 				{
@@ -112,7 +97,8 @@ func TestCheckAddresses(t *testing.T) {
 					},
 				},
 			},
-			unhealthyPods: []string{"foo"},
+			unhealthyPods:  []string{"foo"},
+			conditionCount: 1,
 		},
 		"Degraded with 2 unhealthy pods": {
 			addresses: []corev1.EndpointAddress{
@@ -135,7 +121,6 @@ func TestCheckAddresses(t *testing.T) {
 	}
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			unhealthyEndpoints := sets.NewString(tc.unhealthyEndpoints...)
 			unhealthyPods := sets.NewString(tc.unhealthyPods...)
 			conditions := checkAddresses(
 				context.TODO(),
@@ -143,12 +128,6 @@ func TestCheckAddresses(t *testing.T) {
 				func(_ context.Context, reference *corev1.ObjectReference) []string {
 					if unhealthyPods.Has(reference.Name) {
 						return []string{"unhealthy"}
-					}
-					return nil
-				},
-				func(endpointIP string) error {
-					if unhealthyEndpoints.Has(endpointIP) {
-						return fmt.Errorf("unhealthy")
 					}
 					return nil
 				},

--- a/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
+++ b/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
@@ -1,14 +1,9 @@
-package endpointaccessible
+package oauthendpoints
 
 import (
-	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
-	"net/http"
 	"strconv"
-	"sync"
-	"time"
 
 	routev1informers "github.com/openshift/client-go/route/informers/externalversions/route/v1"
 	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
@@ -16,7 +11,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"github.com/openshift/cluster-authentication-operator/pkg/libs/endpointaccessible"
+
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
@@ -33,7 +29,7 @@ func NewOAuthRouteCheckController(
 		return listOAuthRoutes(routeLister, recorder)
 	}
 
-	return NewEndpointAccessibleController(
+	return endpointaccessible.NewEndpointAccessibleController(
 		"OAuthRouteCheck",
 		operatorClient, endpointListFunc, []factory.Informer{routeInformer}, recorder)
 }
@@ -50,7 +46,7 @@ func NewOAuthServiceCheckController(
 		return listOAuthServices(serviceLister, recorder)
 	}
 
-	return NewEndpointAccessibleController(
+	return endpointaccessible.NewEndpointAccessibleController(
 		"OAuthServiceCheck",
 		operatorClient, endpointsListFunc, []factory.Informer{serviceInformer}, recorder)
 }
@@ -69,7 +65,7 @@ func NewOAuthServiceEndpointsCheckController(
 		return listOAuthServiceEndpoints(endpointsLister, recorder)
 	}
 
-	return NewEndpointAccessibleController(
+	return endpointaccessible.NewEndpointAccessibleController(
 		"OAuthServiceEndpointsCheck",
 		operatorClient, endpointsListFn, []factory.Informer{endpointsInformer}, recorder)
 }
@@ -127,92 +123,6 @@ func listOAuthRoutes(routeLister routev1listers.RouteLister, recorder events.Rec
 		return nil, fmt.Errorf("route status does not have host address")
 	}
 	return toHealthzURL(results), nil
-}
-
-type endpointAccessibleController struct {
-	operatorClient v1helpers.OperatorClient
-	endpointListFn EndpointListFunc
-}
-
-type EndpointListFunc func() ([]string, error)
-
-// NewEndpointAccessibleController returns a controller that checks if the endpoints
-// listed by endpointListFn are reachable
-func NewEndpointAccessibleController(
-	name string,
-	operatorClient v1helpers.OperatorClient,
-	endpointListFn EndpointListFunc,
-	triggers []factory.Informer,
-	recorder events.Recorder,
-) factory.Controller {
-	c := &endpointAccessibleController{
-		operatorClient: operatorClient,
-		endpointListFn: endpointListFn,
-	}
-
-	return factory.New().
-		WithInformers(triggers...).
-		WithInformers(operatorClient.Informer()).
-		WithSync(c.sync).
-		ResyncEvery(30*time.Second).
-		WithSyncDegradedOnError(operatorClient).
-		ToController(name+"EndpointAccessibleController", recorder.WithComponentSuffix(name+"endpoint-accessible-controller"))
-}
-
-func (c *endpointAccessibleController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	endpoints, err := c.endpointListFn()
-	if err != nil {
-		return err
-	}
-
-	// check all the endpoints in parallel.  This matters for pods.
-	errCh := make(chan error, len(endpoints))
-	wg := sync.WaitGroup{}
-	for _, endpoint := range endpoints {
-		wg.Add(1)
-		go func(endpoint string) {
-			defer wg.Done()
-
-			req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second) // avoid waiting forever
-			defer cancel()
-			req.WithContext(reqCtx)
-
-			// we don't really care  if anyone lies to us. We aren't sending important data.
-			client := &http.Client{
-				Timeout: 5 * time.Second,
-				Transport: &http.Transport{
-					Proxy: http.ProxyFromEnvironment,
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					},
-				},
-			}
-
-			resp, err := client.Do(req)
-			if err != nil {
-				errCh <- err
-				return
-			}
-
-			if resp.StatusCode > 299 || resp.StatusCode < 200 {
-				errCh <- fmt.Errorf("%q returned %q", endpoint, resp.Status)
-			}
-		}(endpoint)
-	}
-	wg.Wait()
-	close(errCh)
-
-	var errors []error
-	for err := range errCh {
-		errors = append(errors, err)
-	}
-
-	return utilerrors.NewAggregate(errors)
 }
 
 func toHealthzURL(urls []string) []string {

--- a/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
+++ b/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
@@ -47,7 +47,7 @@ func NewOAuthRouteCheckController(
 	}
 
 	return endpointaccessible.NewEndpointAccessibleController(
-		"OAuthRouteCheck",
+		"OAuthRoute",
 		operatorClient, endpointListFunc, getTLSConfigFunc, []factory.Informer{routeInformer, secretInformer, ingressInformer}, recorder)
 }
 
@@ -72,7 +72,7 @@ func NewOAuthServiceCheckController(
 	}
 
 	return endpointaccessible.NewEndpointAccessibleController(
-		"OAuthServiceCheck",
+		"OAuthService",
 		operatorClient, endpointsListFunc, getTLSConfigFunc, []factory.Informer{serviceInformer, secretInformer}, recorder)
 }
 
@@ -98,7 +98,7 @@ func NewOAuthServiceEndpointsCheckController(
 	}
 
 	return endpointaccessible.NewEndpointAccessibleController(
-		"OAuthServiceEndpointsCheck",
+		"OAuth",
 		operatorClient, endpointsListFn, getTLSConfigFunc, []factory.Informer{endpointsInformer, secretInformer}, recorder)
 }
 

--- a/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
+++ b/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
@@ -1,15 +1,20 @@
 package oauthendpoints
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"strconv"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1lister "github.com/openshift/client-go/config/listers/config/v1"
 	routev1informers "github.com/openshift/client-go/route/informers/externalversions/route/v1"
 	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/klog"
 
 	"github.com/openshift/cluster-authentication-operator/pkg/libs/endpointaccessible"
 
@@ -20,44 +25,66 @@ import (
 // NewOAuthRouteCheckController returns a controller that checks the health of authentication route.
 func NewOAuthRouteCheckController(
 	operatorClient v1helpers.OperatorClient,
+	secretInformerForNamespaces corev1informers.SecretInformer,
 	routeInformerNamespaces routev1informers.RouteInformer,
+	ingressInformerAllNamespaces configv1informers.IngressInformer,
 	recorder events.Recorder,
 ) factory.Controller {
+	secretLister := secretInformerForNamespaces.Lister()
+	secretInformer := secretInformerForNamespaces.Informer()
 	routeLister := routeInformerNamespaces.Lister()
 	routeInformer := routeInformerNamespaces.Informer()
+	ingressLister := ingressInformerAllNamespaces.Lister()
+	ingressInformer := ingressInformerAllNamespaces.Informer()
+
 	endpointListFunc := func() ([]string, error) {
 		return listOAuthRoutes(routeLister, recorder)
 	}
 
+	getTLSConfigFunc := func() (*tls.Config, error) {
+		return getOAuthRouteTLSConfig(secretLister, ingressLister, recorder)
+	}
+
 	return endpointaccessible.NewEndpointAccessibleController(
 		"OAuthRouteCheck",
-		operatorClient, endpointListFunc, []factory.Informer{routeInformer}, recorder)
+		operatorClient, endpointListFunc, getTLSConfigFunc, []factory.Informer{routeInformer, secretInformer, ingressInformer}, recorder)
 }
 
 // NewOAuthServiceCheckController returns a controller that checks the health of authentication service.
 func NewOAuthServiceCheckController(
 	operatorClient v1helpers.OperatorClient,
+	secretInformerForNamespaces corev1informers.SecretInformer,
 	corev1Informers corev1informers.Interface,
 	recorder events.Recorder,
 ) factory.Controller {
+	secretLister := secretInformerForNamespaces.Lister()
+	secretInformer := secretInformerForNamespaces.Informer()
 	serviceLister := corev1Informers.Services().Lister()
 	serviceInformer := corev1Informers.Services().Informer()
+
 	endpointsListFunc := func() ([]string, error) {
 		return listOAuthServices(serviceLister, recorder)
 	}
 
+	getTLSConfigFunc := func() (*tls.Config, error) {
+		return getOAuthEndpointTLSConfig(secretLister, recorder)
+	}
+
 	return endpointaccessible.NewEndpointAccessibleController(
 		"OAuthServiceCheck",
-		operatorClient, endpointsListFunc, []factory.Informer{serviceInformer}, recorder)
+		operatorClient, endpointsListFunc, getTLSConfigFunc, []factory.Informer{serviceInformer, secretInformer}, recorder)
 }
 
 // NewOAuthServiceEndpointsCheckController returns a controller that checks the health of authentication service
 // endpoints.
 func NewOAuthServiceEndpointsCheckController(
 	operatorClient v1helpers.OperatorClient,
+	secretInformerForNamespaces corev1informers.SecretInformer,
 	corev1Informers corev1informers.Interface,
 	recorder events.Recorder,
 ) factory.Controller {
+	secretLister := secretInformerForNamespaces.Lister()
+	secretInformer := secretInformerForNamespaces.Informer()
 	endpointsLister := corev1Informers.Endpoints().Lister()
 	endpointsInformer := corev1Informers.Endpoints().Informer()
 
@@ -65,9 +92,13 @@ func NewOAuthServiceEndpointsCheckController(
 		return listOAuthServiceEndpoints(endpointsLister, recorder)
 	}
 
+	getTLSConfigFunc := func() (*tls.Config, error) {
+		return getOAuthEndpointTLSConfig(secretLister, recorder)
+	}
+
 	return endpointaccessible.NewEndpointAccessibleController(
 		"OAuthServiceEndpointsCheck",
-		operatorClient, endpointsListFn, []factory.Informer{endpointsInformer}, recorder)
+		operatorClient, endpointsListFn, getTLSConfigFunc, []factory.Informer{endpointsInformer, secretInformer}, recorder)
 }
 
 func listOAuthServiceEndpoints(endpointsLister corev1listers.EndpointsLister, recorder events.Recorder) ([]string, error) {
@@ -123,6 +154,66 @@ func listOAuthRoutes(routeLister routev1listers.RouteLister, recorder events.Rec
 		return nil, fmt.Errorf("route status does not have host address")
 	}
 	return toHealthzURL(results), nil
+}
+
+func getOAuthRouteTLSConfig(secretLister corev1listers.SecretLister, ingressLister configv1lister.IngressLister, recorder events.Recorder) (*tls.Config, error) {
+	ingress, err := ingressLister.Get("cluster")
+	if err != nil {
+		recorder.Warningf("OAuthRouteSecret", "failed to get ingress config: %v", err)
+		return nil, err
+	}
+	if len(ingress.Spec.Domain) == 0 {
+		return nil, fmt.Errorf("ingress config domain cannot be empty")
+	}
+
+	routerSecret, err := secretLister.Secrets("openshift-authentication").Get("v4-0-config-system-router-certs")
+	if err != nil {
+		recorder.Warningf("OAuthRouteSecret", "failed to get oauth route ca cert: %v", err)
+		return nil, err
+	}
+
+	// find the domain that matches our route
+	if _, ok := routerSecret.Data[ingress.Spec.Domain]; !ok {
+		klog.Infof("unable to find router certs for domain %s", ingress.Spec.Domain)
+		return nil, nil
+	}
+
+	rootCAs := x509.NewCertPool()
+	if ok := rootCAs.AppendCertsFromPEM(routerSecret.Data[ingress.Spec.Domain]); !ok {
+		klog.Infof("failed to parse router certs for domain %s", ingress.Spec.Domain)
+		return nil, nil
+	}
+
+	return &tls.Config{
+		RootCAs: rootCAs,
+	}, nil
+}
+
+func getOAuthEndpointTLSConfig(secretLister corev1listers.SecretLister, recorder events.Recorder) (*tls.Config, error) {
+	serviceSecret, err := secretLister.Secrets("openshift-authentication").Get("v4-0-config-system-serving-cert")
+	if err != nil {
+		recorder.Warningf("OAuthEndpointSecret", "failed to get oauth endpoint ca cert: %v", err)
+		return nil, err
+	}
+
+	// find the domain that matches our route
+	if _, ok := serviceSecret.Data["tls.crt"]; !ok {
+		return nil, fmt.Errorf("unable to find service ca bundle")
+	}
+
+	rootCAs := x509.NewCertPool()
+	if ok := rootCAs.AppendCertsFromPEM(serviceSecret.Data["tls.crt"]); !ok {
+		return nil, fmt.Errorf("no certificates could be parsed from the service ca bundle")
+	}
+	return &tls.Config{
+		RootCAs: rootCAs,
+		// Specify a host name allowed by the serving cert of the
+		// endpoints to ensure that TLS validates successfully. The
+		// serving cert the endpoint uses does not include IP SANs
+		// so accessing the endpoint via IP would otherwise result
+		// in validation failure.
+		ServerName: "oauth-openshift.openshift-authentication.svc",
+	}, nil
 }
 
 func toHealthzURL(urls []string) []string {

--- a/pkg/controllers/oauthendpoints/oauth_endpoints_controller_test.go
+++ b/pkg/controllers/oauthendpoints/oauth_endpoints_controller_test.go
@@ -1,0 +1,27 @@
+package oauthendpoints
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_toHealthzURL(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "test urls",
+			args: []string{"a", "b"},
+			want: []string{"https://a/healthz", "https://b/healthz"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toHealthzURL(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toHealthzURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/targetversion/target_version_controller.go
+++ b/pkg/controllers/targetversion/target_version_controller.go
@@ -6,24 +6,17 @@ import (
 	"os"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/informers"
-	appsv1lister "k8s.io/client-go/listers/apps/v1"
-	corev1lister "k8s.io/client-go/listers/core/v1"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
-	configinformer "github.com/openshift/client-go/config/informers/externalversions"
-	configv1lister "github.com/openshift/client-go/config/listers/config/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
-	routeinformer "github.com/openshift/client-go/route/informers/externalversions/route/v1"
-	routev1lister "github.com/openshift/client-go/route/listers/route/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	appsv1lister "k8s.io/client-go/listers/apps/v1"
 
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/common"
 )
@@ -51,64 +44,37 @@ var knownConditionNames = sets.NewString(
 
 type targetVersionController struct {
 	operatorClient   v1helpers.OperatorClient
-	ingressLister    configv1lister.IngressLister
-	routeLister      routev1lister.RouteLister
-	secretLister     corev1lister.SecretLister
 	deploymentLister appsv1lister.DeploymentLister
 
 	oauthClientClient oauthclient.OAuthClientInterface
 	versionGetter     status.VersionGetter
-	systemCABundle    []byte
 }
 
 func NewTargetVersionController(
 	kubeInformersNamespaced informers.SharedInformerFactory,
-	configInformers configinformer.SharedInformerFactory,
-	routeInformer routeinformer.RouteInformer,
 	oauthClient oauthclient.OAuthClientInterface,
 	operatorClient v1helpers.OperatorClient,
 	versionGetter status.VersionGetter,
-	systemCABundle []byte,
 	recorder events.Recorder,
 ) factory.Controller {
 	c := &targetVersionController{
 		deploymentLister:  kubeInformersNamespaced.Apps().V1().Deployments().Lister(),
-		secretLister:      kubeInformersNamespaced.Core().V1().Secrets().Lister(),
-		ingressLister:     configInformers.Config().V1().Ingresses().Lister(),
-		routeLister:       routeInformer.Lister(),
 		oauthClientClient: oauthClient,
 		versionGetter:     versionGetter,
 
 		operatorClient: operatorClient,
-		systemCABundle: systemCABundle,
 	}
 
 	return factory.New().ResyncEvery(30*time.Second).WithInformers(
-		kubeInformersNamespaced.Core().V1().Secrets().Informer(),
 		kubeInformersNamespaced.Apps().V1().Deployments().Informer(),
-		configInformers.Config().V1().Ingresses().Informer(),
-		routeInformer.Informer(),
 	).WithSync(c.sync).ToController("TargetVersion", recorder.WithComponentSuffix("target-version-controller"))
 }
 
 func (c *targetVersionController) sync(ctx context.Context, syncContext factory.SyncContext) error {
 	foundConditions := []operatorv1.OperatorCondition{}
 
-	ingressConfig, ingressConditions := common.GetIngressConfig(c.ingressLister, "OAuthVersionIngressConfig")
-	foundConditions = append(foundConditions, ingressConditions...)
-
-	route, routeConditions := common.GetOAuthServerRoute(c.routeLister, "OAuthVersionRoute")
-	foundConditions = append(foundConditions, routeConditions...)
-
-	routeSecret, routeSecretConditions := c.getRouteSecret()
-	foundConditions = append(foundConditions, routeSecretConditions...)
-
 	deployment, deploymentConditions := c.getDeployment()
 	foundConditions = append(foundConditions, deploymentConditions...)
-
-	if len(foundConditions) == 0 {
-		foundConditions = append(foundConditions, common.CheckRouteHealthy(route, routeSecret, c.systemCABundle, ingressConfig, "OAuthVersionRoute")...)
-	}
 
 	if deployment != nil {
 		foundConditions = append(foundConditions, common.CheckDeploymentReady(deployment, "OAuthVersionDeployment")...)
@@ -123,19 +89,6 @@ func (c *targetVersionController) sync(ctx context.Context, syncContext factory.
 	}
 
 	return common.UpdateControllerConditions(c.operatorClient, knownConditionNames, foundConditions)
-}
-
-func (c *targetVersionController) getRouteSecret() (*corev1.Secret, []operatorv1.OperatorCondition) {
-	routerSecret, err := c.secretLister.Secrets("openshift-authentication").Get("v4-0-config-system-router-certs")
-	if err != nil {
-		return nil, []operatorv1.OperatorCondition{{
-			Type:    "OAuthVersionRouteSecretDegraded",
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "GetFailed",
-			Message: fmt.Sprintf("Unable to get OAuth server route certificate secret: %v", err),
-		}}
-	}
-	return routerSecret, nil
 }
 
 func (c *targetVersionController) getDeployment() (*appsv1.Deployment, []operatorv1.OperatorCondition) {

--- a/pkg/libs/endpointaccessible/endpoint_accessible_controller.go
+++ b/pkg/libs/endpointaccessible/endpoint_accessible_controller.go
@@ -1,0 +1,102 @@
+package endpointaccessible
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type endpointAccessibleController struct {
+	operatorClient v1helpers.OperatorClient
+	endpointListFn EndpointListFunc
+}
+
+type EndpointListFunc func() ([]string, error)
+
+// NewEndpointAccessibleController returns a controller that checks if the endpoints
+// listed by endpointListFn are reachable
+func NewEndpointAccessibleController(
+	name string,
+	operatorClient v1helpers.OperatorClient,
+	endpointListFn EndpointListFunc,
+	triggers []factory.Informer,
+	recorder events.Recorder,
+) factory.Controller {
+	c := &endpointAccessibleController{
+		operatorClient: operatorClient,
+		endpointListFn: endpointListFn,
+	}
+
+	return factory.New().
+		WithInformers(triggers...).
+		WithInformers(operatorClient.Informer()).
+		WithSync(c.sync).
+		ResyncEvery(30*time.Second).
+		WithSyncDegradedOnError(operatorClient).
+		ToController(name+"EndpointAccessibleController", recorder.WithComponentSuffix(name+"endpoint-accessible-controller"))
+}
+
+func (c *endpointAccessibleController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	endpoints, err := c.endpointListFn()
+	if err != nil {
+		return err
+	}
+
+	// check all the endpoints in parallel.  This matters for pods.
+	errCh := make(chan error, len(endpoints))
+	wg := sync.WaitGroup{}
+	for _, endpoint := range endpoints {
+		wg.Add(1)
+		go func(endpoint string) {
+			defer wg.Done()
+
+			req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second) // avoid waiting forever
+			defer cancel()
+			req.WithContext(reqCtx)
+
+			// we don't really care  if anyone lies to us. We aren't sending important data.
+			client := &http.Client{
+				Timeout: 5 * time.Second,
+				Transport: &http.Transport{
+					Proxy: http.ProxyFromEnvironment,
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				},
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			if resp.StatusCode > 299 || resp.StatusCode < 200 {
+				errCh <- fmt.Errorf("%q returned %q", endpoint, resp.Status)
+			}
+		}(endpoint)
+	}
+	wg.Wait()
+	close(errCh)
+
+	var errors []error
+	for err := range errCh {
+		errors = append(errors, err)
+	}
+
+	return utilerrors.NewAggregate(errors)
+}

--- a/pkg/libs/endpointaccessible/endpoint_accessible_controller_test.go
+++ b/pkg/libs/endpointaccessible/endpoint_accessible_controller_test.go
@@ -3,7 +3,6 @@ package endpointaccessible
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -51,27 +50,6 @@ func Test_endpointAccessibleController_sync(t *testing.T) {
 			}
 			if err := c.sync(context.Background(), factory.NewSyncContext(tt.name, events.NewInMemoryRecorder(tt.name))); (err != nil) != tt.wantErr {
 				t.Errorf("sync() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func Test_toHealthzURL(t *testing.T) {
-	tests := []struct {
-		name string
-		args []string
-		want []string
-	}{
-		{
-			name: "test urls",
-			args: []string{"a", "b"},
-			want: []string{"https://a/healthz", "https://b/healthz"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := toHealthzURL(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("toHealthzURL() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -359,6 +359,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1().Secrets(),
 		routeInformersNamespaced.Route().V1().Routes(),
 		operatorCtx.operatorConfigInformer.Config().V1().Ingresses(),
+		systemCABundle,
 		controllerContext.EventRecorder,
 	)
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -50,9 +50,9 @@ import (
 
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/deployment"
-	"github.com/openshift/cluster-authentication-operator/pkg/controllers/endpointaccessible"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/ingressstate"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/metadata"
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/oauthendpoints"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/payload"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/readiness"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/routercerts"
@@ -354,19 +354,19 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		controllerContext.EventRecorder,
 	)
 
-	authRouteCheckController := endpointaccessible.NewOAuthRouteCheckController(
+	authRouteCheckController := oauthendpoints.NewOAuthRouteCheckController(
 		operatorCtx.operatorClient,
 		routeInformersNamespaced.Route().V1().Routes(),
 		controllerContext.EventRecorder,
 	)
 
-	authServiceCheckController := endpointaccessible.NewOAuthServiceCheckController(
+	authServiceCheckController := oauthendpoints.NewOAuthServiceCheckController(
 		operatorCtx.operatorClient,
 		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1(),
 		controllerContext.EventRecorder,
 	)
 
-	authServiceEndpointCheckController := endpointaccessible.NewOAuthServiceEndpointsCheckController(
+	authServiceEndpointCheckController := oauthendpoints.NewOAuthServiceEndpointsCheckController(
 		operatorCtx.operatorClient,
 		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1(),
 		controllerContext.EventRecorder,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -356,18 +356,22 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 
 	authRouteCheckController := oauthendpoints.NewOAuthRouteCheckController(
 		operatorCtx.operatorClient,
+		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1().Secrets(),
 		routeInformersNamespaced.Route().V1().Routes(),
+		operatorCtx.operatorConfigInformer.Config().V1().Ingresses(),
 		controllerContext.EventRecorder,
 	)
 
 	authServiceCheckController := oauthendpoints.NewOAuthServiceCheckController(
 		operatorCtx.operatorClient,
+		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1().Secrets(),
 		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1(),
 		controllerContext.EventRecorder,
 	)
 
 	authServiceEndpointCheckController := oauthendpoints.NewOAuthServiceEndpointsCheckController(
 		operatorCtx.operatorClient,
+		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1().Secrets(),
 		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1(),
 		controllerContext.EventRecorder,
 	)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -338,21 +338,19 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		controllerContext.EventRecorder,
 	)
 
+	targetVersionController := targetversion.NewTargetVersionController(
+		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication"),
+		oauthClient.OauthV1().OAuthClients(),
+		operatorCtx.operatorClient,
+		operatorCtx.versionRecorder,
+		controllerContext.EventRecorder,
+	)
+
 	systemCABundle, err := ioutil.ReadFile("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
 	if err != nil {
 		// this may fail route-health checks in proxy environments
 		klog.Warningf("Unable to read system CA from /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem: %v", err)
 	}
-	targetVersionController := targetversion.NewTargetVersionController(
-		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication"),
-		operatorCtx.operatorConfigInformer,
-		routeInformersNamespaced.Route().V1().Routes(),
-		oauthClient.OauthV1().OAuthClients(),
-		operatorCtx.operatorClient,
-		operatorCtx.versionRecorder,
-		systemCABundle,
-		controllerContext.EventRecorder,
-	)
 
 	authRouteCheckController := oauthendpoints.NewOAuthRouteCheckController(
 		operatorCtx.operatorClient,


### PR DESCRIPTION
this is a follow up change set to clean up the changes made by this [PR](https://github.com/openshift/cluster-authentication-operator/pull/306). It removes the duplicate health checks to route and oauth endpoints. It also adds support for using ca data when making a connection to an endpoint.