### PR TITLE
Don't bump operator version when the oauth-apiserver deployment is not yet ready

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -459,8 +459,7 @@ func prepareOauthAPIServerOperator(ctx context.Context, controllerContext *contr
 		os.Getenv("IMAGE_OAUTH_APISERVER"),
 		os.Getenv("OPERATOR_IMAGE"),
 		operatorCtx.kubeClient,
-		eventRecorder,
-		operatorCtx.versionRecorder)
+		eventRecorder)
 
 	apiServerControllers, err := apiservercontrollerset.NewAPIServerControllerSet(
 		operatorCtx.operatorClient,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -348,8 +348,14 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		// this may fail route-health checks in proxy environments
 		klog.Warningf("Unable to read system CA from /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem: %v", err)
 	}
+
+	targetNsInformers := v1helpers.NewKubeInformersForNamespaces(
+		operatorCtx.kubeClient,
+		"openshift-authentication",
+		"openshift-oauth-apiserver",
+	)
 	targetVersionController := targetversion.NewTargetVersionController(
-		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-authentication"),
+		targetNsInformers,
 		operatorCtx.operatorConfigInformer,
 		routeInformersNamespaced.Route().V1().Routes(),
 		oauthClient.OauthV1().OAuthClients(),
@@ -385,6 +391,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		routeInformersNamespaced.Start,
 		kubeSystemNamespaceInformers.Start,
 		openshiftAuthenticationInformers.Start,
+		targetNsInformers.Start,
 	)
 
 	operatorCtx.controllersToRunFunc = append(operatorCtx.controllersToRunFunc,

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehash"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
-	"github.com/openshift/library-go/pkg/operator/status"
 	"k8s.io/klog"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -58,7 +57,6 @@ type OAuthAPIServerWorkload struct {
 	operatorImagePullSpec     string
 	kubeClient                kubernetes.Interface
 	eventRecorder             events.Recorder
-	versionRecorder           status.VersionGetter
 }
 
 // NewOAuthAPIServerWorkload creates new OAuthAPIServerWorkload struct
@@ -71,7 +69,6 @@ func NewOAuthAPIServerWorkload(
 	operatorImagePullSpec string,
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder,
-	versionRecorder status.VersionGetter,
 ) *OAuthAPIServerWorkload {
 	return &OAuthAPIServerWorkload{
 		operatorClient:            operatorClient,
@@ -82,7 +79,6 @@ func NewOAuthAPIServerWorkload(
 		operatorImagePullSpec:     operatorImagePullSpec,
 		kubeClient:                kubeClient,
 		eventRecorder:             eventRecorder,
-		versionRecorder:           versionRecorder,
 	}
 }
 


### PR DESCRIPTION
Updates the target version controller to take the oauth API server deployment into account.

In the ideal world, we should only check the clusteroperator's "Available" condition and bump the version when that is true (==> the version controller would depend on all the other controllers properly reporting status)