### PR TITLE
[4.7] Bug 1971087: add a controller to remove webhooktokenauthenticator config

### DIFF
--- a/pkg/controllers/webhooksremover/webhooksremover.go
+++ b/pkg/controllers/webhooksremover/webhooksremover.go
@@ -1,0 +1,67 @@
+package webhooksremover
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type webhooksRemoverController struct {
+	authConfigClient configv1client.AuthenticationInterface
+	authConfigLister configv1listers.AuthenticationLister
+}
+
+// NewWebhooksRemoverController creates a controller that removes the WebhookTokenAuthenticator
+// configuration from the authentication.config object.
+// This controller exists in case of a downgrade from OCP versions where this field
+// is being set by this very operator. If left unset, this field would render the
+// cluster unupgradable.
+func NewWebhooksRemoverController(
+	operatorClient v1helpers.OperatorClient,
+	authConfigClient configv1client.AuthenticationInterface,
+	authConfigInformer configv1informers.SharedInformerFactory,
+	eventsRecorder events.Recorder,
+) factory.Controller {
+	c := webhooksRemoverController{
+		authConfigClient: authConfigClient,
+		authConfigLister: authConfigInformer.Config().V1().Authentications().Lister(),
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithSyncDegradedOnError(operatorClient).
+		WithInformers(
+			operatorClient.Informer(),
+			authConfigInformer.Config().V1().Authentications().Informer(),
+		).
+		ToController("WebhooksRemover", eventsRecorder.WithComponentSuffix("webhooks-remover"))
+}
+
+func (c *webhooksRemoverController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	authConfig, err := c.authConfigLister.Get("cluster")
+	if err != nil {
+		return err
+	}
+
+	if authConfig.Spec.Type != configv1.AuthenticationTypeIntegratedOAuth && len(authConfig.Spec.Type) != 0 {
+		// not using integrated openshift auth
+		return nil
+	}
+
+	if authConfig.Spec.WebhookTokenAuthenticator == nil {
+		return nil
+	}
+
+	authConfigCopy := authConfig.DeepCopy()
+	authConfigCopy.Spec.WebhookTokenAuthenticator = nil
+
+	_, err = c.authConfigClient.Update(ctx, authConfigCopy, v1.UpdateOptions{})
+	return err
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -62,6 +62,7 @@ import (
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/routercerts"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/serviceca"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/targetversion"
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/webhooksremover"
 	"github.com/openshift/cluster-authentication-operator/pkg/operator/assets"
 	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
 	"github.com/openshift/cluster-authentication-operator/pkg/operator/encryptionprovider"
@@ -406,6 +407,13 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		operatorCtx.operatorClient,
 	)
 
+	webhooksRemover := webhooksremover.NewWebhooksRemoverController(
+		operatorCtx.operatorClient,
+		operatorCtx.configClient.ConfigV1().Authentications(),
+		operatorCtx.operatorConfigInformer,
+		controllerContext.EventRecorder,
+	)
+
 	// TODO remove this controller once we support Removed
 	managementStateController := management.NewOperatorManagementStateController("authentication", operatorCtx.operatorClient, controllerContext.EventRecorder)
 	management.SetOperatorNotRemovable()
@@ -431,6 +439,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		authRouteCheckController.Run,
 		authServiceCheckController.Run,
 		authServiceEndpointCheckController.Run,
+		webhooksRemover.Run,
 		workersAvailableController.Run,
 		proxyConfigController.Run,
 		func(ctx context.Context, workers int) { staleConditions.Run(ctx, workers) },


### PR DESCRIPTION
In 4.8, we're configuring the
authentication.spec.webhookTokenAuthenticator field. However, in 4.7,
having this field configured makes the kube-apiserver-operator
mark the cluster as "upgradable=false".

We need to unset the field in 4.7 in order to prevent a downgraded
cluster to become unupgradable.

/assign @deads2k 