### PR TITLE
Bug 1879417: don't error out on non-json output of password grant attempt

### DIFF
--- a/pkg/operator2/idp.go
+++ b/pkg/operator2/idp.go
@@ -376,7 +376,11 @@ func (c *authOperator) checkOIDCPasswordGrantFlow(
 	respJSON := json.NewDecoder(resp.Body)
 	respMap := map[string]interface{}{}
 	if err = respJSON.Decode(&respMap); err != nil {
-		return false, fmt.Errorf("failed to decode response from the OIDC server: %v", err)
+		// only log the error, some OIDCs ignore/don't implement the Accept header
+		// and respond with HTML in case they don't support password credential grants at all
+		klog.Errorf("failed to JSON-decode the response from the OIDC server's token endpoint (%s): %v", tokenURL, err)
+		oidcPasswordChecks[secret.ResourceVersion] = false
+		return false, nil
 	}
 
 	if errVal, ok := respMap["error"]; ok {


### PR DESCRIPTION
Some OIDCs return HTML page when they don't support password grants.