### PR TITLE
Bug 1969631: encryption controllers wait for all informers before running the sync loops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210609085852-3ea492dfde03
+	github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210609085852-3ea492dfde03 h1:vWDknzDw3C75LJsDW3OK+UVek/mmRZrCKZUZXnBDiIo=
-github.com/openshift/library-go v0.0.0-20210609085852-3ea492dfde03/go.mod h1:D0QEmUeYyWP9ORJ92EprPOMkiFg72yX8GM9KxajnMAI=
+github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255 h1:4lXXCXSNmAD56T+lL0CRQfm4aImnb1I6Va9QVtN/d+Q=
+github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
@@ -42,7 +42,7 @@ func NewControllers(
 	// TODO: update the eventHandlers used by the controllers to ignore components that do not match their own
 	encryptionSecretSelector := metav1.ListOptions{LabelSelector: secrets.EncryptionKeySecretsLabel + "=" + component}
 
-	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer, kubeInformersForNamespaces, encryptionSecretSelector.LabelSelector)
+	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer.Lister(), kubeInformersForNamespaces, encryptionSecretSelector.LabelSelector, component)
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +69,7 @@ func NewControllers(
 				deployer,
 				encryptionEnabledChecker.PreconditionFulfilled,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,
@@ -79,6 +80,7 @@ func NewControllers(
 				deployer,
 				encryptionEnabledChecker.PreconditionFulfilled,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,
@@ -91,6 +93,7 @@ func NewControllers(
 				encryptionEnabledChecker.PreconditionFulfilled,
 				migrator,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,
@@ -101,6 +104,7 @@ func NewControllers(
 				deployer,
 				encryptionEnabledChecker.PreconditionFulfilled,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -38,6 +39,7 @@ func NewConditionController(
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -56,6 +58,7 @@ func NewConditionController(
 	return factory.New().WithInformers(
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
 		operatorClient.Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ResyncEvery(time.Minute).WithSync(c.sync).ToController("EncryptionConditionController", eventRecorder.WithComponentSuffix("encryption-condition-controller"))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
@@ -19,6 +19,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
@@ -75,6 +76,7 @@ func NewMigrationController(
 	preconditionsFulfilledFn preconditionsFulfilled,
 	migrator migrators.Migrator,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -97,6 +99,7 @@ func NewMigrationController(
 		migrator,
 		operatorClient.Informer(),
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-migration-controller"))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
@@ -16,6 +16,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -51,6 +52,7 @@ func NewPruneController(
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -69,6 +71,7 @@ func NewPruneController(
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithInformers(
 		operatorClient.Informer(),
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-prune-controller"))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
@@ -13,6 +13,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -53,6 +54,7 @@ func NewStateController(
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -74,6 +76,7 @@ func NewStateController(
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithInformers(
 		operatorClient.Informer(),
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-state-controller"))
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/preconditions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/preconditions.go
@@ -3,17 +3,13 @@ package encryption
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
-
-	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 type preconditionChecker struct {
@@ -22,37 +18,26 @@ type preconditionChecker struct {
 
 	secretLister          corev1listers.SecretNamespaceLister
 	apiServerConfigLister configv1listers.APIServerLister
-
-	cacheSynced []cache.InformerSynced
 }
 
 // newEncryptionEnabledPrecondition determines if encryption controllers should synchronise.
 // It uses the cache for gathering data to avoid sending requests to the API servers.
-func newEncryptionEnabledPrecondition(apiServerConfigInformer configv1informers.APIServerInformer, kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces, encryptionSecretSelectorString string) (*preconditionChecker, error) {
+func newEncryptionEnabledPrecondition(apiServerConfigLister configv1listers.APIServerLister, kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces, encryptionSecretSelectorString, component string) (*preconditionChecker, error) {
 	encryptionSecretSelector, err := labels.Parse(encryptionSecretSelectorString)
 	if err != nil {
 		return nil, err
 	}
 	return &preconditionChecker{
+		component:                component,
 		encryptionSecretSelector: encryptionSecretSelector,
 		secretLister:             kubeInformersForNamespaces.SecretLister().Secrets("openshift-config-managed"),
-		apiServerConfigLister:    apiServerConfigInformer.Lister(),
-		cacheSynced: []cache.InformerSynced{
-			apiServerConfigInformer.Informer().HasSynced,
-			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer().HasSynced,
-		},
+		apiServerConfigLister:    apiServerConfigLister,
 	}, nil
 }
 
 // PreconditionFulfilled a method that indicates whether all prerequisites are met and we can Sync.
+// This method MUST be call after the informers synced
 func (pc *preconditionChecker) PreconditionFulfilled() (bool, error) {
-	if !pc.hasCachesSynced() {
-		// at this point we are unable to perform our checks
-		// report there is work to do so that controllers run their sync loops
-		klog.V(4).Info("unable to check preconditions. The caches haven't been synchronized. Forcing the encryption controllers to run their sync loops.")
-		return true, nil
-	}
-
 	encryptionWasEnabled, err := pc.encryptionWasEnabled()
 	if err != nil {
 		return false, err // got an error, report it and run the sync loops
@@ -103,13 +88,4 @@ func (pc *preconditionChecker) encryptionWasEnabled() (bool, error) {
 		return false, err // unknown error
 	}
 	return len(encryptionSecrets) > 0, nil
-}
-
-func (pc *preconditionChecker) hasCachesSynced() bool {
-	for i := range pc.cacheSynced {
-		if !pc.cacheSynced[i]() {
-			return false
-		}
-	}
-	return true
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -28,7 +28,7 @@ import (
 // PruneController is a controller that watches static installer pod revision statuses and spawns
 // a pruner pod to delete old revision resources from disk
 type PruneController struct {
-	targetNamespace, podResourcePrefix string
+	targetNamespace, podResourcePrefix, certDir string
 	// command is the string to use for the pruning pod command
 	command []string
 
@@ -57,6 +57,7 @@ const (
 func NewPruneController(
 	targetNamespace string,
 	podResourcePrefix string,
+	certDir string,
 	command []string,
 	configMapGetter corev1client.ConfigMapsGetter,
 	secretGetter corev1client.SecretsGetter,
@@ -67,6 +68,7 @@ func NewPruneController(
 	c := &PruneController{
 		targetNamespace:   targetNamespace,
 		podResourcePrefix: podResourcePrefix,
+		certDir:           certDir,
 		command:           command,
 
 		operatorClient:  operatorClient,
@@ -225,6 +227,7 @@ func (c *PruneController) ensurePrunePod(recorder events.Recorder, nodeName stri
 		fmt.Sprintf("--max-eligible-revision=%d", maxEligibleRevision),
 		fmt.Sprintf("--protected-revisions=%s", revisionsToString(protectedRevisions)),
 		fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
+		fmt.Sprintf("--cert-dir=%s", c.certDir),
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
 	)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,7 +199,7 @@ github.com/openshift/client-go/route/informers/externalversions/route/v1
 github.com/openshift/client-go/route/listers/route/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20210609085852-3ea492dfde03
+# github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255
 ## explicit
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
Before this change, the precondition checker could run the encryption controllers when the caches haven't been synchronized.
During synchronization, the controllers send live requests to the API server.
A **single** failed request can put a controller into a degraded state and leave it in that state forever. 

Thus the precondition function MUST be called after the caches were synchronized. This PR ensures that.

For example, in [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade/1400652395809083392/artifacts/e2e-aws-upgrade/) CI run the `kas-o` operator acquired a lock at `03:33:24`:

at `03:33:40` the `EncryptionPruneControllerDegraded` went degraded and **never** recovered.

around the same time, a few other controllers (`ResourceSyncControllerDegraded`, `RevisionControllerDegraded`, `TargetConfigControllerDegraded`) went degraded due to the same reason (`etcdserver: request timed out`) but recovered a few seconds later, around `03:33:55`