### PR TITLE
Bug 1867908: add connection timeouts and proxy from env to http client

### DIFF
--- a/pkg/controllers/endpointaccessible/endpoint_accessible_controller.go
+++ b/pkg/controllers/endpointaccessible/endpoint_accessible_controller.go
@@ -183,10 +183,15 @@ func (c *endpointAccessibleController) sync(ctx context.Context, syncCtx factory
 			req.WithContext(reqCtx)
 
 			// we don't really care  if anyone lies to us. We aren't sending important data.
-			insecureTransport := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			client := &http.Client{
+				Timeout: 5 * time.Second,
+				Transport: &http.Transport{
+					Proxy: http.ProxyFromEnvironment,
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				},
 			}
-			client := &http.Client{Transport: insecureTransport}
 
 			resp, err := client.Do(req)
 			if err != nil {


### PR DESCRIPTION
Add client side timeout to not wait ~2mins to report a failure. Request is expected to be served within 5 seconds now. Also add the flag to get proxy configuration from the environment. This flag should resolve the issues we are seeing in proxy environments.