### PR TITLE
Exclude operator config for ibm-cloud-managed profile

### DIFF
--- a/manifests/02_config.cr.yaml
+++ b/manifests/02_config.cr.yaml
@@ -3,7 +3,6 @@ kind: Authentication
 metadata:
   name: cluster
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"


### PR DESCRIPTION
The operator config is not needed for an ibm-cloud or hypershift deployment because the auth operator does not run in cluster.