### PR TITLE
Restrict log permissions

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -36,7 +36,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'chmod 0700 /var/log/oauth-apiserver']
+          command: ['sh', '-c', 'chmod 0700 /var/log/oauth-apiserver && touch /var/log/oauth-apiserver/audit.log && chmod 0600 /var/log/oauth-apiserver/*']
           securityContext:
             privileged: true
           volumeMounts:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -131,7 +131,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           image: ${IMAGE}
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'chmod 0700 /var/log/oauth-apiserver']
+          command: ['sh', '-c', 'chmod 0700 /var/log/oauth-apiserver && touch /var/log/oauth-apiserver/audit.log && chmod 0600 /var/log/oauth-apiserver/*']
           securityContext:
             privileged: true
           volumeMounts:

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "1b0b8e398eda25b4901e44697aa775bd899be9edb50389d654f1a2fcb2e4f9c3"
+    operator.openshift.io/spec-hash: "91d9904f3a2d6336f1ed47ff7002e0dc76a47d26f6f7c35255cc0a57780882e0"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -107,7 +107,7 @@ spec:
           command:
             - sh
             - "-c"
-            - "chmod 0700 /var/log/oauth-apiserver"
+            - "chmod 0700 /var/log/oauth-apiserver && touch /var/log/oauth-apiserver/audit.log && chmod 0600 /var/log/oauth-apiserver/*"
           imagePullPolicy: IfNotPresent
           name: fix-audit-permissions
           resources: {}

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "54637c4cbab0844dcd394ea0e95226d52ad954c7f95f3ae3d524b012a72b117d"
+    operator.openshift.io/spec-hash: "a179b976eeed3ff1ca91317265534671f3f563b871df1ab2fdd1a42d9199fbf4"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -116,7 +116,7 @@ spec:
           command:
             - sh
             - "-c"
-            - "chmod 0700 /var/log/oauth-apiserver"
+            - "chmod 0700 /var/log/oauth-apiserver && touch /var/log/oauth-apiserver/audit.log && chmod 0600 /var/log/oauth-apiserver/*"
           imagePullPolicy: IfNotPresent
           name: fix-audit-permissions
           resources: {}

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "6d4a96bf85a19afc5fed72eb00934c5c87a3fe9aacb4771ccb4727dd9f3ecc6f"
+    operator.openshift.io/spec-hash: "9297825f8f7725dd2bf81a23aa97e591a0007ace241460b3d14848135a4f658a"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -111,7 +111,7 @@ spec:
           command:
             - sh
             - "-c"
-            - "chmod 0700 /var/log/oauth-apiserver"
+            - "chmod 0700 /var/log/oauth-apiserver && touch /var/log/oauth-apiserver/audit.log && chmod 0600 /var/log/oauth-apiserver/*"
           imagePullPolicy: IfNotPresent
           name: fix-audit-permissions
           resources: {}


### PR DESCRIPTION
While the current log directory permissions are restrictive and correct,
the file permissions are too permissive and it raises flags on
evaluations of the deployment. Let's instead change the permissions to
0600 which is more appropriate for these types of logs.