### PR TITLE
oauth-openshift: add audit policy and log

### DIFF
--- a/bindata/oauth-openshift/audit-policy.yaml
+++ b/bindata/oauth-openshift/audit-policy.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+metadata:
+  name: audit
+  namespace: openshift-authentication
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    - level: RequestResponse

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -63,7 +63,12 @@ spec:
               fi
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
-              --v=${LOG_LEVEL}
+              --v=${LOG_LEVEL} \
+              --audit-log-path=/var/log/oauth-server/audit.log \
+              --audit-log-format=json \
+              --audit-log-maxsize=100 \
+              --audit-log-maxbackup=10 \
+              --audit-policy-file=/var/run/configmaps/audit/audit.yaml
           ports:
             - name: https
               containerPort: 6443
@@ -72,6 +77,10 @@ spec:
             readOnlyRootFilesystem: false # because of the `cp` in args
             runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
+            - mountPath: /var/run/configmaps/audit
+              name: audit-policies
+            - mountPath: /var/log/oauth-server
+              name: audit-dir
             - name: v4-0-config-system-session
               readOnly: true
               mountPath: /var/config/system/secrets/v4-0-config-system-session
@@ -137,6 +146,12 @@ spec:
               cpu: 10m
               memory: 50Mi
       volumes:
+        - name: audit-policies
+          configMap:
+            name: audit
+        - hostPath:
+            path: /var/log/oauth-server
+          name: audit-dir
         - name: v4-0-config-system-session
           secret:
             secretName: v4-0-config-system-session

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -9,6 +9,7 @@
 // bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
 // bindata/oauth-apiserver/sa.yaml
 // bindata/oauth-apiserver/svc.yaml
+// bindata/oauth-openshift/audit-policy.yaml
 // bindata/oauth-openshift/authentication-clusterrolebinding.yaml
 // bindata/oauth-openshift/branding-secret.yaml
 // bindata/oauth-openshift/cabundle.yaml
@@ -488,6 +489,32 @@ func oauthApiserverSvcYaml() (*asset, error) {
 	return a, nil
 }
 
+var _oauthOpenshiftAuditPolicyYaml = []byte(`kind: ConfigMap
+metadata:
+  name: audit
+  namespace: openshift-authentication
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    - level: RequestResponse
+`)
+
+func oauthOpenshiftAuditPolicyYamlBytes() ([]byte, error) {
+	return _oauthOpenshiftAuditPolicyYaml, nil
+}
+
+func oauthOpenshiftAuditPolicyYaml() (*asset, error) {
+	bytes, err := oauthOpenshiftAuditPolicyYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "oauth-openshift/audit-policy.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _oauthOpenshiftAuthenticationClusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -631,7 +658,12 @@ spec:
               fi
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
-              --v=${LOG_LEVEL}
+              --v=${LOG_LEVEL} \
+              --audit-log-path=/var/log/oauth-server/audit.log \
+              --audit-log-format=json \
+              --audit-log-maxsize=100 \
+              --audit-log-maxbackup=10 \
+              --audit-policy-file=/var/run/configmaps/audit/audit.yaml
           ports:
             - name: https
               containerPort: 6443
@@ -640,6 +672,10 @@ spec:
             readOnlyRootFilesystem: false # because of the ` + "`" + `cp` + "`" + ` in args
             runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
+            - mountPath: /var/run/configmaps/audit
+              name: audit-policies
+            - mountPath: /var/log/oauth-server
+              name: audit-dir
             - name: v4-0-config-system-session
               readOnly: true
               mountPath: /var/config/system/secrets/v4-0-config-system-session
@@ -705,6 +741,12 @@ spec:
               cpu: 10m
               memory: 50Mi
       volumes:
+        - name: audit-policies
+          configMap:
+            name: audit
+        - hostPath:
+            path: /var/log/oauth-server
+          name: audit-dir
         - name: v4-0-config-system-session
           secret:
             secretName: v4-0-config-system-session
@@ -1004,6 +1046,7 @@ var _bindata = map[string]func() (*asset, error){
 	"oauth-apiserver/oauth-apiserver-pdb.yaml":                    oauthApiserverOauthApiserverPdbYaml,
 	"oauth-apiserver/sa.yaml":                                     oauthApiserverSaYaml,
 	"oauth-apiserver/svc.yaml":                                    oauthApiserverSvcYaml,
+	"oauth-openshift/audit-policy.yaml":                           oauthOpenshiftAuditPolicyYaml,
 	"oauth-openshift/authentication-clusterrolebinding.yaml":      oauthOpenshiftAuthenticationClusterrolebindingYaml,
 	"oauth-openshift/branding-secret.yaml":                        oauthOpenshiftBrandingSecretYaml,
 	"oauth-openshift/cabundle.yaml":                               oauthOpenshiftCabundleYaml,
@@ -1071,6 +1114,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"svc.yaml":                          {oauthApiserverSvcYaml, map[string]*bintree{}},
 	}},
 	"oauth-openshift": {nil, map[string]*bintree{
+		"audit-policy.yaml":                      {oauthOpenshiftAuditPolicyYaml, map[string]*bintree{}},
 		"authentication-clusterrolebinding.yaml": {oauthOpenshiftAuthenticationClusterrolebindingYaml, map[string]*bintree{}},
 		"branding-secret.yaml":                   {oauthOpenshiftBrandingSecretYaml, map[string]*bintree{}},
 		"cabundle.yaml":                          {oauthOpenshiftCabundleYaml, map[string]*bintree{}},


### PR DESCRIPTION
This effectively replaces https://github.com/openshift/cluster-authentication-operator/pull/507

/cc @stlaz @EmilyM1 @ibihim 
