### PR TITLE
Bug 1953041: manifests/deployment: bump cpu and memory resource requests

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -38,8 +38,8 @@ spec:
           exec authentication-operator operator --config=/var/run/configmaps/config/operator-config.yaml --v=2 --terminate-on-files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt
         resources:
           requests:
-            memory: 50Mi
-            cpu: 10m
+            memory: 200Mi
+            cpu: 20m
         securityContext:
           readOnlyRootFilesystem: false # because of the `cp` in args
         volumeMounts:


### PR DESCRIPTION
This is based on the following measurements on an idle 4.8-ci cluster:

CPU:
![image](https://user-images.githubusercontent.com/375856/117446645-a705b600-af3c-11eb-8eae-96606e06411a.png)

Memory:
![image](https://user-images.githubusercontent.com/375856/117446652-abca6a00-af3c-11eb-8e45-1b4e2f4f8a01.png)

These values are higher than the current settings, but let me know if this increase is concerning.

/cc @sttts @stlaz