### PR TITLE
Bug 1977027: Remove not needed Prometheus Rule

### DIFF
--- a/manifests/0000_90_cluster-authentication-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_03_prometheusrule.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: authentication-operator
+  namespace: openshift-authentication-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
+spec:
+  groups:
+    - name: old-format-tokens
+      rules:
+        - alert: DeprecatedOAuthTokensInUse
+          annotations:
+            message: >-
+              Either OAuthAccessTokens or OAuthAuthorizeTokens have been detected in your cluster that do not match
+              the new required naming scheme in the next version of OpenShift. These are all such tokens
+              whose name is not prefixed by "sha256~". These tokens are deprecated since OpenShift 4.6
+              for security reasons (see the release notes for more details) and will not be usable in
+              the next release so it is therefore advised to remove them.
+          expr: |
+            openshift_authentication_operator_old_accesstokens > 0 or openshift_authentication_operator_old_authorizetokens > 0
+          for: 1h
+          labels:
+            severity: info
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1977027

This Pull Request removes the `0000_90_cluster-authentication-operator_03_prometheusrule.yaml` Prometheus Rule, which is no longer necessary after the successful upgrade.

The implementation uses the `release.openshift.io/delete: "true"` annotation, which has been described in https://github.com/openshift/cluster-version-operator/pull/438/files#diff-a094a7a19dcb006cb1206c7011aba1254ab06411b1cfcdc319a6355175132b02