### PR TITLE
e2e: remove workaround for early progressing=false

### DIFF
--- a/test/e2e/tokentimeout_test.go
+++ b/test/e2e/tokentimeout_test.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 
 	oauthapi "github.com/openshift/api/oauth/v1"
 	userapi "github.com/openshift/api/user/v1"
@@ -112,8 +111,6 @@ func TestTokenInactivityTimeout(t *testing.T) {
 		require.NoError(t, err, "authentication operator never became progressing")
 		err = test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(t, configClient, "authentication")
 		require.NoError(t, err)
-		client := kubernetes.NewForConfigOrDie(kubeConfig)
-		waitOAuthServerReplicasReady(t, client)
 
 		checkTokenAccess(t, userClient, oauthClientClient, configInactivityTimeout, nil, testInactivityTimeoutScenarios)
 	})
@@ -131,8 +128,6 @@ func TestTokenInactivityTimeout(t *testing.T) {
 		require.NoError(t, err, "authentication operator never became progressing")
 		err = test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(t, configClient, "authentication")
 		require.NoError(t, err)
-		client := kubernetes.NewForConfigOrDie(kubeConfig)
-		waitOAuthServerReplicasReady(t, client)
 
 		checkTokenAccess(t, userClient, oauthClientClient, configInactivityTimeout, nil, testTokenTimeouts)
 	})
@@ -304,24 +299,4 @@ func createOAuthClient(t *testing.T, oauthClientClient *oauthclient.OauthV1Clien
 			t.Logf("%v", err)
 		}
 	}
-}
-
-func waitOAuthServerReplicasReady(t *testing.T, kubeClient kubernetes.Interface) {
-	t.Logf("waiting all oauth-apiserver replicas to be updated and ready")
-
-	err := wait.PollImmediate(time.Second, 10*time.Minute, func() (bool, error) {
-		deployment, err := kubeClient.AppsV1().Deployments("openshift-oauth-apiserver").Get(context.Background(), "apiserver", metav1.GetOptions{})
-		if err != nil {
-			t.Logf("failed to retrieve oauth-apiserver's deployment: %v", err)
-			return false, nil
-		}
-
-		var requestedReplicas int32 = 1
-		if specReplicas := deployment.Spec.Replicas; specReplicas != nil {
-			requestedReplicas = *specReplicas
-		}
-		return requestedReplicas == deployment.Status.ReadyReplicas && deployment.Status.UpdatedReplicas == requestedReplicas, nil
-	})
-	require.NoError(t, err)
-
 }


### PR DESCRIPTION
the related lib-go changes about workloads progressing have been pushed to lib-go and merged in another PR