### PR TITLE
[WIP] AUTH-89: Audit logs as opts, yet another PR

### DIFF
--- a/bindata/oauth-openshift/audit-policy.yaml
+++ b/bindata/oauth-openshift/audit-policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit
+  namespace: openshift-authentication
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: None
+      nonResourceURLs:
+      - "/healthz*"
+      - "/logs"
+      - "/metrics"
+      - "/version"
+    - level: Metadata

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -63,15 +63,21 @@ spec:
               fi
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
-              --v=${LOG_LEVEL}
+              --v=5 \
+              ${AUDIT_OPTS}
           ports:
             - name: https
               containerPort: 6443
               protocol: TCP
           securityContext:
+            privileged: true
             readOnlyRootFilesystem: false # because of the `cp` in args
             runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
+            - mountPath: /var/run/configmaps/audit
+              name: audit-policies
+            - mountPath: /var/log/oauth-server
+              name: audit-dir
             - name: v4-0-config-system-session
               readOnly: true
               mountPath: /var/config/system/secrets/v4-0-config-system-session
@@ -137,6 +143,12 @@ spec:
               cpu: 10m
               memory: 50Mi
       volumes:
+        - name: audit-policies
+          configMap:
+            name: audit
+        - hostPath:
+            path: /var/log/oauth-server
+          name: audit-dir
         - name: v4-0-config-system-session
           secret:
             secretName: v4-0-config-system-session

--- a/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
@@ -71,6 +71,7 @@ func NewConfigObserver(
 		oauth.ObserveIdentityProviders,
 		oauth.ObserveTemplates,
 		oauth.ObserveTokenConfig,
+		oauth.ObserveAudit,
 		configobserveroauth.ObserveAccessTokenInactivityTimeout,
 		routersecret.ObserveRouterSecret,
 	} {

--- a/pkg/controllers/configobservation/oauth/observe_audit.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit.go
@@ -1,0 +1,90 @@
+package oauth
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation"
+)
+
+var (
+	AuditOptionsPath []string = []string{
+		"serverArguments", "auditOptions",
+	}
+	AuditOptionsArgs []string = []string{
+		"--audit-log-path=/var/log/oauth-server/audit.log",
+		"--audit-log-format=json",
+		"--audit-log-maxsize=100",
+		"--audit-log-maxbackup=10",
+		"--audit-policy-file=/var/run/configmaps/audit/audit.yaml",
+	}
+)
+
+func ObserveAudit(
+	genericListers configobserver.Listers,
+	recorder events.Recorder,
+	existingConfig map[string]interface{},
+) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, AuditOptionsPath)
+	}()
+
+	listers := genericListers.(configobservation.Listers)
+	var errs []error
+
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warning("oauth.config.openshift.io/cluster: not found")
+		oauthConfig = new(configv1.OAuth)
+	} else if err != nil {
+		return existingConfig, []error{fmt.Errorf(
+			"xxx get oauth.config.openshift.io/cluster: %w",
+			err,
+		)}
+	}
+
+	observedConfig := map[string]interface{}{}
+	observedAuditProfile := oauthConfig.Spec.Audit.Profile
+	if observedAuditProfile != configv1.OAuthNoneAuditProfileType {
+		if err := unstructured.SetNestedStringSlice(
+			observedConfig,
+			AuditOptionsArgs,
+			AuditOptionsPath...,
+		); err != nil {
+			return existingConfig, append(errs, fmt.Errorf(
+				"xxx set nested field (%s) for profile (%s): %w",
+				strings.Join(AuditOptionsPath, "/"),
+				observedAuditProfile,
+				err,
+			))
+		}
+	}
+
+	currentAuditProfile, _, err := unstructured.NestedStringSlice(
+		existingConfig,
+		AuditOptionsPath...,
+	)
+	if err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	if !equality.Semantic.DeepEqual(currentAuditProfile, AuditOptionsArgs) {
+		recorder.Eventf(
+			"ObserveAuditProfile",
+			"AuditProfile changed from '%s' to '%s'",
+			currentAuditProfile,
+			AuditOptionsArgs,
+		)
+	}
+
+	return observedConfig, errs
+}

--- a/pkg/controllers/configobservation/oauth/observe_audit_test.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit_test.go
@@ -1,0 +1,119 @@
+package oauth_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation"
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation/oauth"
+)
+
+func TestAuditProfile(t *testing.T) {
+	for _, tt := range [...]struct {
+		name                     string
+		config                   *configv1.OAuth
+		previouslyObservedConfig map[string]interface{}
+		expected                 map[string]interface{}
+		errors                   []error
+	}{
+		{
+			name:                     "nil config",
+			config:                   nil,
+			previouslyObservedConfig: map[string]interface{}{},
+			expected:                 map[string]interface{}{
+				"serverArguments": map[string]interface{}{
+					"auditOptions": []interface{}{
+						string("--audit-log-path=/var/log/oauth-server/audit.log"),
+						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
+						string("--audit-log-maxbackup=10"),
+						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
+					},
+				},
+			},
+			errors:                   []error{},
+		},
+		{
+			name: "disable audit options from scratch",
+			config: &configv1.OAuth{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
+					Profile: configv1.OAuthNoneAuditProfileType,
+				}},
+			},
+			previouslyObservedConfig: map[string]interface{}{},
+			expected:                 map[string]interface{}{},
+		},
+		{
+			name: "enable audit options from scratch",
+			config: &configv1.OAuth{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
+					Profile: configv1.OAuthWriteLoginEventsProfileType,
+				}},
+			},
+			previouslyObservedConfig: map[string]interface{}{},
+			expected:                 map[string]interface{}{
+				"serverArguments": map[string]interface{}{
+					"auditOptions": []interface{}{
+						string("--audit-log-path=/var/log/oauth-server/audit.log"),
+						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
+						string("--audit-log-maxbackup=10"),
+						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
+					},
+				},
+			},
+		},
+		{
+			name: "disable audit profile from enabled",
+			config: &configv1.OAuth{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
+					Profile: configv1.OAuthNoneAuditProfileType,
+				}},
+			},
+			previouslyObservedConfig:                 map[string]interface{}{
+				"serverArguments": map[string]interface{}{
+					"auditOptions": []interface{}{
+						string("--audit-log-path=/var/log/oauth-server/audit.log"),
+						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
+						string("--audit-log-maxbackup=10"),
+						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
+					},
+				},
+			},
+			expected: map[string]interface{}{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tt.config != nil {
+				if err := indexer.Add(tt.config); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			listers := configobservation.Listers{
+				OAuthLister_: configlistersv1.NewOAuthLister(indexer),
+			}
+
+			have, errs := oauth.ObserveAudit(listers, events.NewInMemoryRecorder(t.Name()), tt.previouslyObservedConfig)
+			if len(errs) > 0 {
+				t.Errorf("Expected 0 errors, have %v.", len(errs))
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expected, have) {
+				t.Errorf("result does not match expected config: %s", cmp.Diff(tt.expected, have))
+			}
+
+		})
+	}
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -9,6 +9,7 @@
 // bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
 // bindata/oauth-apiserver/sa.yaml
 // bindata/oauth-apiserver/svc.yaml
