### PR TITLE
Bug 1943804: splits the encryption tests

### DIFF
--- a/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
+++ b/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
@@ -1,9 +1,68 @@
 package e2e_encryption_rotation
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
+	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+)
 
 // TestEncryptionRotation first encrypts data with aescbc key
 // then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
 func TestEncryptionRotation(t *testing.T) {
-	t.Log("implement me")
+	ctx := context.TODO()
+	library.TestEncryptionRotation(t, library.RotationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       "openshift-config-managed",
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-openshift-oauth-apiserver"),
+			EncryptionConfigSecretNamespace: "openshift-config-managed",
+			OperatorNamespace:               "openshift-authentication-operator",
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertTokens,
+		},
+		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, _ string) runtime.Object {
+			return operatorencryption.CreateAndStoreTokenOfLife(ctx, t, operatorencryption.GetClients(t))
+		},
+		GetRawResourceFunc: func(t testing.TB, clientSet library.ClientSet, _ string) string {
+			return operatorencryption.GetRawTokenOfLife(t, clientSet)
+		},
+		UnsupportedConfigFunc: func(rawUnsupportedEncryptionCfg []byte) error {
+			cs := operatorencryption.GetClients(t)
+			authOperator, err := cs.OperatorClient.Get(ctx, "cluster", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			unsupportedConfigAsMap := map[string]interface{}{}
+			if len(authOperator.Spec.UnsupportedConfigOverrides.Raw) > 0 {
+				if err := json.Unmarshal(authOperator.Spec.UnsupportedConfigOverrides.Raw, &unsupportedConfigAsMap); err != nil {
+					return err
+				}
+			}
+			unsupportedEncryptionConfigAsMap := map[string]interface{}{}
+			if err := json.Unmarshal(rawUnsupportedEncryptionCfg, &unsupportedEncryptionConfigAsMap); err != nil {
+				return err
+			}
+			if err := unstructured.SetNestedMap(unsupportedConfigAsMap, unsupportedEncryptionConfigAsMap, oauthapiconfigobservercontroller.OAuthAPIServerConfigPrefix); err != nil {
+				return err
+			}
+			rawUnsupportedCfg, err := json.Marshal(unsupportedConfigAsMap)
+			if err != nil {
+				return err
+			}
+			authOperator.Spec.UnsupportedConfigOverrides.Raw = rawUnsupportedCfg
+
+			_, err = cs.OperatorClient.Update(ctx, authOperator, metav1.UpdateOptions{})
+			return err
+		},
+	})
 }

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -2,15 +2,11 @@ package e2eencryption
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
 	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
 )
@@ -57,57 +53,5 @@ func TestEncryptionTurnOnAndOff(t *testing.T) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertTokenOfLifeNotEncrypted,
 		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.TokenOfLife(t) },
 		ResourceName:                   "TokenOfLife",
-	})
-}
-
-// TestEncryptionRotation first encrypts data with aescbc key
-// then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
-func TestEncryptionRotation(t *testing.T) {
-	ctx := context.TODO()
-	library.TestEncryptionRotation(t, library.RotationScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       "openshift-config-managed",
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-openshift-oauth-apiserver"),
-			EncryptionConfigSecretNamespace: "openshift-config-managed",
-			OperatorNamespace:               "openshift-authentication-operator",
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertTokens,
-		},
-		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, _ string) runtime.Object {
-			return operatorencryption.CreateAndStoreTokenOfLife(ctx, t, operatorencryption.GetClients(t))
-		},
-		GetRawResourceFunc: func(t testing.TB, clientSet library.ClientSet, _ string) string {
-			return operatorencryption.GetRawTokenOfLife(t, clientSet)
-		},
-		UnsupportedConfigFunc: func(rawUnsupportedEncryptionCfg []byte) error {
-			cs := operatorencryption.GetClients(t)
-			authOperator, err := cs.OperatorClient.Get(ctx, "cluster", metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-
-			unsupportedConfigAsMap := map[string]interface{}{}
-			if len(authOperator.Spec.UnsupportedConfigOverrides.Raw) > 0 {
-				if err := json.Unmarshal(authOperator.Spec.UnsupportedConfigOverrides.Raw, &unsupportedConfigAsMap); err != nil {
-					return err
-				}
-			}
-			unsupportedEncryptionConfigAsMap := map[string]interface{}{}
-			if err := json.Unmarshal(rawUnsupportedEncryptionCfg, &unsupportedEncryptionConfigAsMap); err != nil {
-				return err
-			}
-			if err := unstructured.SetNestedMap(unsupportedConfigAsMap, unsupportedEncryptionConfigAsMap, oauthapiconfigobservercontroller.OAuthAPIServerConfigPrefix); err != nil {
-				return err
-			}
-			rawUnsupportedCfg, err := json.Marshal(unsupportedConfigAsMap)
-			if err != nil {
-				return err
-			}
-			authOperator.Spec.UnsupportedConfigOverrides.Raw = rawUnsupportedCfg
-
-			_, err = cs.OperatorClient.Update(ctx, authOperator, metav1.UpdateOptions{})
-			return err
-		},
 	})
 }


### PR DESCRIPTION
The current timeout for all encryption test is 4 hours.
Previously the time needed to roll out a new KAS was 15 minutes, due to a known issue on AWS with the NLB it can take now 22 minutes.
It means that the tests need ~25 min to make sure that all servers are on the same revision and it is safe to start the test.

Since the rotation scenario needs to enable the encryption first, then wait and check if all resources were migrated, then change the encryption key and check the migration again.
It means that only these tests will need ~1 hour just for installing the servers.

Thus this PR moves the rotation tests to a separate CI job.
It will shorten the overall time needed to test encryption but also increase the pass rate of the tests as we have seen them frequently failing to due to a timeout.

xref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1079