### PR TITLE
test/library: Pin keycloak contianer label to 15.0.1

### DIFF
--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -37,7 +37,11 @@ func AddKeycloakIDP(
 
 	nsName, keycloakHost, cleanup := deployPod(t, kubeClients, routeClient,
 		"keycloak",
-		"quay.io/keycloak/keycloak:latest",
+		// Keycloak version 15.0.2 does not work with FIPS:
+		// https://issues.redhat.com/browse/KEYCLOAK-19771
+		//
+		// So we need to stay in this label until that gets solved.
+		"quay.io/keycloak/keycloak:15.0.1",
 		[]corev1.EnvVar{
 			// configure password for GitLab root user
 			{Name: "KEYCLOAK_USER", Value: "admin"},


### PR DESCRIPTION
the latest label (which uses 15.0.2) does not work with FIPS. So we need
to stay in 15.0.1 for now.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>