### PR TITLE
Bug 2052467: Custom route HTTPS certificate SAN validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 all: build
 .PHONY: all
 
+export GODEBUG := x509ignoreCN=0
+
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \

--- a/pkg/operator/datasync/errors.go
+++ b/pkg/operator/datasync/errors.go
@@ -1,0 +1,22 @@
+package datasync
+
+import (
+	"crypto/x509"
+	"fmt"
+)
+
+type ErrNoSAN struct {
+	certSerialNumber string
+	certIssuer       string
+}
+
+func (err ErrNoSAN) Error() string {
+	return fmt.Sprintf("certificate relies on legacy Common Name field, use SANs instead:\n\tsn=%s;\n\tiss=%s", err.certSerialNumber, err.certIssuer)
+}
+
+func newErrNoSAN(cert *x509.Certificate) ErrNoSAN {
+	return ErrNoSAN{
+		certSerialNumber: cert.SerialNumber.String(),
+		certIssuer:       cert.Issuer.String(),
+	}
+}

--- a/pkg/operator/datasync/validation.go
+++ b/pkg/operator/datasync/validation.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/util/keyutil"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
 )
 
 var validators = map[string]func(data []byte) []error{
@@ -88,6 +89,11 @@ func ValidateServerCert(pem []byte) []error {
 		return append(errs, fmt.Errorf("expected at least one server certificate"))
 	}
 
+	for _, cert := range certs {
+		if !crypto.CertHasSAN(cert) {
+			errs = append(errs, newErrNoSAN(cert))
+		}
+	}
 	return errs
 }
 


### PR DESCRIPTION
This patch adds a new validation check for custom route HTTPS
certificates: certificates without SAN fields will prevent upgrades.

This change puts in force the long-standing deprecation of the CN field
as a provider for names.

After this patch, custom routes secured with legacy HTTPS certificates
will prevent the upgrade to OCP v4.10. OCP v4.10 is compiled with Go
v1.17 and is incompatible with such legacy certificates; this
deprecation prevents unexpected failures to occur on upgrade.

Addresses: Bug 2052467