### PR TITLE
manifests: drop unnecessary histogram buckets

### DIFF
--- a/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
@@ -17,6 +17,11 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
+    - action: drop
+      regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
+      sourceLabels:
+      - __name__
+      - le
     path: /metrics
     port: https
     scheme: https
@@ -47,6 +52,11 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
+    - action: drop
+      regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
+      sourceLabels:
+      - __name__
+      - le
     path: /metrics
     port: https
     scheme: https


### PR DESCRIPTION
This change drops a few buckets from the
`apiserver_request_duration_seconds` histogram for the authentication
operator and the OAuth service. The dropped values are consistent with
what is already done for the OAuth API server. In practice we go from 38
buckets down to 13.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>