### PR TITLE
e2e: new gitlab version broke initial root user login

### DIFF
--- a/test/e2e/password_grant_check_test.go
+++ b/test/e2e/password_grant_check_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestGitLabAsOIDCPasswordGrantCheck(t *testing.T) {
+	// FIXME:
+	t.Skip("13.9.0 seems to have broken the root login used in this test")
 	kubeConfig := test.NewClientConfigForTest(t)
 
 	kubeClients, err := kubernetes.NewForConfig(kubeConfig)


### PR DESCRIPTION
I couldn't find a specific change that would break this in the release notes. It is possible they started checking `client_id` even for these logins.