### PR TITLE
[WIP]More Oauth server log 

### DIFF
--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -64,6 +64,11 @@ spec:
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
               --v=${LOG_LEVEL}
+              --audit-log-path=/var/log/oauth-server/audit.log \
+              --audit-log-format=json \
+              --audit-log-maxsize=100 \
+              --audit-log-maxbackup=10 \
+              --audit-policy-file=/var/run/configmaps/oauth-audit/audit.yaml
           ports:
             - name: https
               containerPort: 6443
@@ -72,6 +77,10 @@ spec:
             readOnlyRootFilesystem: false # because of the `cp` in args
             runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
+            - mountPath: /var/run/configmaps/oauth-audit
+              name: audit-policies
+            - mountPath: /var/log/oauth-server
+              name: audit-dir
             - name: v4-0-config-system-session
               readOnly: true
               mountPath: /var/config/system/secrets/v4-0-config-system-session
@@ -137,6 +146,12 @@ spec:
               cpu: 10m
               memory: 50Mi
       volumes:
+        - name: audit-policies
+          configMap:
+            name: audit
+        - hostPath:
+            path: /var/log/oauth-server
+          name: oauth-audit-dir
         - name: v4-0-config-system-session
           secret:
             secretName: v4-0-config-system-session

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -268,6 +268,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 			"oauth-openshift/oauth-service.yaml",
 			"oauth-openshift/trust_distribution_role.yaml",
 			"oauth-openshift/trust_distribution_rolebinding.yaml",
+			"oauth-openshift/audit.yaml",
 		},
 		resourceapply.NewKubeClientHolder(operatorCtx.kubeClient),
 		operatorCtx.operatorClient,


### PR DESCRIPTION
Because:
https://github.com/openshift/cluster-authentication-operator/pull/497
https://github.com/openshift/cluster-authentication-operator/pull/505
https://github.com/openshift/cluster-authentication-operator/pull/507
https://github.com/openshift/cluster-authentication-operator/pull/509
https://github.com/openshift/cluster-authentication-operator/pull/511

This one gives unique audit dir names in case it's getting overwritten from oauth-apiserver/deployment.yaml