### PR TITLE
Bug 1866818: routercerts: always trust the default ingress ca

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -281,6 +281,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		controllerContext.EventRecorder,
 		operatorCtx.operatorConfigInformer.Config().V1().Ingresses(),
 		openshiftAuthenticationInformers.Core().V1().Secrets(),
+		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().ConfigMaps(),
 		"openshift-authentication",
 		"v4-0-config-system-router-certs",
 		"oauth-openshift",


### PR DESCRIPTION
Sometimes, the CA cert does not seem to appear in the routercerts secret. We should have always trusted the default ingress cert for router certs, adding that here.

/assign @deads2k 
/cc @Miciah 