### PR TITLE
Bug 2019832: pkg/operator: configure high inertia for apiserver and OAuthServer

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -523,7 +523,7 @@ func prepareOauthAPIServerOperator(ctx context.Context, controllerContext *contr
 	}
 	var statusControllerOptions []func(*status.StatusSyncer) *status.StatusSyncer
 	if infra == nil || infra.Status.ControlPlaneTopology == configv1.HighlyAvailableTopologyMode {
-		statusControllerOptions = append(statusControllerOptions, apiservercontrollerset.WithStatusControllerPdbCompatibleHighInertia("APIServer"))
+		statusControllerOptions = append(statusControllerOptions, apiservercontrollerset.WithStatusControllerPdbCompatibleHighInertia("(APIServer|OAuthServer)"))
 	}
 
 	const apiServerConditionsPrefix = "APIServer"


### PR DESCRIPTION
Currently, only apiserver high inertia is considered but not oauthserver.

This fixes it.

/cc @stlaz @deads2k 