### PR TITLE
[4.8] bug 2003946: Deploy PDB to prevent more than one replica going unavailable

### DIFF
--- a/bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
+++ b/bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: oauth-apiserver-pdb
+  namespace: openshift-oauth-apiserver
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver
+      apiserver: "true"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -6,6 +6,7 @@
 // bindata/oauth-apiserver/authenticator-kubeconfig.yaml
 // bindata/oauth-apiserver/deploy.yaml
 // bindata/oauth-apiserver/ns.yaml
+// bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
 // bindata/oauth-apiserver/sa.yaml
 // bindata/oauth-apiserver/svc.yaml
 // bindata/oauth-openshift/authentication-clusterrolebinding.yaml
@@ -391,6 +392,34 @@ func oauthApiserverNsYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "oauth-apiserver/ns.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _oauthApiserverOauthApiserverPdbYaml = []byte(`apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: oauth-apiserver-pdb
+  namespace: openshift-oauth-apiserver
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver
+      apiserver: "true"
+`)
+
+func oauthApiserverOauthApiserverPdbYamlBytes() ([]byte, error) {
+	return _oauthApiserverOauthApiserverPdbYaml, nil
+}
+
+func oauthApiserverOauthApiserverPdbYaml() (*asset, error) {
+	bytes, err := oauthApiserverOauthApiserverPdbYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "oauth-apiserver/oauth-apiserver-pdb.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -861,6 +890,7 @@ var _bindata = map[string]func() (*asset, error){
 	"oauth-apiserver/authenticator-kubeconfig.yaml":               oauthApiserverAuthenticatorKubeconfigYaml,
 	"oauth-apiserver/deploy.yaml":                                 oauthApiserverDeployYaml,
 	"oauth-apiserver/ns.yaml":                                     oauthApiserverNsYaml,
+	"oauth-apiserver/oauth-apiserver-pdb.yaml":                    oauthApiserverOauthApiserverPdbYaml,
 	"oauth-apiserver/sa.yaml":                                     oauthApiserverSaYaml,
 	"oauth-apiserver/svc.yaml":                                    oauthApiserverSvcYaml,
 	"oauth-openshift/authentication-clusterrolebinding.yaml":      oauthOpenshiftAuthenticationClusterrolebindingYaml,
@@ -922,6 +952,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"authenticator-kubeconfig.yaml":     {oauthApiserverAuthenticatorKubeconfigYaml, map[string]*bintree{}},
 		"deploy.yaml":                       {oauthApiserverDeployYaml, map[string]*bintree{}},
 		"ns.yaml":                           {oauthApiserverNsYaml, map[string]*bintree{}},
+		"oauth-apiserver-pdb.yaml":          {oauthApiserverOauthApiserverPdbYaml, map[string]*bintree{}},
 		"sa.yaml":                           {oauthApiserverSaYaml, map[string]*bintree{}},
 		"svc.yaml":                          {oauthApiserverSvcYaml, map[string]*bintree{}},
 	}},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -534,6 +534,7 @@ func prepareOauthAPIServerOperator(ctx context.Context, controllerContext *contr
 			"oauth-apiserver/sa.yaml",
 			"oauth-apiserver/RBAC/useroauthaccesstokens_binding.yaml",
 			"oauth-apiserver/RBAC/useroauthaccesstokens_clusterrole.yaml",
+			"oauth-apiserver/oauth-apiserver-pdb.yaml",
 			libgoassets.AuditPoliciesConfigMapFileName,
 		},
 		operatorCtx.kubeInformersForNamespaces,


### PR DESCRIPTION
In case master nodes are drained to quickly in a row there's no
waiting until instances go back to available. So it's possible
for two or more replicas to go unavailable which may lead
to all instances going unavailable.

Backporting https://github.com/openshift/cluster-authentication-operator/pull/476