### PR TITLE
Bug 1977054: observe api-audiences for the oauth-apiserver

### DIFF
--- a/pkg/operator/configobservation/authentication/apiaudiences.go
+++ b/pkg/operator/configobservation/authentication/apiaudiences.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
+)
+
+var (
+	audiencesPath = []string{"apiServerArguments", "api-audiences"}
+)
+
+// ObserveAPIAudiences changes apiServerArguments.api-audiences from
+// the default value if Authentication.Spec.ServiceAccountIssuer specifies a valid
+// non-empty value.
+func ObserveAPIAudiences(
+	genericListers configobserver.Listers,
+	recorder events.Recorder,
+	existingConfig map[string]interface{},
+) (ret map[string]interface{}, errs []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, audiencesPath)
+	}()
+
+	listers := genericListers.(configobservation.Listers)
+	errs = []error{}
+	var issuerChanged bool
+	var existingAudience, newAudience string
+	// when the issuer will change, indicate that by setting `issuerChanged` to true
+	// to emit the informative event
+	defer func() {
+		if !issuerChanged {
+			return
+		}
+
+		recorder.Eventf(
+			"ObserveAPIAudiences",
+			"service account issuer changed from %s to %s",
+			existingAudience, newAudience,
+		)
+	}()
+
+	existingAudiences, _, err := unstructured.NestedStringSlice(existingConfig, audiencesPath...)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("unable to extract service account issuer from unstructured: %v", err))
+	}
+
+	// we're using the value of authentication.spec.issuer which is always a string, not a slice
+	if len(existingAudiences) > 0 {
+		existingAudience = existingAudiences[0]
+	}
+
+	authConfig, err := listers.AuthConfigLister().Get("cluster")
+	if apierrors.IsNotFound(err) {
+		klog.Warningf("authentications.config.openshift.io/cluster: not found")
+		// No issuer if the auth config is missing
+		authConfig = &configv1.Authentication{}
+	} else if err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	newAudience = authConfig.Spec.ServiceAccountIssuer
+	if len(newAudience) == 0 {
+		newAudience = "https://kubernetes.default.svc"
+	} else if err := checkIssuer(newAudience); err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	// set `issuerChanged` to emit an event about config change in defer
+	issuerChanged = existingAudience != newAudience
+
+	return map[string]interface{}{
+		"apiServerArguments": map[string]interface{}{
+			"api-audiences": []interface{}{
+				newAudience,
+			},
+		},
+	}, errs
+}
+
+// checkIssuer validates the issuer in the same way that it will be validated by
+// kube-apiserver
+func checkIssuer(issuer string) error {
+	if !strings.Contains(issuer, ":") {
+		return nil
+	}
+	// If containing a colon, must parse without error as a url
+	_, err := url.Parse(issuer)
+	if err != nil {
+		return fmt.Errorf("service-account issuer contained a ':' but was not a valid URL: %v", err)
+	}
+	return nil
+}

