### PR TITLE
AUTH-89: add audit options to oauth-server on oauth-audit-profile Variant01

### DIFF
--- a/bindata/oauth-openshift/audit-policy.yaml
+++ b/bindata/oauth-openshift/audit-policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit
+  namespace: openshift-authentication
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: None
+      nonResourceURLs:
+      - "/healthz*"
+      - "/logs"
+      - "/metrics"
+      - "/version"
+    - level: Metadata

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -63,15 +63,21 @@ spec:
               fi
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
-              --v=${LOG_LEVEL}
+              --v=${LOG_LEVEL} \
+              ${AUDIT_OPTS}
           ports:
             - name: https
               containerPort: 6443
               protocol: TCP
           securityContext:
+            privileged: true
             readOnlyRootFilesystem: false # because of the `cp` in args
             runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
+            - mountPath: /var/run/configmaps/audit
+              name: audit-policies
+            - mountPath: /var/log/oauth-server
+              name: audit-dir
             - name: v4-0-config-system-session
               readOnly: true
               mountPath: /var/config/system/secrets/v4-0-config-system-session
@@ -137,6 +143,12 @@ spec:
               cpu: 10m
               memory: 50Mi
       volumes:
+        - name: audit-policies
+          configMap:
+            name: audit
+        - hostPath:
+            path: /var/log/oauth-server
+          name: audit-dir
         - name: v4-0-config-system-session
           secret:
             secretName: v4-0-config-system-session

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
               --v=${LOG_LEVEL} \
-              ${AUDIT_OPTS}
+              ${SERVER_ARGUMENTS}
           ports:
             - name: https
               containerPort: 6443

--- a/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
@@ -71,6 +71,7 @@ func NewConfigObserver(
 		oauth.ObserveIdentityProviders,
 		oauth.ObserveTemplates,
 		oauth.ObserveTokenConfig,
+		oauth.ObserveAudit,
 		configobserveroauth.ObserveAccessTokenInactivityTimeout,
 		routersecret.ObserveRouterSecret,
 	} {

--- a/pkg/controllers/configobservation/oauth/observe_audit.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit.go
@@ -1,0 +1,90 @@
+package oauth
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation"
+)
+
+var (
+	AuditOptionsPath []string = []string{
+		"serverArguments", "auditOptions",
+	}
+	AuditOptionsArgs []string = []string{
+		"--audit-log-path=/var/log/oauth-server/audit.log",
+		"--audit-log-format=json",
+		"--audit-log-maxsize=100",
+		"--audit-log-maxbackup=10",
+		"--audit-policy-file=/var/run/configmaps/audit/audit.yaml",
+	}
+)
+
+func ObserveAudit(
+	genericListers configobserver.Listers,
+	recorder events.Recorder,
+	existingConfig map[string]interface{},
+) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, AuditOptionsPath)
+	}()
+
+	listers := genericListers.(configobservation.Listers)
+	var errs []error
+
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warning("oauth.config.openshift.io/cluster: not found")
+		oauthConfig = new(configv1.OAuth)
+	} else if err != nil {
+		return existingConfig, []error{fmt.Errorf(
+			"xxx get oauth.config.openshift.io/cluster: %w",
+			err,
+		)}
+	}
+
+	observedConfig := map[string]interface{}{}
+	observedAuditProfile := oauthConfig.Spec.Audit.Profile
+	if observedAuditProfile != configv1.OAuthNoneAuditProfileType {
+		if err := unstructured.SetNestedStringSlice(
+			observedConfig,
+			AuditOptionsArgs,
+			AuditOptionsPath...,
+		); err != nil {
+			return existingConfig, append(errs, fmt.Errorf(
+				"xxx set nested field (%s) for profile (%s): %w",
+				strings.Join(AuditOptionsPath, "/"),
+				observedAuditProfile,
+				err,
+			))
+		}
+	}
+
+	currentAuditProfile, _, err := unstructured.NestedStringSlice(
+		existingConfig,
+		AuditOptionsPath...,
+	)
+	if err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	if !equality.Semantic.DeepEqual(currentAuditProfile, AuditOptionsArgs) {
+		recorder.Eventf(
+			"ObserveAuditProfile",
+			"AuditProfile changed from '%s' to '%s'",
+			currentAuditProfile,
+			AuditOptionsArgs,
+		)
+	}
+
+	return observedConfig, errs
+}

