### PR TITLE
Bug 1943442: redeploy with maxSurge=1 in single-node to avoid unavailability

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -58,12 +58,15 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             fi
+            echo -b "Rotating audit logs in /var/log/oauth-apiserver"
+            test -f /var/log/oauth-apiserver/audit.log && mv /var/log/oauth-apiserver/audit{,-$(date '+%Y-%m-%dT%H-%M-%S.%3N')}.log
+            echo
             exec oauth-apiserver start \
               --secure-port=8443 \
               --audit-log-path=/var/log/oauth-apiserver/audit.log \
               --audit-log-format=json \
               --audit-log-maxsize=100 \
-              --audit-log-maxbackup=10 \
+              --audit-log-maxage=3 \
               --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \

--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -8,16 +8,6 @@ metadata:
     apiserver: "true"
 # The number of replicas will be set in code to the number of master nodes.
 spec:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      # To ensure that only one pod at a time writes to the node's
-      # audit log, require the update strategy to proceed a node at a
-      # time. Only when a master node has its existing
-      # oauth-apiserver pod stopped will a new one be allowed to
-      # start.
-      maxUnavailable: 1
-      maxSurge: 0
   selector:
     matchLabels:
       app: openshift-oauth-apiserver

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -286,16 +286,6 @@ metadata:
     apiserver: "true"
 # The number of replicas will be set in code to the number of master nodes.
 spec:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      # To ensure that only one pod at a time writes to the node's
-      # audit log, require the update strategy to proceed a node at a
-      # time. Only when a master node has its existing
-      # oauth-apiserver pod stopped will a new one be allowed to
-      # start.
-      maxUnavailable: 1
-      maxSurge: 0
   selector:
     matchLabels:
       app: openshift-oauth-apiserver

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -336,12 +336,15 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             fi
+            echo -b "Rotating audit logs in /var/log/oauth-apiserver"
+            test -f /var/log/oauth-apiserver/audit.log && mv /var/log/oauth-apiserver/audit{,-$(date '+%Y-%m-%dT%H-%M-%S.%3N')}.log
+            echo
             exec oauth-apiserver start \
               --secure-port=8443 \
               --audit-log-path=/var/log/oauth-apiserver/audit.log \
               --audit-log-format=json \
               --audit-log-maxsize=100 \
-              --audit-log-maxbackup=10 \
+              --audit-log-maxage=3 \
               --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \


### PR DESCRIPTION
- set maxSurge=1, maxUnavailability=0 in single-node on the deployment
- rotate audit logs start to avoid write conflicts