### PR TITLE
Bug 2059515: e2e: Pin the Keycloak version used in tests

### DIFF
--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -38,7 +38,7 @@ func AddKeycloakIDP(
 
 	nsName, keycloakHost, cleanup := deployPod(t, kubeClients, routeClient,
 		"keycloak",
-		"quay.io/keycloak/keycloak:latest",
+		"quay.io/keycloak/keycloak:17.0.0-legacy",
 		[]corev1.EnvVar{
 			// configure password for GitLab root user
 			{Name: "KEYCLOAK_USER", Value: "admin"},


### PR DESCRIPTION
Before this patch, the e2e tests pulled the `latest` tag of
`quay.io/keycloak/keycloak`. The upgrade of the `latest` image to
Keycloack v17.0.0 made the e2e test suite fail.

More specifically, in the same conditions the 17.0.0 image [does not
start automatically][1] any more when the container is created.

This patch pins the Keycloak version to the "legacy" variant of v17.0.0,
which exposes the same behaviour as what the tests expect.

[1]: https://github.com/keycloak/keycloak-containers/commit/41baf7c224ca6206edb44d73252b44bb72ee31cc