### PR TITLE
expose pod information to oauth-apiserver container via env variables

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -75,6 +75,15 @@ spec:
           requests:
             memory: 200Mi
             cpu: 150m
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         # we need to set this to privileged to be able to write audit to /var/log/oauth-apiserver
         securityContext:
           privileged: true

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -353,6 +353,15 @@ spec:
           requests:
             memory: 200Mi
             cpu: 150m
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         # we need to set this to privileged to be able to write audit to /var/log/oauth-apiserver
         securityContext:
           privileged: true

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "8cd028ac0830a64f052c69de498a9e13569ac9af1187f370b740f8e027473c3c"
+    operator.openshift.io/spec-hash: "ee310bca2dd9a4049a5ed7aeecb2e5e155af7eeaa071aebd484ae8a49a47dee6"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -78,6 +78,15 @@ spec:
             requests:
               cpu: 150m
               memory: 200Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "0155b7ef3a6af0aeb538a94741635e4b90c4b7ebdf1b90ee9baba16599c2813a"
+    operator.openshift.io/spec-hash: "cabcad5486ba4d89079410e4ce1957f04c0598a4ba7c106f9482e674c2c1cd21"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -87,6 +87,15 @@ spec:
             requests:
               cpu: 150m
               memory: 200Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "2323af5c89a5e6d33b0acb47c691090516c92006e7aae97720d5e824b3f96977"
+    operator.openshift.io/spec-hash: "51595c0782015980457c34cca1a1e9171f492b2d4ae16e021582c596e95de9a0"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -82,6 +82,15 @@ spec:
             requests:
               cpu: 150m
               memory: 200Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
the pod name and the namespace are used by the termination code to properly record events.

before the change the termination events were recorded to the default namespace and weren't associated with any pod.
after the change the termination evens are recorded in the openshift-oauth-apiserver namespace and are bound to oauth-apiserver pods.