### PR TITLE
feat: library-go bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,8 @@ require (
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67
+	github.com/openshift/library-go v0.0.0-20211217155025-d48a1fb9b7c2
 	github.com/spf13/cobra v1.2.1
-	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/client/v3 v3.5.0
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf
+	github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/client/v3 v3.5.0
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a

--- a/go.sum
+++ b/go.sum
@@ -512,13 +512,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37 h1:40
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-<<<<<<< HEAD
-github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf h1:LfL5dbDoRE792MJoIBQcGAeScq2AHFzvY3iXWxCe2OI=
-github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf/go.mod h1:hz4rpghzCaE+vejl9v04JdmrujaZA8BBpajosXfIGl8=
-=======
-github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67 h1:wNd5jvgf9kXsyT+z11aBlh5spqKPNwsQKplrJRx4nsc=
-github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67/go.mod h1:M/Gi/GUUrMdSS07nrYtTiK43J6/VUAyk/+IfN4ZqUY4=
->>>>>>> 3e9646f1 (feat: library-go bump)
+github.com/openshift/library-go v0.0.0-20211217155025-d48a1fb9b7c2 h1:XIc3BF59OalAmDZ2YTYiUvRo1LMAGoZbdK01VBPduXU=
+github.com/openshift/library-go v0.0.0-20211217155025-d48a1fb9b7c2/go.mod h1:hz4rpghzCaE+vejl9v04JdmrujaZA8BBpajosXfIGl8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,13 @@ github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37 h1:40
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
+<<<<<<< HEAD
 github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf h1:LfL5dbDoRE792MJoIBQcGAeScq2AHFzvY3iXWxCe2OI=
 github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf/go.mod h1:hz4rpghzCaE+vejl9v04JdmrujaZA8BBpajosXfIGl8=
+=======
+github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67 h1:wNd5jvgf9kXsyT+z11aBlh5spqKPNwsQKplrJRx4nsc=
+github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67/go.mod h1:M/Gi/GUUrMdSS07nrYtTiK43J6/VUAyk/+IfN4ZqUY4=
+>>>>>>> 3e9646f1 (feat: library-go bump)
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -547,14 +547,18 @@ func prepareOauthAPIServerOperator(ctx context.Context, controllerContext *contr
 	).WithStaticResourcesController(
 		"APIServerStaticResources",
 		assets.Asset,
-		[]string{
-			"oauth-apiserver/ns.yaml",
-			"oauth-apiserver/apiserver-clusterrolebinding.yaml",
-			"oauth-apiserver/svc.yaml",
-			"oauth-apiserver/sa.yaml",
-			"oauth-apiserver/RBAC/useroauthaccesstokens_binding.yaml",
-			"oauth-apiserver/RBAC/useroauthaccesstokens_clusterrole.yaml",
-			"oauth-apiserver/oauth-apiserver-pdb.yaml",
+		[]apiservercontrollerset.ConditionalFiles{
+			{
+				Files: []string{
+					"oauth-apiserver/ns.yaml",
+					"oauth-apiserver/apiserver-clusterrolebinding.yaml",
+					"oauth-apiserver/svc.yaml",
+					"oauth-apiserver/sa.yaml",
+					"oauth-apiserver/RBAC/useroauthaccesstokens_binding.yaml",
+					"oauth-apiserver/RBAC/useroauthaccesstokens_clusterrole.yaml",
+					"oauth-apiserver/oauth-apiserver-pdb.yaml",
+				},
+			},
 		},
 		operatorCtx.kubeInformersForNamespaces,
 		operatorCtx.kubeClient,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,11 +249,7 @@ github.com/openshift/client-go/route/informers/externalversions/route/v1
 github.com/openshift/client-go/route/listers/route/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-<<<<<<< HEAD
-# github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf
-=======
-# github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67
->>>>>>> 3e9646f1 (feat: library-go bump)
+# github.com/openshift/library-go v0.0.0-20211217155025-d48a1fb9b7c2
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,11 @@ github.com/openshift/client-go/route/informers/externalversions/route/v1
 github.com/openshift/client-go/route/listers/route/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
+<<<<<<< HEAD
 # github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf
+=======
+# github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67
+>>>>>>> 3e9646f1 (feat: library-go bump)
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
Bumping the library-go dependency to latest, this should take advantage of leader election changes for SNO clusters proposed in this [library-go PR](https://github.com/openshift/library-go/pull/1242) and performance improvements in this [PR](https://github.com/openshift/library-go/pull/1235).

Changes:
  - updated library-go to latest


Signed-off-by: ehila <ehila@redhat.com>