### PR TITLE
Rename workload annotations

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -29,7 +29,7 @@ spec:
         app: openshift-oauth-apiserver
         apiserver: "true"
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: oauth-apiserver-sa
       priorityClassName: system-node-critical

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: oauth-openshift
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: authentication-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: authentication-operator
       containers:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -307,7 +307,7 @@ spec:
         app: openshift-oauth-apiserver
         apiserver: "true"
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: oauth-apiserver-sa
       priorityClassName: system-node-critical
@@ -634,7 +634,7 @@ spec:
       labels:
         app: oauth-openshift
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "10646c8cfd2765b3d2ccbae9356a26126307aacbfbe2a8e947ce41bc01583e13"
+    operator.openshift.io/spec-hash: "184fec9ba339674f4104966f3ecd5639e637d0cdf49f50acc5270c8d432c58d0"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -31,7 +31,7 @@ spec:
         revision: '0'
       name: openshift-oauth-apiserver
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "5dd11b47293e61e26f8cfb4c07f02b1d431fb2633c8d0eeb53350080fe5fb5ce"
+    operator.openshift.io/spec-hash: "24a0c678eca3b5aa1cf792f9ce12185eabff4200cfc6dfd8412072e3b9ea99f6"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -31,7 +31,7 @@ spec:
         revision: '0'
       name: openshift-oauth-apiserver
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "10c95b41be09423bb1154e3be831ecea4a9c56ed7ca333ddb68d3677bf80b114"
+    operator.openshift.io/spec-hash: "4bab5bda94f4ab35f1575ddf28607cefed18b93be7fbaa43e9bdf4b220272377"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -31,7 +31,7 @@ spec:
         revision: '0'
       name: openshift-oauth-apiserver
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         -


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please