### PR TITLE
Bug 2039417: remove degraded condition 4.9

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -287,6 +287,8 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 			"OAuthVersionRouteAvailable",
 			"OAuthVersionRouteSecretDegraded",
 			"OAuthVersionIngressConfigDegraded",
+			// removed in https://github.com/openshift/cluster-authentication-operator/commit/7c29d664bd571ce5f8e99456a206584651d200a7
+			"RouteDegraded",
 		},
 		operatorCtx.operatorClient,
 		controllerContext.EventRecorder,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2039417

This Pull Request removes a stale status condition that was removed from code in https://github.com/openshift/cluster-authentication-operator/commit/7c29d664bd571ce5f8e99456a206584651d200a7