### PR TITLE
extends shutdown delay duration to 10 seconds

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -67,7 +67,7 @@ spec:
               --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-              --shutdown-delay-duration=3s \
+              --shutdown-delay-duration=10s \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -345,7 +345,7 @@ spec:
               --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-              --shutdown-delay-duration=3s \
+              --shutdown-delay-duration=10s \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "8cd028ac0830a64f052c69de498a9e13569ac9af1187f370b740f8e027473c3c"
+    operator.openshift.io/spec-hash: "ad30c07fc0d64b5914b83c364aba4bd14e487e265fb149e2b0bf9939707e5134"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -48,7 +48,7 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=3s \
+                --shutdown-delay-duration=10s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --api-audiences=https://kubernetes.default.svc \

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "0155b7ef3a6af0aeb538a94741635e4b90c4b7ebdf1b90ee9baba16599c2813a"
+    operator.openshift.io/spec-hash: "2401fe738d81595c74678cc3e4ef9e0803525299a29cf92a2187e6322d471840"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -48,7 +48,7 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=3s \
+                --shutdown-delay-duration=10s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --api-audiences=https://kubernetes.default.svc \

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "2323af5c89a5e6d33b0acb47c691090516c92006e7aae97720d5e824b3f96977"
+    operator.openshift.io/spec-hash: "9201dbc347c40eec254f7fdfe3ab896bfe007fdb3bd3bab1e42321ec4bf58791"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -48,7 +48,7 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=3s \
+                --shutdown-delay-duration=10s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --api-audiences=https://kubernetes.default.svc \


### PR DESCRIPTION
the general rule of thumb is to wait ~5s-10s for any service behind the service network.
during that time the controllers should remove the endpoint from the pool and the applicaiton won't receive any new connections.