### PR TITLE
Bug 1946540: only configure webhook authenticators when oauth-apiservers are ready during upgrade

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -627,6 +627,7 @@ func prepareOauthAPIServerOperator(ctx context.Context, controllerContext *contr
 		operatorCtx.configClient.ConfigV1().Authentications(),
 		operatorCtx.operatorClient.Client,
 		operatorCtx.operatorClient,
+		operatorCtx.versionRecorder,
 		eventRecorder,
 	)
 


### PR DESCRIPTION
If we configure the webhook authenticators too early during an upgrade,
we might end up with apiservers that are incapable of handling
TokenReviews. Make sure that the version of the oauth-apiserver payload
in the version getter global to the operator is current if it is set.
If it is unset, this should not be an upgrade.

/assign @deads2k 