### PR TITLE
 Bug 1950379: routersecret: sync only the cert/key pair for the default domain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,12 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/openshift/api v0.0.0-20210331193751-3acddb19d360
 	github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
 	github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc
+	github.com/openshift/library-go v0.0.0-20210511071040-c52a0262d4a2
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -131,9 +131,8 @@ github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQo
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -407,8 +406,8 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f h1:MAFVN4yW6pP
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc h1:tywho0nChchtAD4E2YmlX9MWQ3CBoWT49GrTHfM2+ss=
-github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210511071040-c52a0262d4a2 h1:QY4RMZDZntfxY0YRstkX3itJ6ISZs+3VTHk3fpUinv0=
+github.com/openshift/library-go v0.0.0-20210511071040-c52a0262d4a2/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -652,7 +651,6 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/controllers/common/config.go
+++ b/pkg/controllers/common/config.go
@@ -3,9 +3,13 @@ package common
 import (
 	"bytes"
 	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/openshift/library-go/pkg/controller/factory"
 )
 
 // UnstructuredConfigFrom returns the configuration from the operator's observedConfig field in the subtree given by the prefix
@@ -25,4 +29,16 @@ func UnstructuredConfigFrom(observedBytes []byte, prefix ...string) ([]byte, err
 	}
 
 	return json.Marshal(actualConfig)
+}
+
+// TODO: this should be in library-go
+func NamesFilter(names ...string) factory.EventFilterFunc {
+	nameSet := sets.NewString(names...)
+	return func(obj interface{}) bool {
+		metaObj, ok := obj.(metav1.ObjectMetaAccessor)
+		if !ok {
+			return false
+		}
+		return nameSet.Has(metaObj.GetObjectMeta().GetName())
+	}
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -223,14 +223,6 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		return err
 	}
 
