### PR TITLE
pkg/controllers: Use library-go's IngressURI helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20200930075302-db52bc4ef99f
 	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
 	github.com/openshift/client-go v0.0.0-20200929181438-91d71ef2122c
-	github.com/openshift/library-go v0.0.0-20200930190915-f7cb85f605db
+	github.com/openshift/library-go v0.0.0-20201006230840-f360b9835cc8
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5 h1:E6WhVL5p3rf
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/client-go v0.0.0-20200929181438-91d71ef2122c h1:DQTWW8DGRN7fu5qwEPcbdP9hAxXi7dm5cvi0hrdR3UE=
 github.com/openshift/client-go v0.0.0-20200929181438-91d71ef2122c/go.mod h1:MwESrlhzumQGcGtPCpz/WjDrlvhu1fMNlLBcNYjO0fY=
-github.com/openshift/library-go v0.0.0-20200930190915-f7cb85f605db h1:9exsUh1WRQ2U+ZeIuX50Qb+oHAZXkcTL07A3FJhfc/A=
-github.com/openshift/library-go v0.0.0-20200930190915-f7cb85f605db/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
+github.com/openshift/library-go v0.0.0-20201006230840-f360b9835cc8 h1:WoTAxt198VLaxZyr1QTnItIfz/g1bb9PA7B8CnCMXE0=
+github.com/openshift/library-go v0.0.0-20201006230840-f360b9835cc8/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/route/routeapihelpers/routeapihelpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/route/routeapihelpers/routeapihelpers.go
@@ -1,0 +1,44 @@
+// Package routeapihelpers contains utilities for handling OpenShift route objects.
+package routeapihelpers
+
+import (
+	"fmt"
+	"net/url"
+
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// IngressURI calculates an admitted ingress URI.
+// If 'host' is nonempty, only the ingress for that host is considered.
+// If 'host' is empty, the first admitted ingress is used.
+func IngressURI(route *routev1.Route, host string) (*url.URL, *routev1.RouteIngress, error) {
+	scheme := "http"
+	if route.Spec.TLS != nil {
+		scheme = "https"
+	}
+
+	for _, ingress := range route.Status.Ingress {
+		if host == "" || host == ingress.Host {
+			uri := &url.URL{
+				Scheme: scheme,
+				Host:   ingress.Host,
+			}
+
+			for _, condition := range ingress.Conditions {
+				if condition.Type == routev1.RouteAdmitted && condition.Status == corev1.ConditionTrue {
+					return uri, &ingress, nil
+				}
+			}
+
+			if host == ingress.Host {
+				return uri, &ingress, fmt.Errorf("ingress for host %s in route %s in namespace %s is not admitted", host, route.ObjectMeta.Name, route.ObjectMeta.Namespace)
+			}
+		}
+	}
+
+	if host == "" {
+		return nil, nil, fmt.Errorf("no admitted ingress for route %s in namespace %s", route.ObjectMeta.Name, route.ObjectMeta.Namespace)
+	}
+	return nil, nil, fmt.Errorf("no ingress for host %s in route %s in namespace %s", host, route.ObjectMeta.Name, route.ObjectMeta.Namespace)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,7 +196,7 @@ github.com/openshift/client-go/route/informers/externalversions/internalinterfac
 github.com/openshift/client-go/route/informers/externalversions/route
 github.com/openshift/client-go/route/informers/externalversions/route/v1
 github.com/openshift/client-go/route/listers/route/v1
-# github.com/openshift/library-go v0.0.0-20200930190915-f7cb85f605db
+# github.com/openshift/library-go v0.0.0-20201006230840-f360b9835cc8
 ## explicit
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets
@@ -253,6 +253,7 @@ github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller
 github.com/openshift/library-go/pkg/operator/v1helpers
+github.com/openshift/library-go/pkg/route/routeapihelpers
 github.com/openshift/library-go/pkg/serviceability
 github.com/openshift/library-go/test/library
 github.com/openshift/library-go/test/library/encryption


### PR DESCRIPTION
Using the helper from openshift/library-go#911 to centralize some route handling and error message generation.

Generated with:

```console
$ emacs pkg/... # everything in the diff
$ go get github.com/openshift/library-go@f360b9835cc8815eccc26cb52dafe05d3cbb3e93
go: github.com/openshift/library-go f360b9835cc8815eccc26cb52dafe05d3cbb3e93 => v0.0.0-20201006230840-f360b9835cc8
$ go mod tidy
$ go mod vendor
$ git add -A go.* vendor
```

using:

```console
$ go version
go version go1.15.2 linux/amd64
```