--- a/pkg/controllers/configobservation/oauth/observe_audit.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/klog/v2"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
@@ -17,10 +18,10 @@ import (
 )
 
 var (
-	AuditOptionsPath []string = []string{
+	AuditOptionsPath = []string{
 		"serverArguments",
 	}
-	auditOptionsArgs map[string]interface{} = map[string]interface{}{
+	auditOptionsArgs = map[string]interface{}{
 		"audit-log-path":      "/var/log/oauth-server/audit.log",
 		"audit-log-format":    "json",
 		"audit-log-maxsize":   "100",
@@ -45,7 +46,9 @@ func ObserveAudit(
 	if errors.IsNotFound(err) {
 		klog.Warning("oauth.config.openshift.io/cluster: not found")
 		oauthConfig = new(configv1.OAuth)
+		klog.V(2).Info("xxx there is no oauth")
 	} else if err != nil {
+		klog.V(2).Info("xxx err on get oauth")
 		return existingConfig, []error{fmt.Errorf(
 			"xxx get oauth.config.openshift.io/cluster: %w",
 			err,
@@ -60,6 +63,7 @@ func ObserveAudit(
 			auditOptionsArgs,
 			AuditOptionsPath...,
 		); err != nil {
+			klog.V(2).Info("xxx err on adding nested fields")
 			return existingConfig, append(errs, fmt.Errorf(
 				"xxx set nested field (%s) for profile (%s): %w",
 				strings.Join(AuditOptionsPath, "/"),
@@ -74,6 +78,7 @@ func ObserveAudit(
 		AuditOptionsPath...,
 	)
 	if err != nil {
+		klog.V(2).Info("xxx err on getting currrent stuff")
 		return existingConfig, append(errs, err)
 	}
 
@@ -84,7 +89,10 @@ func ObserveAudit(
 			currentAuditProfile,
 			auditOptionsArgs,
 		)
+		klog.V(2).Info("xxx state change")
 	}
+
+	klog.V(2).Infof("xxx observedConfig: %+v", observedConfig)
 
 	return observedConfig, errs
 }

--- a/pkg/controllers/configobservation/oauth/observe_audit.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit.go
@@ -22,11 +22,11 @@ var (
 		"serverArguments",
 	}
 	auditOptionsArgs = map[string]interface{}{
-		"audit-log-path":      "/var/log/oauth-server/audit.log",
-		"audit-log-format":    "json",
-		"audit-log-maxsize":   "100",
-		"audit-log-maxbackup": "10",
-		"audit-policy-file":   "/var/run/configmaps/audit/audit.yaml",
+		"audit-log-path":      []interface{}{"/var/log/oauth-server/audit.log"},
+		"audit-log-format":    []interface{}{"json"},
+		"audit-log-maxsize":   []interface{}{"100"},
+		"audit-log-maxbackup": []interface{}{"10"},
+		"audit-policy-file":   []interface{}{"/var/run/configmaps/audit/audit.yaml"},
 	}
 )
 
@@ -57,7 +57,7 @@ func ObserveAudit(
 
 	observedConfig := map[string]interface{}{}
 	observedAuditProfile := oauthConfig.Spec.Audit.Profile
-	if observedAuditProfile != configv1.OAuthNoneAuditProfileType {
+	if observedAuditProfile != configv1.OAuthAuditProfileNone {
 		if err := unstructured.SetNestedField(
 			observedConfig,
 			auditOptionsArgs,

--- a/pkg/controllers/configobservation/oauth/observe_audit.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	AuditOptionsPath = []string{
+	ServerArgumentsPath = []string{
 		"serverArguments",
 	}
 	auditOptionsArgs = map[string]interface{}{
@@ -36,7 +36,7 @@ func ObserveAudit(
 	existingConfig map[string]interface{},
 ) (ret map[string]interface{}, _ []error) {
 	defer func() {
-		ret = configobserver.Pruned(ret, AuditOptionsPath)
+		ret = configobserver.Pruned(ret, ServerArgumentsPath)
 	}()
 
 	listers := genericListers.(configobservation.Listers)
@@ -61,12 +61,12 @@ func ObserveAudit(
 		if err := unstructured.SetNestedField(
 			observedConfig,
 			auditOptionsArgs,
-			AuditOptionsPath...,
+			ServerArgumentsPath...,
 		); err != nil {
 			klog.V(2).Info("xxx err on adding nested fields")
 			return existingConfig, append(errs, fmt.Errorf(
 				"xxx set nested field (%s) for profile (%s): %w",
-				strings.Join(AuditOptionsPath, "/"),
+				strings.Join(ServerArgumentsPath, "/"),
 				observedAuditProfile,
 				err,
 			))
@@ -75,7 +75,7 @@ func ObserveAudit(
 
 	currentAuditProfile, _, err := unstructured.NestedFieldCopy(
 		existingConfig,
-		AuditOptionsPath...,
+		ServerArgumentsPath...,
 	)
 	if err != nil {
 		klog.V(2).Info("xxx err on getting currrent stuff")

--- a/pkg/controllers/configobservation/oauth/observe_audit_test.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit_test.go
@@ -20,11 +20,11 @@ import (
 func TestAuditProfile(t *testing.T) {
 	auditOpts := map[string]interface{}{
 		"serverArguments": map[string]interface{}{
-			"audit-log-path":      "/var/log/oauth-server/audit.log",
-			"audit-log-format":    "json",
-			"audit-log-maxsize":   "100",
-			"audit-log-maxbackup": "10",
-			"audit-policy-file":   "/var/run/configmaps/audit/audit.yaml",
+			"audit-log-format":    []interface{}{string("json")},
+			"audit-log-maxbackup": []interface{}{string("10")},
+			"audit-log-maxsize":   []interface{}{string("100")},
+			"audit-log-path":      []interface{}{string("/var/log/oauth-server/audit.log")},
+			"audit-policy-file":   []interface{}{string("/var/run/configmaps/audit/audit.yaml")},
 		},
 	}
 
@@ -47,7 +47,7 @@ func TestAuditProfile(t *testing.T) {
 			config: &configv1.OAuth{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
-					Profile: configv1.OAuthNoneAuditProfileType,
+					Profile: configv1.OAuthAuditProfileNone,
 				}},
 			},
 			previouslyObservedConfig: map[string]interface{}{},
@@ -58,7 +58,7 @@ func TestAuditProfile(t *testing.T) {
 			config: &configv1.OAuth{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
-					Profile: configv1.OAuthWriteLoginEventsProfileType,
+					Profile: configv1.OAuthAuditProfileWriteLoginEvents,
 				}},
 			},
 			previouslyObservedConfig: map[string]interface{}{},
@@ -69,7 +69,7 @@ func TestAuditProfile(t *testing.T) {
 			config: &configv1.OAuth{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
-					Profile: configv1.OAuthNoneAuditProfileType,
+					Profile: configv1.OAuthAuditProfileNone,
 				}},
 			},
 			previouslyObservedConfig: auditOpts,

--- a/pkg/controllers/configobservation/oauth/observe_audit_test.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit_test.go
@@ -1,0 +1,119 @@
+package oauth_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation"
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation/oauth"
+)
+
+func TestAuditProfile(t *testing.T) {
+	for _, tt := range [...]struct {
+		name                     string
+		config                   *configv1.OAuth
+		previouslyObservedConfig map[string]interface{}
+		expected                 map[string]interface{}
+		errors                   []error
+	}{
+		{
+			name:                     "nil config",
+			config:                   nil,
+			previouslyObservedConfig: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"serverArguments": map[string]interface{}{
+					"auditOptions": []interface{}{
+						string("--audit-log-path=/var/log/oauth-server/audit.log"),
+						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
+						string("--audit-log-maxbackup=10"),
+						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
+					},
+				},
+			},
+			errors: []error{},
+		},
+		{
+			name: "disable audit options from scratch",
+			config: &configv1.OAuth{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
+					Profile: configv1.OAuthNoneAuditProfileType,
+				}},
+			},
+			previouslyObservedConfig: map[string]interface{}{},
+			expected:                 map[string]interface{}{},
+		},
+		{
+			name: "enable audit options from scratch",
+			config: &configv1.OAuth{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
+					Profile: configv1.OAuthWriteLoginEventsProfileType,
+				}},
+			},
+			previouslyObservedConfig: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"serverArguments": map[string]interface{}{
+					"auditOptions": []interface{}{
+						string("--audit-log-path=/var/log/oauth-server/audit.log"),
+						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
+						string("--audit-log-maxbackup=10"),
+						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
+					},
+				},
+			},
+		},
+		{
+			name: "disable audit profile from enabled",
+			config: &configv1.OAuth{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.OAuthSpec{Audit: configv1.OAuthAudit{
+					Profile: configv1.OAuthNoneAuditProfileType,
+				}},
+			},
+			previouslyObservedConfig: map[string]interface{}{
+				"serverArguments": map[string]interface{}{
+					"auditOptions": []interface{}{
+						string("--audit-log-path=/var/log/oauth-server/audit.log"),
+						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
+						string("--audit-log-maxbackup=10"),
+						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
+					},
+				},
+			},
+			expected: map[string]interface{}{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tt.config != nil {
+				if err := indexer.Add(tt.config); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			listers := configobservation.Listers{
+				OAuthLister_: configlistersv1.NewOAuthLister(indexer),
+			}
+
+			have, errs := oauth.ObserveAudit(listers, events.NewInMemoryRecorder(t.Name()), tt.previouslyObservedConfig)
+			if len(errs) > 0 {
+				t.Errorf("Expected 0 errors, have %v.", len(errs))
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expected, have) {
+				t.Errorf("result does not match expected config: %s", cmp.Diff(tt.expected, have))
+			}
+
+		})
+	}
+}

--- a/pkg/controllers/configobservation/oauth/observe_audit_test.go
+++ b/pkg/controllers/configobservation/oauth/observe_audit_test.go
@@ -18,6 +18,16 @@ import (
 )
 
 func TestAuditProfile(t *testing.T) {
+	auditOpts := map[string]interface{}{
+		"serverArguments": map[string]interface{}{
+			"audit-log-path":      "/var/log/oauth-server/audit.log",
+			"audit-log-format":    "json",
+			"audit-log-maxsize":   "100",
+			"audit-log-maxbackup": "10",
+			"audit-policy-file":   "/var/run/configmaps/audit/audit.yaml",
+		},
+	}
+
 	for _, tt := range [...]struct {
 		name                     string
 		config                   *configv1.OAuth
@@ -29,17 +39,8 @@ func TestAuditProfile(t *testing.T) {
 			name:                     "nil config",
 			config:                   nil,
 			previouslyObservedConfig: map[string]interface{}{},
-			expected: map[string]interface{}{
-				"serverArguments": map[string]interface{}{
-					"auditOptions": []interface{}{
-						string("--audit-log-path=/var/log/oauth-server/audit.log"),
-						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
-						string("--audit-log-maxbackup=10"),
-						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
-					},
-				},
-			},
-			errors: []error{},
+			expected:                 auditOpts,
+			errors:                   []error{},
 		},
 		{
 			name: "disable audit options from scratch",
@@ -61,16 +62,7 @@ func TestAuditProfile(t *testing.T) {
 				}},
 			},
 			previouslyObservedConfig: map[string]interface{}{},
-			expected: map[string]interface{}{
-				"serverArguments": map[string]interface{}{
-					"auditOptions": []interface{}{
-						string("--audit-log-path=/var/log/oauth-server/audit.log"),
-						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
-						string("--audit-log-maxbackup=10"),
-						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
-					},
-				},
-			},
+			expected:                 auditOpts,
 		},
 		{
 			name: "disable audit profile from enabled",
@@ -80,17 +72,8 @@ func TestAuditProfile(t *testing.T) {
 					Profile: configv1.OAuthNoneAuditProfileType,
 				}},
 			},
-			previouslyObservedConfig: map[string]interface{}{
-				"serverArguments": map[string]interface{}{
-					"auditOptions": []interface{}{
-						string("--audit-log-path=/var/log/oauth-server/audit.log"),
-						string("--audit-log-format=json"), string("--audit-log-maxsize=100"),
-						string("--audit-log-maxbackup=10"),
-						string("--audit-policy-file=/var/run/configmaps/audit/audit.yaml"),
-					},
-				},
-			},
-			expected: map[string]interface{}{},
+			previouslyObservedConfig: auditOpts,
+			expected:                 map[string]interface{}{},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controllers/deployment/arguments.go
+++ b/pkg/controllers/deployment/arguments.go
@@ -1,0 +1,106 @@
+package deployment
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/common"
+	"github.com/openshift/cluster-authentication-operator/pkg/controllers/configobservation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	shellEscapePattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
+)
+
+type ServerArguments map[string][]string
+
+func getServerArguments(operatorConfig *runtime.RawExtension) (ServerArguments, error) {
+	oauthServerObservedConfig, err := common.UnstructuredConfigFrom(
+		operatorConfig.Raw,
+		configobservation.OAuthServerConfigPrefix,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to grab the operator config: %w", err)
+	}
+
+	configDeserialized := new(struct {
+		Args map[string]interface{} `json:"serverArguments"` // Now this thing is screwed.
+	})
+	if err := json.Unmarshal(oauthServerObservedConfig, &configDeserialized); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the observedConfig: %v", err)
+	}
+
+	return Parse(configDeserialized.Args)
+}
+
+func Parse(raw map[string]interface{}) (ServerArguments, error) {
+	args := make(ServerArguments)
+
+	for argName, argValue := range raw {
+		var argsSlice []string
+
+		argsSlice, found, err := unstructured.NestedStringSlice(raw, argName)
+		if !found || err != nil {
+			str, found, err := unstructured.NestedString(raw, argName)
+			if !found || err != nil {
+				return nil, fmt.Errorf(
+					"unable to create server arguments, incorrect value %v under %s key, expected []string or string",
+					argValue, argName,
+				)
+			}
+
+			argsSlice = append(argsSlice, str)
+		}
+
+		args[argName] = argsSlice
+	}
+	return args, nil
+}
+
+// shellEscape returns a shell-escaped version of the string s. The returned value
+// is a string that can safely be used as one token in a shell command line.
+//
+// note: this method was copied from https://github.com/alessio/shellescape/blob/0d13ae33b78a20a5d91c54ca7e216e1b75aaedef/shellescape.go#L30
+func shellEscape(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+	if shellEscapePattern.MatchString(s) {
+		return "'" + strings.Replace(s, "'", "'\"'\"'", -1) + "'"
+	}
+
+	return s
+}
+
+func Encode(args ServerArguments) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(args))
+	for key := range args {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	for _, key := range keys {
+		values := args[key]
+		for _, value := range values {
+			if buf.Len() > 0 {
+				buf.WriteByte('\n')
+			}
+			buf.WriteString("--")
+			buf.WriteString(shellEscape(key))
+			buf.WriteByte('=')
+			buf.WriteString(shellEscape(value)) // escape here
+		}
+	}
+
+	return buf.String()
+}

--- a/pkg/controllers/deployment/default_deployment.go
+++ b/pkg/controllers/deployment/default_deployment.go
@@ -177,7 +177,7 @@ func serverArgsToStringSlice(args serverArguments) []string {
 func stringSliceToNewLinedString(flags []string) string {
 	newLiner := times(
 		fmt.Sprintf(" \\\n"),
-		len(flags) - 1,
+		len(flags)-1,
 	)
 
 	var flagBlob strings.Builder
@@ -190,16 +190,15 @@ func stringSliceToNewLinedString(flags []string) string {
 	return flagBlob.String()
 }
 
-
 // times a generic candidate
-func times(s string, t int) func () string {
-	return func () string {
-			if t > 0 {
-				t = t-1
-				return s
-			}
+func times(s string, t int) func() string {
+	return func() string {
+		if t > 0 {
+			t = t - 1
+			return s
+		}
 
-			return ""
+		return ""
 	}
 }
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -9,6 +9,7 @@
 // bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
 // bindata/oauth-apiserver/sa.yaml
 // bindata/oauth-apiserver/svc.yaml
+// bindata/oauth-openshift/audit-policy.yaml
 // bindata/oauth-openshift/authentication-clusterrolebinding.yaml
 // bindata/oauth-openshift/branding-secret.yaml
 // bindata/oauth-openshift/cabundle.yaml
@@ -488,6 +489,40 @@ func oauthApiserverSvcYaml() (*asset, error) {
 	return a, nil
 }
 
+var _oauthOpenshiftAuditPolicyYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit
+  namespace: openshift-authentication
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: None
+      nonResourceURLs:
+      - "/healthz*"
+      - "/logs"
+      - "/metrics"
+      - "/version"
+    - level: Metadata
+`)
+
+func oauthOpenshiftAuditPolicyYamlBytes() ([]byte, error) {
+	return _oauthOpenshiftAuditPolicyYaml, nil
+}
+
+func oauthOpenshiftAuditPolicyYaml() (*asset, error) {
+	bytes, err := oauthOpenshiftAuditPolicyYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "oauth-openshift/audit-policy.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _oauthOpenshiftAuthenticationClusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -631,15 +666,21 @@ spec:
               fi
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
-              --v=${LOG_LEVEL}
+              --v=${LOG_LEVEL} \
+              ${AUDIT_OPTS}
           ports:
             - name: https
               containerPort: 6443
               protocol: TCP
           securityContext:
+            privileged: true
             readOnlyRootFilesystem: false # because of the ` + "`" + `cp` + "`" + ` in args
             runAsUser: 0 # because /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem is only writable by root
           volumeMounts:
+            - mountPath: /var/run/configmaps/audit
+              name: audit-policies
+            - mountPath: /var/log/oauth-server
+              name: audit-dir
             - name: v4-0-config-system-session
               readOnly: true
               mountPath: /var/config/system/secrets/v4-0-config-system-session
@@ -705,6 +746,12 @@ spec:
               cpu: 10m
               memory: 50Mi
       volumes:
+        - name: audit-policies
+          configMap:
+            name: audit
+        - hostPath:
+            path: /var/log/oauth-server
+          name: audit-dir
         - name: v4-0-config-system-session
           secret:
             secretName: v4-0-config-system-session
@@ -1004,6 +1051,7 @@ var _bindata = map[string]func() (*asset, error){
 	"oauth-apiserver/oauth-apiserver-pdb.yaml":                    oauthApiserverOauthApiserverPdbYaml,
 	"oauth-apiserver/sa.yaml":                                     oauthApiserverSaYaml,
 	"oauth-apiserver/svc.yaml":                                    oauthApiserverSvcYaml,
+	"oauth-openshift/audit-policy.yaml":                           oauthOpenshiftAuditPolicyYaml,
 	"oauth-openshift/authentication-clusterrolebinding.yaml":      oauthOpenshiftAuthenticationClusterrolebindingYaml,
 	"oauth-openshift/branding-secret.yaml":                        oauthOpenshiftBrandingSecretYaml,
 	"oauth-openshift/cabundle.yaml":                               oauthOpenshiftCabundleYaml,
@@ -1071,6 +1119,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"svc.yaml":                          {oauthApiserverSvcYaml, map[string]*bintree{}},
 	}},
 	"oauth-openshift": {nil, map[string]*bintree{
+		"audit-policy.yaml":                      {oauthOpenshiftAuditPolicyYaml, map[string]*bintree{}},
 		"authentication-clusterrolebinding.yaml": {oauthOpenshiftAuthenticationClusterrolebindingYaml, map[string]*bintree{}},
 		"branding-secret.yaml":                   {oauthOpenshiftBrandingSecretYaml, map[string]*bintree{}},
 		"cabundle.yaml":                          {oauthOpenshiftCabundleYaml, map[string]*bintree{}},

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -667,7 +667,7 @@ spec:
               exec oauth-server osinserver \
               --config=/var/config/system/configmaps/v4-0-config-system-cliconfig/v4-0-config-system-cliconfig \
               --v=${LOG_LEVEL} \
-              ${AUDIT_OPTS}
+              ${SERVER_ARGUMENTS}
           ports:
             - name: https
               containerPort: 6443

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -261,6 +261,7 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 		"OpenshiftAuthenticationStaticResources",
 		assets.Asset,
 		[]string{
+			"oauth-openshift/audit-policy.yaml",
 			"oauth-openshift/ns.yaml",
 			"oauth-openshift/authentication-clusterrolebinding.yaml",
 			"oauth-openshift/cabundle.yaml",

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -236,7 +236,10 @@ func getStructuredConfig(authOperatorSpec operatorv1.OperatorSpec) (*oAuthAPISer
 		return nil, err
 	}
 
-	unstructuredUnsupportedCfg, err := common.UnstructuredConfigFrom(authOperatorSpec.UnsupportedConfigOverrides.Raw, configobservation.OAuthAPIServerConfigPrefix)
+	unstructuredUnsupportedCfg, err := common.UnstructuredConfigFrom(
+		authOperatorSpec.UnsupportedConfigOverrides.Raw,
+		configobservation.OAuthAPIServerConfigPrefix,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# What

Add an observer for the new OAuth field for Audit Profiles. Add audit options to the oauth server deployment if not disabled-profile is used.

# Why

oauth-server leverages audit framework from k8s.io/apiserver and needs audit opts to be set to enable it.

# Notes

Depends on [api/oauth](https://github.com/openshift/api/pull/1128).