### PR TITLE
bug 1871890: add current profile annotations to CVO manifests

### DIFF
--- a/manifests/0000_90_cluster-authentication-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_01_prometheusrbac.yaml
@@ -4,6 +4,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-authentication-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:
   - ""
@@ -22,6 +24,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-authentication
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:
   - ""
@@ -40,6 +44,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-authentication-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,6 +61,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-authentication
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
@@ -4,6 +4,8 @@ kind: ServiceMonitor
 metadata:
   name: authentication-operator
   namespace: openshift-authentication-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -30,6 +32,8 @@ kind: ServiceMonitor
 metadata:
   name: oauth-openshift
   namespace: openshift-authentication
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-authentication-operator
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/02_config.cr.yaml
+++ b/manifests/02_config.cr.yaml
@@ -3,6 +3,7 @@ kind: Authentication
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/manifests/02_service.yaml
+++ b/manifests/02_service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
   labels:
     app: authentication-operator

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   namespace: openshift-authentication-operator
   name: authentication-operator-config
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/03_openshift_service_ca.yaml
+++ b/manifests/03_openshift_service_ca.yaml
@@ -4,5 +4,6 @@ metadata:
   name: service-ca-bundle
   namespace: openshift-authentication-operator
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     service.beta.openshift.io/inject-cabundle: "true"
 data: {}

--- a/manifests/03_operator_trusted_ca.yaml
+++ b/manifests/03_operator_trusted_ca.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: openshift-authentication-operator
   name: trusted-ca-bundle
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/04_roles.yaml
+++ b/manifests/04_roles.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openshift:operator:authentication
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin  # TODO fix, this is madness

--- a/manifests/05_serviceaccount.yaml
+++ b/manifests/05_serviceaccount.yaml
@@ -3,5 +3,7 @@ kind: ServiceAccount
 metadata:
   namespace: openshift-authentication-operator
   name: authentication-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
   labels:
     app: authentication-operator

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: authentication-operator
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     config.openshift.io/inject-proxy: authentication-operator
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:

--- a/manifests/08_clusteroperator.yaml
+++ b/manifests/08_clusteroperator.yaml
@@ -3,6 +3,7 @@ kind: ClusterOperator
 metadata:
   name: authentication
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 status:
   versions:


### PR DESCRIPTION
Cluster profiles are a way to support different deployment models for OpenShift clusters. A profile is an identifier that the Cluster Version Operator uses to determine which manifests to apply. Operators can be excluded completely or can have different manifests for each supported profile.

To support above, a deployment model in which not all operators rendered by the CVO by default is needed. The use case includes IBM Public Cloud, in which a hosted control plane is used. Potentially it can also be used for Code Ready Containers.

The following annotation may be used to include manifests for a given profile:

```
include.release.openshift.io/[identifier]=true
```

This would make the CVO render this manifest only when CLUSTER_PROFILE=[identifier] has been specified.

This PR is just a rebase of the original PR https://github.com/openshift/cluster-authentication-operator/pull/325 created by @deads2k .

This matches https://github.com/openshift/enhancements/pull/414 and doesn't change existing behavior.