### PR TITLE
Bug 1891758: deployment: update event spam

### DIFF
--- a/pkg/controllers/deployment/deployment_controller.go
+++ b/pkg/controllers/deployment/deployment_controller.go
@@ -360,7 +360,9 @@ func (c *deploymentController) updateOperatorDeploymentInfo(
 	operatorConfig *operatorv1.Authentication,
 	deployment *appsv1.Deployment,
 ) error {
-	operatorStatusOutdated := operatorConfig.Status.ObservedGeneration != operatorConfig.Generation || operatorConfig.Status.ReadyReplicas != deployment.Status.UpdatedReplicas
+	operatorStatusOutdated := operatorConfig.Status.ObservedGeneration != operatorConfig.Generation ||
+		operatorConfig.Status.ReadyReplicas != deployment.Status.UpdatedReplicas ||
+		resourcemerge.ExpectedDeploymentGeneration(deployment, operatorConfig.Status.Generations) != deployment.Generation
 
 	if operatorStatusOutdated {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {


### PR DESCRIPTION
When authentication.operator observedGeneration and readyReplicas
get set before the observed deployment's generation, the last element
would have never gotten set and the ApplyDeployment function would have
kept reporting deployment update event endlessly.