### PR TITLE
oauth-server: deployment precondition - wait for config present instead of route admited

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220119134102-3236af51f6e1
+	github.com/openshift/library-go v0.0.0-20220228122324-23f77ebf85bf
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd/client/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220119134102-3236af51f6e1 h1:A1d2p0VBeQ1O0jyXIcDoFHkff6ijbQehve4U3fRx+vg=
-github.com/openshift/library-go v0.0.0-20220119134102-3236af51f6e1/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
+github.com/openshift/library-go v0.0.0-20220228122324-23f77ebf85bf h1:hlCkeS2Qv/ILKzHePPjOXcNo6BteoWzIfBQFbHAVZSU=
+github.com/openshift/library-go v0.0.0-20220228122324-23f77ebf85bf/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/controllers/deployment/deployment_controller.go
+++ b/pkg/controllers/deployment/deployment_controller.go
@@ -23,8 +23,6 @@ import (
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
-	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
-	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
 	bootstrap "github.com/openshift/library-go/pkg/authentication/bootstrapauthenticator"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/apiserver/controller/workload"
@@ -33,7 +31,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-	"github.com/openshift/library-go/pkg/route/routeapihelpers"
 )
 
 var _ workload.Delegate = &oauthServerDeploymentSyncer{}
@@ -61,7 +58,6 @@ type oauthServerDeploymentSyncer struct {
 	secretLister    corev1listers.SecretLister
 	podsLister      corev1listers.PodLister
 	proxyLister     configv1listers.ProxyLister
-	routeLister     routev1listers.RouteLister
 
 	bootstrapUserDataGetter    bootstrap.BootstrapUserDataGetter
 	bootstrapUserChangeRollOut bool
@@ -75,7 +71,6 @@ func NewOAuthServerWorkloadController(
 	nodeInformer coreinformers.NodeInformer,
 	openshiftClusterConfigClient configv1client.ClusterOperatorInterface,
 	configInformers configinformer.SharedInformerFactory,
-	routeInformersForTargetNamespace routeinformers.SharedInformerFactory,
 	authOperatorGetter operatorv1client.AuthenticationsGetter,
 	bootstrapUserDataGetter bootstrap.BootstrapUserDataGetter,
 	eventsRecorder events.Recorder,
@@ -97,7 +92,6 @@ func NewOAuthServerWorkloadController(
 		secretLister:    kubeInformersForTargetNamespace.Core().V1().Secrets().Lister(),
 		podsLister:      kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
 		proxyLister:     configInformers.Config().V1().Proxies().Lister(),
-		routeLister:     routeInformersForTargetNamespace.Route().V1().Routes().Lister(),
 
 		bootstrapUserDataGetter: bootstrapUserDataGetter,
 	}
@@ -120,7 +114,6 @@ func NewOAuthServerWorkloadController(
 		kubeClient,
 		kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
 		[]factory.Informer{
-			configInformers.Config().V1().Ingresses().Informer(),
 			configInformers.Config().V1().Proxies().Informer(),
 			nodeInformer.Informer(),
 		},
@@ -130,7 +123,6 @@ func NewOAuthServerWorkloadController(
 			kubeInformersForTargetNamespace.Core().V1().Secrets().Informer(),
 			kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 			kubeInformersForTargetNamespace.Core().V1().Namespaces().Informer(),
-			routeInformersForTargetNamespace.Route().V1().Routes().Informer(),
 		},
 		oauthDeploymentSyncer,
 		openshiftClusterConfigClient,
@@ -140,16 +132,15 @@ func NewOAuthServerWorkloadController(
 }
 
 func (c *oauthServerDeploymentSyncer) PreconditionFulfilled(_ context.Context) (bool, error) {
-	route, err := c.routeLister.Routes("openshift-authentication").Get("oauth-openshift")
+	configCM, err := c.configMapLister.ConfigMaps("openshift-authentication").Get("v4-0-config-system-cliconfig")
 	if err != nil {
-		return false, fmt.Errorf("waiting for the oauth-openshift route to appear: %w", err)
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
 	}
 
-	if _, _, err := routeapihelpers.IngressURI(route, ""); err != nil {
-		return false, fmt.Errorf("waiting for the oauth-openshift route to contain an admitted ingress: %w", err)
-	}
-
-	return true, nil
+	return len(configCM.Data["v4-0-config-system-cliconfig"]) > 0, nil
 }
 
 func (c *oauthServerDeploymentSyncer) Sync(ctx context.Context, syncContext factory.SyncContext) (*appsv1.Deployment, bool, []error) {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -359,7 +359,6 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		operatorCtx.kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes(),
 		operatorCtx.configClient.ConfigV1().ClusterOperators(),
 		operatorCtx.operatorConfigInformer,
-		routeInformersNamespaced,
 		operatorCtx.operatorClient.Client,
 		bootstrapauthenticator.NewBootstrapUserDataGetter(operatorCtx.kubeClient.CoreV1(), operatorCtx.kubeClient.CoreV1()),
 		controllerContext.EventRecorder,


### PR DESCRIPTION
We don't need a successfully admitted route in order for the oauht-server to properly deploy.

/assign @deads2k 