### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_90_cluster-authentication-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_01_prometheusrbac.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -30,6 +31,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -52,6 +54,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -74,6 +77,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -93,6 +97,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -112,6 +117,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -38,6 +39,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -67,6 +69,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/02_config.cr.yaml
+++ b/manifests/02_config.cr.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/02_service.yaml
+++ b/manifests/02_service.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: authentication-operator
   name: metrics

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/03_openshift_service_ca.yaml
+++ b/manifests/03_openshift_service_ca.yaml
@@ -8,4 +8,5 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.beta.openshift.io/inject-cabundle: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data: {}

--- a/manifests/03_operator_trusted_ca.yaml
+++ b/manifests/03_operator_trusted_ca.yaml
@@ -8,5 +8,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/04_roles.yaml
+++ b/manifests/04_roles.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin  # TODO fix, this is madness

--- a/manifests/05_serviceaccount.yaml
+++ b/manifests/05_serviceaccount.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: authentication-operator

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     config.openshift.io/inject-proxy: authentication-operator
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/08_clusteroperator.yaml
+++ b/manifests/08_clusteroperator.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 status:
   versions:
   - name: operator

--- a/manifests/09_flowschema.yaml
+++ b/manifests/09_flowschema.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser
@@ -46,6 +47,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser
@@ -77,6 +79,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser
@@ -108,6 +111,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser


### PR DESCRIPTION
This PR adds annotation for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.