--- a/pkg/operator/configobservation/authentication/apiaudiences_test.go
+++ b/pkg/operator/configobservation/authentication/apiaudiences_test.go
@@ -1,0 +1,123 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
+)
+
+func TestObservedConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		issuer            string
+		authMissing       bool
+		existingIssuer    string
+		expectedAudiences string
+		expectedChange    bool
+	}{
+		{
+			name:              "no issuer, no previous issuer",
+			existingIssuer:    "",
+			issuer:            "",
+			expectedAudiences: "https://kubernetes.default.svc",
+			expectedChange:    true,
+		},
+		{
+			name:              "no issuer, default already observed",
+			existingIssuer:    "https://kubernetes.default.svc",
+			issuer:            "",
+			expectedAudiences: "https://kubernetes.default.svc",
+		},
+		{
+			name:              "no issuer, previous issuer set",
+			existingIssuer:    "https://example.com",
+			issuer:            "",
+			expectedAudiences: "https://kubernetes.default.svc",
+			expectedChange:    true,
+		},
+		{
+			name:              "issuer set, no previous issuer",
+			existingIssuer:    "",
+			issuer:            "https://example.com",
+			expectedAudiences: "https://example.com",
+			expectedChange:    true,
+		},
+		{
+			name:              "issuer set, previous issuer same",
+			existingIssuer:    "https://example.com",
+			issuer:            "https://example.com",
+			expectedAudiences: "https://example.com",
+		},
+		{
+			name:              "issuer set, previous issuer different",
+			existingIssuer:    "https://example.com",
+			issuer:            "https://example2.com",
+			expectedAudiences: "https://example2.com",
+			expectedChange:    true,
+		},
+		{
+			name:              "auth missing",
+			existingIssuer:    "https://example2.com",
+			issuer:            "",
+			authMissing:       true,
+			expectedChange:    true,
+			expectedAudiences: "https://kubernetes.default.svc",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if !tc.authMissing {
+				authConfig := authConfigForIssuer(tc.issuer)
+
+				err := indexer.Add(authConfig)
+				require.NoError(t, err)
+			}
+
+			testRecorder := events.NewInMemoryRecorder("APIAudiencesTest")
+			listers := configobservation.Listers{
+				AuthConfigLister_: configlistersv1.NewAuthenticationLister(indexer),
+			}
+
+			newConfig, errs := ObserveAPIAudiences(
+				listers,
+				testRecorder,
+				apiConfigForIssuer(tc.existingIssuer),
+			)
+
+			require.Len(t, errs, 0)
+
+			expectedConfig := apiConfigForIssuer(tc.expectedAudiences)
+
+			require.Equal(t, expectedConfig, newConfig)
+			require.True(t, tc.expectedChange == (len(testRecorder.Events()) > 0))
+		})
+	}
+}
+
+func authConfigForIssuer(issuer string) *configv1.Authentication {
+	return &configv1.Authentication{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.AuthenticationSpec{
+			ServiceAccountIssuer: issuer,
+		},
+	}
+}
+
+func apiConfigForIssuer(issuer string) map[string]interface{} {
+	return map[string]interface{}{
+		"apiServerArguments": map[string]interface{}{
+			"api-audiences": []interface{}{
+				issuer,
+			},
+		},
+	}
+}

