### PR TITLE
Bug 1943804: stub for splitting encryption tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,17 @@ test-e2e-encryption: test-unit
 
 test-e2e-encryption-perf: GO_TEST_PACKAGES :=./test/e2e-encryption-perf/...
 test-e2e-encryption-perf: GO_TEST_FLAGS += -v
-test-e2e-encryption-perf: GO_TEST_FLAGS += -timeout 1h
+test-e2e-encryption-perf: GO_TEST_FLAGS += -timeout 2h
 test-e2e-encryption-perf: GO_TEST_FLAGS += -p 1
 test-e2e-encryption-perf: test-unit
 .PHONY: test-e2e-encryption-perf
+
+test-e2e-encryption-rotation: GO_TEST_PACKAGES :=./test/e2e-encryption-rotation/...
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -v
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -timeout 4h
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-rotation: test-unit
+.PHONY: test-e2e-encryption-rotation
 
 # Configure the 'telepresence' target
 # See vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh for usage and configuration details

--- a/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
+++ b/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
@@ -1,0 +1,9 @@
+package e2e_encryption_rotation
+
+import "testing"
+
+// TestEncryptionRotation first encrypts data with aescbc key
+// then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
+func TestEncryptionRotation(t *testing.T) {
+	t.Log("implement me")
+}


### PR DESCRIPTION
We are going to move the rotation tests to a separate CI job. It will shorten the overall time needed to test encryption but also increase the pass rate of the tests as we have seen them frequently failing due to a timeout.

This PR adds only a stub so that the new CI job can be configured.

We have already split the tests for kas-o in openshift/cluster-kube-apiserver-operator#1131