### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -28,6 +28,8 @@ spec:
       labels:
         app: openshift-oauth-apiserver
         apiserver: "true"
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: oauth-apiserver-sa
       priorityClassName: system-node-critical

--- a/bindata/oauth-apiserver/ns.yaml
+++ b/bindata/oauth-apiserver/ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-oauth-apiserver
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -20,6 +20,8 @@ spec:
       name: oauth-openshift
       labels:
         app: oauth-openshift
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift

--- a/bindata/oauth-openshift/ns.yaml
+++ b/bindata/oauth-openshift/ns.yaml
@@ -4,5 +4,6 @@ metadata:
   name: openshift-authentication
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -20,6 +20,8 @@ spec:
       name: authentication-operator
       labels:
         app: authentication-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: authentication-operator
       containers:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -306,6 +306,8 @@ spec:
       labels:
         app: openshift-oauth-apiserver
         apiserver: "true"
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: oauth-apiserver-sa
       priorityClassName: system-node-critical
@@ -455,6 +457,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-oauth-apiserver
   labels:
     openshift.io/cluster-monitoring: "true"
@@ -630,6 +633,8 @@ spec:
       name: oauth-openshift
       labels:
         app: oauth-openshift
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift
@@ -801,6 +806,7 @@ metadata:
   name: openshift-authentication
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
 `)

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "ad30c07fc0d64b5914b83c364aba4bd14e487e265fb149e2b0bf9939707e5134"
+    operator.openshift.io/spec-hash: "10646c8cfd2765b3d2ccbae9356a26126307aacbfbe2a8e947ce41bc01583e13"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -30,6 +30,8 @@ spec:
         app: openshift-oauth-apiserver
         revision: '0'
       name: openshift-oauth-apiserver
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "2401fe738d81595c74678cc3e4ef9e0803525299a29cf92a2187e6322d471840"
+    operator.openshift.io/spec-hash: "5dd11b47293e61e26f8cfb4c07f02b1d431fb2633c8d0eeb53350080fe5fb5ce"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -30,6 +30,8 @@ spec:
         app: openshift-oauth-apiserver
         revision: '0'
       name: openshift-oauth-apiserver
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "9201dbc347c40eec254f7fdfe3ab896bfe007fdb3bd3bab1e42321ec4bf58791"
+    operator.openshift.io/spec-hash: "10c95b41be09423bb1154e3be831ecea4a9c56ed7ca333ddb68d3677bf80b114"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -30,6 +30,8 @@ spec:
         app: openshift-oauth-apiserver
         revision: '0'
       name: openshift-oauth-apiserver
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         -


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.