### PR TITLE
podsecurity: enforce privileged for openshift-oauth-apiserver namespace

### DIFF
--- a/bindata/oauth-apiserver/ns.yaml
+++ b/bindata/oauth-apiserver/ns.yaml
@@ -7,3 +7,6 @@ metadata:
   name: openshift-oauth-apiserver
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -385,6 +385,9 @@ metadata:
   name: openshift-oauth-apiserver
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
 `)
 
 func oauthApiserverNsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-oauth-apiserver` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 