-	// add syncing for router certs for all cluster ingresses
-	if err := operatorCtx.resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: "openshift-authentication", Name: "v4-0-config-system-router-certs"},
-		resourcesynccontroller.ResourceLocation{Namespace: "openshift-config-managed", Name: "router-certs", Provider: "ingress-operator"},
-	); err != nil {
-		return err
-	}
-
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		"authentication",
 		[]configv1.ObjectReference{
@@ -302,9 +294,11 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 
 	routerCertsController := routercerts.NewRouterCertsDomainValidationController(
 		operatorCtx.operatorClient,
+		operatorCtx.kubeClient.CoreV1(),
 		controllerContext.EventRecorder,
 		operatorCtx.operatorConfigInformer.Config().V1().Ingresses(),
 		openshiftAuthenticationInformers.Core().V1().Secrets(),
+		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets(),
 		operatorCtx.kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().ConfigMaps(),
 		"openshift-authentication",
 		"v4-0-config-system-router-certs",

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/preconditions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/preconditions.go
@@ -1,0 +1,115 @@
+package encryption
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type preconditionChecker struct {
+	component                string
+	encryptionSecretSelector labels.Selector
+
+	secretLister          corev1listers.SecretNamespaceLister
+	apiServerConfigLister configv1listers.APIServerLister
+
+	cacheSynced []cache.InformerSynced
+}
+
+// newEncryptionEnabledPrecondition determines if encryption controllers should synchronise.
+// It uses the cache for gathering data to avoid sending requests to the API servers.
+func newEncryptionEnabledPrecondition(apiServerConfigInformer configv1informers.APIServerInformer, kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces, encryptionSecretSelectorString string) (*preconditionChecker, error) {
+	encryptionSecretSelector, err := labels.Parse(encryptionSecretSelectorString)
+	if err != nil {
+		return nil, err
+	}
+	return &preconditionChecker{
+		encryptionSecretSelector: encryptionSecretSelector,
+		secretLister:             kubeInformersForNamespaces.SecretLister().Secrets("openshift-config-managed"),
+		apiServerConfigLister:    apiServerConfigInformer.Lister(),
+		cacheSynced: []cache.InformerSynced{
+			apiServerConfigInformer.Informer().HasSynced,
+			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer().HasSynced,
+		},
+	}, nil
+}
+
+// PreconditionFulfilled a method that indicates whether all prerequisites are met and we can Sync.
+func (pc *preconditionChecker) PreconditionFulfilled() (bool, error) {
+	if !pc.hasCachesSynced() {
+		// at this point we are unable to perform our checks
+		// report there is work to do so that controllers run their sync loops
+		klog.V(4).Info("unable to check preconditions. The caches haven't been synchronized. Forcing the encryption controllers to run their sync loops.")
+		return true, nil
+	}
+
+	encryptionWasEnabled, err := pc.encryptionWasEnabled()
+	if err != nil {
+		return false, err // got an error, report it and run the sync loops
+	}
+	if !encryptionWasEnabled {
+		return false, nil // encryption hasn't been enabled - no work to do
+	}
+
+	// TODO: add a step that would determine if encryption is disabled on previously encrypted clusters that would require:
+	//       having the current mode set to Identity
+	//       having all servers on the same revision
+	//       having desired and actual encryption configuration aligned
+	//       having all resources migrated
+
+	return true, nil // we might have work to do
+}
+
+// encryptionWasEnabled checks whether encryption was enabled on a cluster. It wasn't enabled when:
+//   a server configuration doesn't exist
+//   the current encryption mode is empty or set to identity mode and
+//   a secret with encryption configuration doesn't exist in the managed namespace and
+//   secrets with encryption keys don't exist in the managed namespace
+func (pc *preconditionChecker) encryptionWasEnabled() (bool, error) {
+	apiServerConfig, err := pc.apiServerConfigLister.Get("cluster")
+	if errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err // unknown error
+	}
+
+	if currentMode := state.Mode(apiServerConfig.Spec.Encryption.Type); len(currentMode) > 0 && currentMode != state.Identity {
+		return true, nil // encryption might be actually in progress
+	}
+
+	encryptionConfiguration, err := pc.secretLister.Get(fmt.Sprintf("%s-%s", encryptionconfig.EncryptionConfSecretName, pc.component))
+	if err != nil && !errors.IsNotFound(err) {
+		return false, err // unknown error
+	}
+	if encryptionConfiguration != nil {
+		return true, nil
+	}
+
+	// very unlikely - encryption config doesn't exists but we have some encryption keys
+	// but since this is coming from a cache just double check
+
+	encryptionSecrets, err := pc.secretLister.List(pc.encryptionSecretSelector)
+	if err != nil && !errors.IsNotFound(err) {
+		return false, err // unknown error
+	}
+	return len(encryptionSecrets) > 0, nil
+}
+
+func (pc *preconditionChecker) hasCachesSynced() bool {
+	for i := range pc.cacheSynced {
+		if !pc.cacheSynced[i]() {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
@@ -3,23 +3,22 @@ package resourceapply
 import (
 	"context"
 
-	"github.com/imdario/mergo"
-	"k8s.io/klog/v2"
-
+	"github.com/openshift/library-go/pkg/operator/events"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-
-	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/klog/v2"
 )
 
 var serviceMonitorGVR = schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"}
 
-func ensureServiceMonitorSpec(required, existing *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
-	requiredSpec, _, err := unstructured.NestedMap(required.UnstructuredContent(), "spec")
+func ensureGenericSpec(required, existing *unstructured.Unstructured, mimicDefaultingFn mimicDefaultingFunc, equalityChecker equalityChecker) (*unstructured.Unstructured, bool, error) {
+	requiredCopy := required.DeepCopy()
+	mimicDefaultingFn(requiredCopy)
+	requiredSpec, _, err := unstructured.NestedMap(requiredCopy.UnstructuredContent(), "spec")
 	if err != nil {
 		return nil, false, err
 	}
@@ -28,20 +27,31 @@ func ensureServiceMonitorSpec(required, existing *unstructured.Unstructured) (*u
 		return nil, false, err
 	}
 
-	if err := mergo.Merge(&existingSpec, &requiredSpec); err != nil {
-		return nil, false, err
-	}
-
-	if equality.Semantic.DeepEqual(existingSpec, requiredSpec) {
+	if equalityChecker.DeepEqual(existingSpec, requiredSpec) {
 		return existing, false, nil
 	}
 
 	existingCopy := existing.DeepCopy()
-	if err := unstructured.SetNestedMap(existingCopy.UnstructuredContent(), existingSpec, "spec"); err != nil {
+	if err := unstructured.SetNestedMap(existingCopy.UnstructuredContent(), requiredSpec, "spec"); err != nil {
 		return nil, true, err
 	}
 
 	return existingCopy, true, nil
+}
+
+// mimicDefaultingFunc is used to set fields that are defaulted.  This allows for sparse manifests to apply correctly.
+// For instance, if field .spec.foo is set to 10 if not set, then a function of this type could be used to set
+// the field to 10 to match the comparison.  This is soemtimes (often?) easier than updating the semantic equality.
+// We often see this in places like RBAC and CRD.  Logically it can happen generically too.
+type mimicDefaultingFunc func(obj *unstructured.Unstructured)
+
+func noDefaulting(obj *unstructured.Unstructured) {}
+
+// equalityChecker allows for custom equality comparisons.  This can be used to allow equality checks to skip certain
+// operator managed fields.  This capability allows something like .spec.scale to be specified or changed by a component
+// like HPA.  Use this capability sparingly.  Most places ought to just use `equality.Semantic`
+type equalityChecker interface {
+	DeepEqual(a1, a2 interface{}) bool
 }
 
 // ApplyServiceMonitor applies the Prometheus service monitor.
@@ -64,25 +74,70 @@ func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, req
 
 	existingCopy := existing.DeepCopy()
 
-	updated, endpointsModified, err := ensureServiceMonitorSpec(required, existingCopy)
+	toUpdate, modified, err := ensureGenericSpec(required, existingCopy, noDefaulting, equality.Semantic)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if !endpointsModified {
+	if !modified {
 		return nil, false, nil
 	}
 
 	if klog.V(4).Enabled() {
-		klog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, existingCopy))
+		klog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 
-	newObj, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Update(context.TODO(), updated, metav1.UpdateOptions{})
+	newObj, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		recorder.Warningf("ServiceMonitorUpdateFailed", "Failed to update ServiceMonitor.monitoring.coreos.com/v1: %v", err)
 		return nil, true, err
 	}
 
 	recorder.Eventf("ServiceMonitorUpdated", "Updated ServiceMonitor.monitoring.coreos.com/v1 because it changed")
+	return newObj, true, err
+}
+
+var prometheusRuleGVR = schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "prometheusrules"}
+
+// ApplyPrometheusRule applies the PrometheusRule
+func ApplyPrometheusRule(client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	namespace := required.GetNamespace()
+
+	existing, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		newObj, createErr := client.Resource(prometheusRuleGVR).Namespace(namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		if createErr != nil {
+			recorder.Warningf("PrometheusRuleCreateFailed", "Failed to create PrometheusRule.monitoring.coreos.com/v1: %v", createErr)
+			return nil, true, createErr
+		}
+		recorder.Eventf("PrometheusRuleCreated", "Created PrometheusRule.monitoring.coreos.com/v1 because it was missing")
+		return newObj, true, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	existingCopy := existing.DeepCopy()
+
+	toUpdate, modified, err := ensureGenericSpec(required, existingCopy, noDefaulting, equality.Semantic)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !modified {
+		return nil, false, nil
+	}
+
+	if klog.V(4).Enabled() {
+		klog.Infof("PrometheusRule %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
+	}
+
+	newObj, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		recorder.Warningf("PrometheusRuleUpdateFailed", "Failed to update PrometheusRule.monitoring.coreos.com/v1: %v", err)
+		return nil, true, err
+	}
+
+	recorder.Eventf("PrometheusRuleUpdated", "Updated PrometheusRule.monitoring.coreos.com/v1 because it changed")
 	return newObj, true, err
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
@@ -12,9 +12,12 @@ import (
 // ApplyKnownUnstructured applies few selected Unstructured types, where it semantic knowledge
 // to merge existing & required objects intelligently. Feel free to add more.
 func ApplyKnownUnstructured(client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
-	serviceMonitorGK := schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}
-	if obj.GetObjectKind().GroupVersionKind().GroupKind() == serviceMonitorGK {
+	switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}:
 		return ApplyServiceMonitor(client, recorder, obj)
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "PrometheusRule"}:
+		return ApplyPrometheusRule(client, recorder, obj)
+
 	}
 
 	return nil, false, fmt.Errorf("unsupported object type: %s", obj.GetKind())

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
@@ -1,9 +1,12 @@
 package resourcemerge
 
 import (
+	"strings"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // EnsureCustomResourceDefinitionV1Beta1 ensures that the existing matches the required.
@@ -23,9 +26,43 @@ func EnsureCustomResourceDefinitionV1Beta1(modified *bool, existing *apiextensio
 func EnsureCustomResourceDefinitionV1(modified *bool, existing *apiextensionsv1.CustomResourceDefinition, required apiextensionsv1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
+	// we need to match defaults
+	mimicCRDV1Defaulting(&required)
 	// we stomp everything
 	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
 		*modified = true
 		existing.Spec = required.Spec
+	}
+}
+
+func mimicCRDV1Defaulting(required *apiextensionsv1.CustomResourceDefinition) {
+	crd_SetDefaults_CustomResourceDefinitionSpec(&required.Spec)
+
+	if required.Spec.Conversion != nil &&
+		required.Spec.Conversion.Webhook != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig.Service != nil {
+		crd_SetDefaults_ServiceReference(required.Spec.Conversion.Webhook.ClientConfig.Service)
+	}
+}
+
+// lifted from https://github.com/kubernetes/kubernetes/blob/v1.21.0/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go#L42-L61
+func crd_SetDefaults_CustomResourceDefinitionSpec(obj *apiextensionsv1.CustomResourceDefinitionSpec) {
+	if len(obj.Names.Singular) == 0 {
+		obj.Names.Singular = strings.ToLower(obj.Names.Kind)
+	}
+	if len(obj.Names.ListKind) == 0 && len(obj.Names.Kind) > 0 {
+		obj.Names.ListKind = obj.Names.Kind + "List"
+	}
+	if obj.Conversion == nil {
+		obj.Conversion = &apiextensionsv1.CustomResourceConversion{
+			Strategy: apiextensionsv1.NoneConverter,
+		}
+	}
+}
+
+func crd_SetDefaults_ServiceReference(obj *apiextensionsv1.ServiceReference) {
+	if obj.Port == nil {
+		obj.Port = utilpointer.Int32Ptr(443)
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -1,5 +1,7 @@
 package resourcesynccontroller
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 // ResourceLocation describes coordinates for a resource to be synced
 type ResourceLocation struct {
 	Namespace string `json:"namespace"`
@@ -10,7 +12,16 @@ type ResourceLocation struct {
 	Provider string `json:"provider,omitempty"`
 }
 
-var emptyResourceLocation = ResourceLocation{}
+type syncRuleSource struct {
+	ResourceLocation
+	syncedKeys sets.String // defines the set of keys to sync from source to dest
+}
+
+type syncRules map[ResourceLocation]syncRuleSource
+
+var (
+	emptyResourceLocation = ResourceLocation{}
+)
 
 // ResourceSyncer allows changes to syncing rules by this controller
 type ResourceSyncer interface {

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -97,7 +97,7 @@ func (c RevisionController) createRevisionIfNeeded(recorder events.Recorder, lat
 
 	nextRevision := latestAvailableRevision + 1
 	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
-	if err := c.createNewRevision(recorder, nextRevision); err != nil {
+	if err := c.createNewRevision(recorder, nextRevision, reason); err != nil {
 		cond := operatorv1.OperatorCondition{
 			Type:    "RevisionControllerDegraded",
 			Status:  operatorv1.ConditionTrue,
@@ -191,7 +191,7 @@ func (c RevisionController) isLatestRevisionCurrent(revision int32) (bool, strin
 	return true, ""
 }
 
-func (c RevisionController) createNewRevision(recorder events.Recorder, revision int32) error {
+func (c RevisionController) createNewRevision(recorder events.Recorder, revision int32, reason string) error {
 	// Create a new InProgress status configmap
 	statusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -201,6 +201,7 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 		Data: map[string]string{
 			"status":   prune.StatusInProgress,
 			"revision": fmt.Sprintf("%d", revision),
+			"reason":   reason,
 		},
 	}
 	statusConfigMap, _, err := resourceapply.ApplyConfigMap(c.configMapGetter, recorder, statusConfigMap)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,8 +25,6 @@ github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.9.0+incompatible
 github.com/evanphx/json-patch
-# github.com/fsnotify/fsnotify v1.4.9
-## explicit
 # github.com/ghodss/yaml v1.0.0
 ## explicit
 github.com/ghodss/yaml
@@ -197,7 +195,7 @@ github.com/openshift/client-go/route/informers/externalversions/route/v1
 github.com/openshift/client-go/route/listers/route/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc
+# github.com/openshift/library-go v0.0.0-20210511071040-c52a0262d4a2
 ## explicit
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
During e2e testing, the routing team is adding additional router which revealed that we may rollout unnecessarily as we don't particularly care about any other but the default router cert/keys.

/hold
contains fake bump on a PoC in lib-go