### PR TITLE
Bug 1876858: manifests: rename operator container to be more descriptive

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: authentication-operator
       containers:
-      - name: operator
+      - name: authentication-operator
         image: quay.io/openshift/origin-cluster-authentication-operator:v4.0
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash", "-ec"]


### PR DESCRIPTION
Rename the operator container to allow for more reasonable debugging.