### PR TITLE
e2e: Pin gitlab docker image to 13.8.4-ce.0

### DIFF
--- a/test/library/gitlabidp.go
+++ b/test/library/gitlabidp.go
@@ -38,7 +38,7 @@ func AddGitlabIDP( // TODO: possibly make this be a wrapper to a function to sim
 
 	nsName, gitlabHost, cleanup := deployPod(t, kubeClients, routeClient,
 		"gitlab",
-		"docker.io/gitlab/gitlab-ce:latest",
+		"docker.io/gitlab/gitlab-ce:13.8.4-ce.0",
 		[]corev1.EnvVar{
 			// configure password for GitLab root user
 			{Name: "GITLAB_OMNIBUS_CONFIG", Value: "gitlab_rails['initial_root_password']='password';"},


### PR DESCRIPTION
Deployment with the latest image was failing as follows:

```
     waits.go:85: waiting for route e2e-test-authentication-operator-qsp8f/test-route to be admitted
    waits.go:93: no admitted ingress for route test-route in namespace e2e-test-authentication-operator-qsp8f
    waits.go:105: waiting for HEAD at "https://test-route-e2e-test-authentication-operator-qsp8f.apps.ci-op-znybibly-1d877.origin-ci-int-aws.dev.rhcloud.com" to report 200
    waits.go:120: HEAD https://test-route-e2e-test-authentication-operator-qsp8f.apps.ci-op-znybibly-1d877.origin-ci-int-aws.dev.rhcloud.com: 503 Service Unavailable
    waits.go:120: HEAD https://test-route-e2e-test-authentication-operator-qsp8f.apps.ci-op-znybibly-1d877.origin-ci-int-aws.dev.rhcloud.com: 502 Bad Gateway
    gitlabidp.go:105:
        	Error Trace:	gitlabidp.go:105
        	            				helpers.go:382
        	            				e2e_test.go:83
        	Error:      	Received unexpected error:
        	            	gitlab login failed for user root: {"error":"invalid_client","error_description":"Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."}
        	Test:       	TestE2e/Configure_test_IdP
        	Messages:   	failed to login as root
```

Pinning to the aforementioned tag seems to make it work again.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>