--- a/pkg/operator/configobservation/listers.go
+++ b/pkg/operator/configobservation/listers.go
@@ -17,11 +17,12 @@ var _ libgoetcd.ConfigMapLister = Listers{}
 var _ libgoetcd.EndpointsLister = Listers{}
 
 type Listers struct {
-	APIServerLister_ configlistersv1.APIServerLister
-	ConfigMapLister_ corelistersv1.ConfigMapLister
-	EndpointsLister_ corelistersv1.EndpointsLister
-	OAuthLister_     configlistersv1.OAuthLister
-	SecretLister_    corelistersv1.SecretLister
+	APIServerLister_  configlistersv1.APIServerLister
+	AuthConfigLister_ configlistersv1.AuthenticationLister
+	ConfigMapLister_  corelistersv1.ConfigMapLister
+	EndpointsLister_  corelistersv1.EndpointsLister
+	OAuthLister_      configlistersv1.OAuthLister
+	SecretLister_     corelistersv1.SecretLister
 
 	ResourceSync       resourcesynccontroller.ResourceSyncer
 	PreRunCachesSynced []cache.InformerSynced
@@ -54,4 +55,8 @@ func (l Listers) OAuthLister() configlistersv1.OAuthLister {
 
 func (l Listers) SecretLister() corelistersv1.SecretLister {
 	return l.SecretLister_
+}
+
+func (l Listers) AuthConfigLister() configlistersv1.AuthenticationLister {
+	return l.AuthConfigLister_
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -71,7 +71,7 @@ import (
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/serviceca"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/webhookauthenticator"
 	"github.com/openshift/cluster-authentication-operator/pkg/operator/assets"
-	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
+	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-authentication-operator/pkg/operator/revisionclient"
 	"github.com/openshift/cluster-authentication-operator/pkg/operator/workload"
 )

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -13,7 +13,7 @@ import (
 	operatorconfigclient "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/common"
 	"github.com/openshift/cluster-authentication-operator/pkg/operator/assets"
-	oauthapiconfigobserver "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
+	configobservation "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	libgoetcd "github.com/openshift/library-go/pkg/operator/configobserver/etcd"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -236,7 +236,6 @@ func getStructuredConfigWithDefaultValues(authOperatorSpec operatorv1.OperatorSp
 
 	defaultAPIServerArguments := map[string][]string{
 		"audit-policy-file": {"/var/run/configmaps/audit/default.yaml"},
-		"api-audiences":     {"https://kubernetes.default.svc"},
 	}
 
 	for defArgName, defArgValue := range defaultAPIServerArguments {
@@ -250,12 +249,12 @@ func getStructuredConfigWithDefaultValues(authOperatorSpec operatorv1.OperatorSp
 
 // merged config is then encoded into oAuthAPIServerConfig struct
 func getStructuredConfig(authOperatorSpec operatorv1.OperatorSpec) (*oAuthAPIServerConfig, error) {
-	unstructuredCfg, err := common.UnstructuredConfigFrom(authOperatorSpec.ObservedConfig.Raw, oauthapiconfigobserver.OAuthAPIServerConfigPrefix)
+	unstructuredCfg, err := common.UnstructuredConfigFrom(authOperatorSpec.ObservedConfig.Raw, configobservation.OAuthAPIServerConfigPrefix)
 	if err != nil {
 		return nil, err
 	}
 
-	unstructuredUnsupportedCfg, err := common.UnstructuredConfigFrom(authOperatorSpec.UnsupportedConfigOverrides.Raw, oauthapiconfigobserver.OAuthAPIServerConfigPrefix)
+	unstructuredUnsupportedCfg, err := common.UnstructuredConfigFrom(authOperatorSpec.UnsupportedConfigOverrides.Raw, configobservation.OAuthAPIServerConfigPrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver_test.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver_test.go
@@ -166,7 +166,6 @@ func TestGetStructuredConfigWithDefaultValue(t *testing.T) {
 				ObservedConfig: runtime.RawExtension{Raw: []byte(emptyAPIServerArgsJSON)},
 			},
 			expectedAPIServerArguments: map[string][]string{
-				"api-audiences":     {"https://kubernetes.default.svc"},
 				"audit-policy-file": {"/var/run/configmaps/audit/default.yaml"},
 			},
 		},

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "184fec9ba339674f4104966f3ecd5639e637d0cdf49f50acc5270c8d432c58d0"
+    operator.openshift.io/spec-hash: "457924646ced04a7c8a59f989420d9e9663e0518d6099a65826a82deae1e70f4"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -53,8 +53,7 @@ spec:
                 --shutdown-delay-duration=10s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
-                --api-audiences=https://kubernetes.default.svc \
-              --audit-policy-file=/var/run/configmaps/audit/default.yaml \
+                --audit-policy-file=/var/run/configmaps/audit/default.yaml \
               --v=2
           command:
             - /bin/bash

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "24a0c678eca3b5aa1cf792f9ce12185eabff4200cfc6dfd8412072e3b9ea99f6"
+    operator.openshift.io/spec-hash: "a6403f39500f1ff961046ddcf63ac16bba88ea0862f6625cff6661536f9f0e48"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -53,8 +53,7 @@ spec:
                 --shutdown-delay-duration=10s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
-                --api-audiences=https://kubernetes.default.svc \
-              --audit-policy-file=/var/run/configmaps/audit/default.yaml \
+                --audit-policy-file=/var/run/configmaps/audit/default.yaml \
               --cors-allowed-origins='//127\.0\.0\.1(:|$)' \
               --cors-allowed-origins='//localhost(:|$)' \
               --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "4bab5bda94f4ab35f1575ddf28607cefed18b93be7fbaa43e9bdf4b220272377"
+    operator.openshift.io/spec-hash: "51a217d1d01a29d73e7fe8af9e19a9fbea9171e30a26574d673cf7f7a3fe0308"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -53,8 +53,7 @@ spec:
                 --shutdown-delay-duration=10s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
-                --api-audiences=https://kubernetes.default.svc \
-              --audit-policy-file=/var/run/configmaps/audit/default.yaml \
+                --audit-policy-file=/var/run/configmaps/audit/default.yaml \
               --cors-allowed-origins='//127\.0\.0\.1(:|$)' \
               --cors-allowed-origins='//localhost(:|$)' \
               --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 \

--- a/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
+++ b/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation"
+	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation/configobservercontroller"
 	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
 )


### PR DESCRIPTION
When the kube-apiserver receives a token validation request,
that request is audience-constrained since we configure the SA
issuer and audiences. This means that kube-apiserver also checks
the audiences returned from a TokenReview during webhook token
authentication.

The oauth-apiserver by default uses the https://kubernetes.default.svc
audiences. If authentication.spec.serviceAccountIssuer is set however,
the kube-apiserver will expect different audiences from the default.
If the oauth-apiserver does not adjust the TokenReview endpoint,
users won't be able to validate their OAuthAccessTokens as the
audience returned by the oauth-apiserver in a TokenReview response
would differ

/assign @s-urbaniak 