### PR TITLE
Fix "components" -> "component" in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,4 +4,4 @@ approvers:
   - stlaz
   - sttts
   - deads2k
-components: apiserver-auth
+component: apiserver-auth


### PR DESCRIPTION
I think this is why the "io.openshift.maintainer.component" label is missing from the Dockerfile:

https://catalog.redhat.com/software/containers/openshift4/ose-cluster-authentication-operator/5cdb45d1d70cc57c44b2248d?container-tabs=dockerfile