### PR TITLE
test/lib: Set `PROXY_ADDRESS_FORWARDING` for keycloak

### DIFF
--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -42,6 +42,7 @@ func AddKeycloakIDP(
 			// configure password for GitLab root user
 			{Name: "KEYCLOAK_USER", Value: "admin"},
 			{Name: "KEYCLOAK_PASSWORD", Value: "password"},
+			{Name: "PROXY_ADDRESS_FORWARDING", Value: "true"},
 		},
 		8080,
 		8443,


### PR DESCRIPTION
As described in the docs [1] and the kubernetes example [2], the
aforementioned environment variable is needed for keycloak to properly
function behind a proxy (in our case, ingress).

[1] https://hub.docker.com/r/jboss/keycloak/
[2] https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/kubernetes-examples/keycloak.yaml

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>