+// bindata/oauth-openshift/audit-policy.yaml
 // bindata/oauth-openshift/authentication-clusterrolebinding.yaml
 // bindata/oauth-openshift/branding-secret.yaml
 // bindata/oauth-openshift/cabundle.yaml
@@ -488,6 +489,40 @@ func oauthApiserverSvcYaml() (*asset, error) {
 	return a, nil
 }
 
+var _oauthOpenshiftAuditPolicyYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit
+  namespace: openshift-authentication
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: None
+      nonResourceURLs:
+      - "/healthz*"
+      - "/logs"
+      - "/metrics"
+      - "/version"
+    - level: Metadata
+`)
+
+func oauthOpenshiftAuditPolicyYamlBytes() ([]byte, error) {
+	return _oauthOpenshiftAuditPolicyYaml, nil
+}
+
+func oauthOpenshiftAuditPolicyYaml() (*asset, error) {
+	bytes, err := oauthOpenshiftAuditPolicyYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "oauth-openshift/audit-policy.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _oauthOpenshiftAuthenticationClusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -631,15 +666,21 @@ spec:
               fi
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
-              --v=${LOG_LEVEL}
+              --v=5 \
+              ${AUDIT_OPTS}
           ports:
             - name: https
               containerPort: 6443
               protocol: TCP
           securityContext:
+            privileged: true
             readOnlyRootFilesystem: false # because of the ` + "`" + `cp` + "`" + ` in args
             runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
+            - mountPath: /var/run/configmaps/audit
+              name: audit-policies
+            - mountPath: /var/log/oauth-server
+              name: audit-dir
             - name: v4-0-config-system-session
               readOnly: true
               mountPath: /var/config/system/secrets/v4-0-config-system-session
@@ -705,6 +746,12 @@ spec:
               cpu: 10m
               memory: 50Mi
       volumes:
+        - name: audit-policies
+          configMap:
+            name: audit
+        - hostPath:
+            path: /var/log/oauth-server
+          name: audit-dir
         - name: v4-0-config-system-session
           secret:
             secretName: v4-0-config-system-session
@@ -1004,6 +1051,7 @@ var _bindata = map[string]func() (*asset, error){
 	"oauth-apiserver/oauth-apiserver-pdb.yaml":                    oauthApiserverOauthApiserverPdbYaml,
 	"oauth-apiserver/sa.yaml":                                     oauthApiserverSaYaml,
 	"oauth-apiserver/svc.yaml":                                    oauthApiserverSvcYaml,
+	"oauth-openshift/audit-policy.yaml":                           oauthOpenshiftAuditPolicyYaml,
 	"oauth-openshift/authentication-clusterrolebinding.yaml":      oauthOpenshiftAuthenticationClusterrolebindingYaml,
 	"oauth-openshift/branding-secret.yaml":                        oauthOpenshiftBrandingSecretYaml,
 	"oauth-openshift/cabundle.yaml":                               oauthOpenshiftCabundleYaml,
@@ -1071,6 +1119,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"svc.yaml":                          {oauthApiserverSvcYaml, map[string]*bintree{}},
 	}},
 	"oauth-openshift": {nil, map[string]*bintree{
+		"audit-policy.yaml":                      {oauthOpenshiftAuditPolicyYaml, map[string]*bintree{}},
 		"authentication-clusterrolebinding.yaml": {oauthOpenshiftAuthenticationClusterrolebindingYaml, map[string]*bintree{}},
 		"branding-secret.yaml":                   {oauthOpenshiftBrandingSecretYaml, map[string]*bintree{}},
 		"cabundle.yaml":                          {oauthOpenshiftCabundleYaml, map[string]*bintree{}},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -261,6 +261,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		"OpenshiftAuthenticationStaticResources",
 		assets.Asset,
 		[]string{
+			"oauth-openshift/audit-policy.yaml",
 			"oauth-openshift/ns.yaml",
 			"oauth-openshift/authentication-clusterrolebinding.yaml",
 			"oauth-openshift/cabundle.yaml",


### PR DESCRIPTION
## What

Start `oauth-server` with audit options.

## Why

Enable audit logging for `oauth-server` and authentication events.