### PR TITLE
encryption condition controller doesn't reset previously set condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20210706092853-b63d499a70ce
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210712125953-134acdbd6d8e
+	github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210712125953-134acdbd6d8e h1:VL6s/wyRqNAuil9zOhnQei5EunTb36BnAlw+E39kL0E=
-github.com/openshift/library-go v0.0.0-20210712125953-134acdbd6d8e/go.mod h1:rln3LbFNOpENSvhmsfH7g/hqc58IF78+o96yAAp5mq0=
+github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1 h1:jclNeKbYKeXiq05pt1PdnjcgKV76oqQIcp8h7uqO3V0=
+github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1/go.mod h1:rln3LbFNOpENSvhmsfH7g/hqc58IF78+o96yAAp5mq0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
@@ -84,6 +84,8 @@ func (c *conditionController) sync(_ context.Context, _ factory.SyncContext) (er
 	encryptedGRs := c.provider.EncryptedGRs()
 	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil || len(transitioningReason) > 0 {
+		// do not update the encryption condition (cond). Note: progressing is set elsewhere.
+		cond = nil
 		return err
 	}
 	currentState, _ := encryptionconfig.ToEncryptionState(currentConfig, foundSecrets)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/restmapper"
 
@@ -45,6 +47,8 @@ var (
 func init() {
 	utilruntime.Must(api.InstallKube(genericScheme))
 	utilruntime.Must(migrationv1alpha1.AddToScheme(genericScheme))
+	utilruntime.Must(apiextensions.AddToScheme(genericScheme))
+	utilruntime.Must(admissionregistrationv1.AddToScheme(genericScheme))
 }
 
 type StaticResourceController struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,7 +199,7 @@ github.com/openshift/client-go/route/informers/externalversions/route/v1
 github.com/openshift/client-go/route/listers/route/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20210712125953-134acdbd6d8e
+# github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1
 ## explicit
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
the condition controller is used to report the current state of the encryption: EncryptionCompleted, EncryptionInProgress or DecryptionCompleted

unfortunately, the previously set condition might have been cleared due to a bug in the controller every time the API server was deployed.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1982398