### PR TITLE
distribute oauth-server trust via a openshift-config-managed configmap

### DIFF
--- a/bindata/oauth-openshift/trust_distribution_role.yaml
+++ b/bindata/oauth-openshift/trust_distribution_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:openshift:oauth-servercert-trust
+  namespace: openshift-config-managed
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - oauth-serving-cert
+  verbs:
+  - get
+  - list
+  - watch

--- a/bindata/oauth-openshift/trust_distribution_rolebinding.yaml
+++ b/bindata/oauth-openshift/trust_distribution_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:oauth-servercert-trust
+  namespace: openshift-config-managed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:openshift:oauth-servercert-trust
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/pkg/controllers/trustdistribution/trustdistribution_controller.go
+++ b/pkg/controllers/trustdistribution/trustdistribution_controller.go
@@ -1,0 +1,101 @@
+package trustdistribution
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	configinformers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/common"
+)
+
+type trustDistributionController struct {
+	configMaps    corev1client.ConfigMapsGetter
+	secretsLister corev1listers.SecretLister
+
+	ingressLister configlistersv1.IngressLister
+}
+
+func NewTrustDistributionController(
+	cmClient corev1client.ConfigMapsGetter,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	ingressInformer configinformers.IngressInformer,
+	eventsRecorder events.Recorder,
+) factory.Controller {
+	c := &trustDistributionController{
+		configMaps:    cmClient,
+		secretsLister: kubeInformersForNamespaces.SecretLister(),
+		ingressLister: ingressInformer.Lister(),
+	}
+
+	return factory.New().
+		WithInformers(
+			ingressInformer.Informer(),
+			kubeInformersForNamespaces.InformersFor("openshift-authentication").Core().V1().Secrets().Informer(),
+			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		).
+		WithSync(c.sync).
+		ToController("TrustDistributionController", eventsRecorder.WithComponentSuffix("trust-distribution"))
+}
+
+func (c *trustDistributionController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	ingressConfig, err := c.ingressLister.Get("cluster")
+	if err != nil {
+		return err
+	}
+
+	certBundle, _, _, err := common.GetActiveRouterCertKeyBytes(c.secretsLister,
+		ingressConfig,
+		"openshift-authentication",
+		"v4-0-config-system-router-certs",
+		"v4-0-config-system-custom-router-certs",
+	)
+	if err != nil {
+		return err
+	}
+
+	var certsFiltered string
+	var errs []error
+
+	// filter the content for certificates only, the router-secret contains private keys
+	// in the bundle as well
+	for block, rest := pem.Decode(certBundle); block != nil; block, rest = pem.Decode(rest) {
+		_, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		certsFiltered += "\n" + string(pem.EncodeToMemory(block))
+	}
+
+	if len(certsFiltered) == 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+
+	_, _, err = resourceapply.ApplyConfigMap(ctx,
+		c.configMaps,
+		syncContext.Recorder(),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oauth-serving-cert",
+				Namespace: "openshift-config-managed",
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": certsFiltered,
+			},
+		})
+
+	return err
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -16,6 +16,8 @@
 // bindata/oauth-openshift/oauth-service.yaml
 // bindata/oauth-openshift/route.yaml
 // bindata/oauth-openshift/serviceaccount.yaml
