### PR TITLE
Bug 1934400: apiserver: specifically allow privilege escalation

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -39,6 +39,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/oauth-apiserver && touch /var/log/oauth-apiserver/audit.log && chmod 0600 /var/log/oauth-apiserver/*']
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           resources:
             requests:
               cpu: 15m
@@ -78,6 +79,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/oauth-apiserver
         securityContext:
           privileged: true
+          allowPrivilegeEscalation: true
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -317,6 +317,7 @@ spec:
           command: ['sh', '-c', 'chmod 0700 /var/log/oauth-apiserver && touch /var/log/oauth-apiserver/audit.log && chmod 0600 /var/log/oauth-apiserver/*']
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           resources:
             requests:
               cpu: 15m
@@ -356,6 +357,7 @@ spec:
         # we need to set this to privileged to be able to write audit to /var/log/oauth-apiserver
         securityContext:
           privileged: true
+          allowPrivilegeEscalation: true
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "8cd028ac0830a64f052c69de498a9e13569ac9af1187f370b740f8e027473c3c"
+    operator.openshift.io/spec-hash: "8574cd9920e00499424fe22faff8cca9041d965728c4394af903be22238a5929"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -80,6 +80,7 @@ spec:
               memory: 200Mi
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             -
@@ -117,6 +118,7 @@ spec:
               memory: 50Mi
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "0155b7ef3a6af0aeb538a94741635e4b90c4b7ebdf1b90ee9baba16599c2813a"
+    operator.openshift.io/spec-hash: "e4a0660ee933929077883a73f076c076fa49dc33c184ac2f58939ee681f6268d"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -89,6 +89,7 @@ spec:
               memory: 200Mi
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             -
@@ -126,6 +127,7 @@ spec:
               memory: 50Mi
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "2323af5c89a5e6d33b0acb47c691090516c92006e7aae97720d5e824b3f96977"
+    operator.openshift.io/spec-hash: "09fcf55e5a635ceb3906c58b3db68c7fa6919d581df379157a6cf2153e0bc5d4"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -84,6 +84,7 @@ spec:
               memory: 200Mi
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             -
@@ -121,6 +122,7 @@ spec:
               memory: 50Mi
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             -


### PR DESCRIPTION
An SCC that allows privileged containers but defaults allowing
privilege escalation in containers might nuke the apiservers on restart.

---
Apparently IBM started distributing such an SCC with `priority:1` in their Cloud Paks multi-cluster-management offerings. Such an SCC is very likely to break any container that sets `privileged: true` but does not set `allowPrivilegeEscalation: true` (as one would expect that to be implied by the system).