### PR TITLE
Bug 2037274: pkg/operator#LegacyCNCerts: use increase function

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -231,7 +231,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		"/var/run/configmaps/service-ca-bundle/service-ca.crt",
 		metricscontroller.NewLegacyCNCertsMetricsSyncFunc(
 			"InvalidProvider",
-			`sum by (provider) (openshift_auth_x509_missing_san_total{job="oauth-openshift",namespace="openshift-authentication"})`,
+			`sum by (provider) (increase(openshift_auth_x509_missing_san_total{job="oauth-openshift",namespace="openshift-authentication"}[30m])) or on() vector(0)`,
 			operatorCtx.operatorClient,
 		),
 	)


### PR DESCRIPTION
Since counters are monotonic, their values are not reset, hence we have to use the `increase` function to detect faulty certificates. Here, a window of 30 minutes has been chosen to have a good reaction time after certs have been corrected.

/cc @stlaz