+// bindata/oauth-openshift/trust_distribution_role.yaml
+// bindata/oauth-openshift/trust_distribution_rolebinding.yaml
 package assets
 
 import (
@@ -843,6 +845,69 @@ func oauthOpenshiftServiceaccountYaml() (*asset, error) {
 	return a, nil
 }
 
+var _oauthOpenshiftTrust_distribution_roleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:openshift:oauth-servercert-trust
+  namespace: openshift-config-managed
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - oauth-serving-cert
+  verbs:
+  - get
+  - list
+  - watch
+`)
+
+func oauthOpenshiftTrust_distribution_roleYamlBytes() ([]byte, error) {
+	return _oauthOpenshiftTrust_distribution_roleYaml, nil
+}
+
+func oauthOpenshiftTrust_distribution_roleYaml() (*asset, error) {
+	bytes, err := oauthOpenshiftTrust_distribution_roleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "oauth-openshift/trust_distribution_role.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _oauthOpenshiftTrust_distribution_rolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:oauth-servercert-trust
+  namespace: openshift-config-managed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:openshift:oauth-servercert-trust
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+`)
+
+func oauthOpenshiftTrust_distribution_rolebindingYamlBytes() ([]byte, error) {
+	return _oauthOpenshiftTrust_distribution_rolebindingYaml, nil
+}
+
+func oauthOpenshiftTrust_distribution_rolebindingYaml() (*asset, error) {
+	bytes, err := oauthOpenshiftTrust_distribution_rolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "oauth-openshift/trust_distribution_rolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -911,6 +976,8 @@ var _bindata = map[string]func() (*asset, error){
 	"oauth-openshift/oauth-service.yaml":                          oauthOpenshiftOauthServiceYaml,
 	"oauth-openshift/route.yaml":                                  oauthOpenshiftRouteYaml,
 	"oauth-openshift/serviceaccount.yaml":                         oauthOpenshiftServiceaccountYaml,
+	"oauth-openshift/trust_distribution_role.yaml":                oauthOpenshiftTrust_distribution_roleYaml,
+	"oauth-openshift/trust_distribution_rolebinding.yaml":         oauthOpenshiftTrust_distribution_rolebindingYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -975,6 +1042,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"oauth-service.yaml":                     {oauthOpenshiftOauthServiceYaml, map[string]*bintree{}},
 		"route.yaml":                             {oauthOpenshiftRouteYaml, map[string]*bintree{}},
 		"serviceaccount.yaml":                    {oauthOpenshiftServiceaccountYaml, map[string]*bintree{}},
+		"trust_distribution_role.yaml":           {oauthOpenshiftTrust_distribution_roleYaml, map[string]*bintree{}},
+		"trust_distribution_rolebinding.yaml":    {oauthOpenshiftTrust_distribution_rolebindingYaml, map[string]*bintree{}},
 	}},
 }}
 

--- a/test/e2e/custom_route_test.go
+++ b/test/e2e/custom_route_test.go
@@ -169,7 +169,8 @@ func pollForCustomServingCertificates(t *testing.T, hostname string, certificate
 	return wait.PollImmediate(time.Minute, 10*time.Minute, func() (bool, error) {
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			return false, err
+			t.Logf("failed to send a HTTP request to %s: %v", hostname, err)
+			return false, nil
 		}
 		defer resp.Body.Close()
 

--- a/test/e2e/custom_route_test.go
+++ b/test/e2e/custom_route_test.go
@@ -162,11 +162,11 @@ func pollForCustomServingCertificates(t *testing.T, hostname string, certificate
 		return err
 	}
 
-	reqCtx, cancel := context.WithTimeout(context.TODO(), 10*time.Second) // avoid waiting forever
-	defer cancel()
-	req = req.WithContext(reqCtx)
+	return wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
+		reqCtx, cancel := context.WithTimeout(context.TODO(), 10*time.Second) // avoid waiting forever
+		defer cancel()
+		req = req.WithContext(reqCtx)
 
-	return wait.PollImmediate(time.Minute, 10*time.Minute, func() (bool, error) {
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			t.Logf("failed to send a HTTP request to %s: %v", hostname, err)


### PR DESCRIPTION
Since the oauth-server's serving certificates can now be customized, it's important to publish the serving certificate of the server. This certificate should be used by applications like the oauth-proxy and openshift-console in order for them to be capable of successfully complete the OAuth2 authorization process as these clients eventually get to talk directly to the oauth-server and therefore need to trust it.

/assign @slaskawi 
/cc @deads2k @jhadvig @spadgett 