### PR TITLE
Bug 1973005: manifests, bindata: explicitely set runAsUser for operator and operand

### DIFF
--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -70,6 +70,7 @@ spec:
               protocol: TCP
           securityContext:
             readOnlyRootFilesystem: false # because of the `cp` in args
+            runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
             - name: v4-0-config-system-session
               readOnly: true

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -42,6 +42,7 @@ spec:
             cpu: 20m
         securityContext:
           readOnlyRootFilesystem: false # because of the `cp` in args
+          runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -604,6 +604,7 @@ spec:
               protocol: TCP
           securityContext:
             readOnlyRootFilesystem: false # because of the ` + "`" + `cp` + "`" + ` in args
+            runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
             - name: v4-0-config-system-session
               readOnly: true


### PR DESCRIPTION
Both cluster-authentication-operator and openshift-oauth-apiserver need to run as root in order to be able to overwrite /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem.

This is implied from picking the default anyuid SCC.
However, if user specifies a more restricted SCC specifying MustRunAsRange with higher or equal priority than anyuid,
that one will be picked causing both processes to be started as non-root.

This fixes it by specifying runAsUser: 0 explicitly.

Alternative: we can try to make `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` writable by all users, i.e. in the Dockerfile (?) to be able to run as non-root.

/cc @stlaz @sttts 