### PR TITLE
Bug 2060473: e2e: Pin Keycloack to the legacy variant

### DIFF
--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -38,7 +38,7 @@ func AddKeycloakIDP(
 
 	nsName, keycloakHost, cleanup := deployPod(t, kubeClients, routeClient,
 		"keycloak",
-		"quay.io/keycloak/keycloak:latest",
+		"quay.io/keycloak/keycloak:17.0.0-legacy",
 		[]corev1.EnvVar{
 			// configure password for GitLab root user
 			{Name: "KEYCLOAK_USER", Value: "admin"},


### PR DESCRIPTION
In v17, the Keycloak container image introduced several breaking changes
to the API[1], and most notably:
* a keycloak container won't start by default; it needs a `start` or
  `start-dev` command
* the `auth` part of the API path has been removed
* server configuration has changed

This patch pins the test suite to the "legacy" variant of the Keycloak
17.0.0 image, which is backwards-compatible.

Before this patch, and because this repository was not pinning the
Keycloak version, e2e tests fail with:

    FAIL: TestKeycloakAsOIDCPasswordGrantCheck

[1]: https://www.keycloak.org/migration/migrating-to-quarkus