### PR TITLE
 Bug 1978193: csr request: use generate names to prevent getting stuck waiting for a cert

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -13,7 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	certinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -652,7 +654,8 @@ func prepareOauthAPIServerOperator(ctx context.Context, controllerContext *contr
 		},
 		csr.CSROption{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "system:openshift:openshift-authenticator",
+				GenerateName: "system:openshift:openshift-authenticator-",
+				Labels:       map[string]string{"authentication.openshift.io/csr": "openshift-authenticator"},
 			},
 			Subject:    &pkix.Name{CommonName: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"},
 			SignerName: certapiv1.KubeAPIServerClientSignerName,
@@ -665,12 +668,18 @@ func prepareOauthAPIServerOperator(ctx context.Context, controllerContext *contr
 		"OpenShiftAuthenticatorCertRequester",
 	)
 
+	labelsReq, err := labels.NewRequirement("authentication.openshift.io/csr", selection.Equals, []string{"openshift-authenticator"})
+	if err != nil {
+		return err
+	}
+	labelSelector := labels.NewSelector().Add(*labelsReq)
+
 	webhookCertsApprover := csr.NewCSRApproverController(
 		"OpenShiftAuthenticator",
 		operatorCtx.operatorClient,
 		operatorCtx.kubeClient.CertificatesV1().CertificateSigningRequests(),
 		kubeInformers.Certificates().V1().CertificateSigningRequests(),
-		csr.NewNamesFilter("system:openshift:openshift-authenticator"),
+		csr.NewLabelFilter(labelSelector),
 		csr.NewServiceAccountApprover(
 			"openshift-authentication-operator",
 			"authentication-operator",


### PR DESCRIPTION
Under certain circumstances, the CSR with the given name may already exist, different from what we expect. Use `GenerateName` to prevent this.

/assign @s-urbaniak 