### PR TITLE
make apiserver readiness probe honor readyz

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -71,7 +71,7 @@ spec:
               --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-              --shutdown-delay-duration=10s \
+              --shutdown-delay-duration=15s \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}
@@ -101,18 +101,36 @@ spec:
         - mountPath: /var/log/oauth-apiserver
           name: audit-dir
         livenessProbe:
-          initialDelaySeconds: 30
           httpGet:
             scheme: HTTPS
             port: 8443
             path: healthz
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
         readinessProbe:
-          failureThreshold: 10
           httpGet:
             scheme: HTTPS
             port: 8443
             path: readyz
-      terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 1
+        startupProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            path: healthz
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 30
+      terminationGracePeriodSeconds: 90 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
       volumes:
       - name: audit-policies
         configMap:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -270,7 +270,7 @@ spec:
               --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-              --shutdown-delay-duration=10s \
+              --shutdown-delay-duration=15s \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}
@@ -300,18 +300,36 @@ spec:
         - mountPath: /var/log/oauth-apiserver
           name: audit-dir
         livenessProbe:
-          initialDelaySeconds: 30
           httpGet:
             scheme: HTTPS
             port: 8443
             path: healthz
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
         readinessProbe:
-          failureThreshold: 10
           httpGet:
             scheme: HTTPS
             port: 8443
             path: readyz
-      terminationGracePeriodSeconds: 70 # a bit more than the 60 seconds timeout of non-long-running requests
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 1
+        startupProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            path: healthz
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 30
+      terminationGracePeriodSeconds: 90 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
       volumes:
       - name: audit-policies
         configMap:

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "fcf2b14e598315755a596df956fe9349a78bfb37272e2a6f0421d62c48f9bb01"
+    operator.openshift.io/spec-hash: "ec8656884875dc86e53a4ac56860dab6e0b75174cb05727c11be347f0706eff0"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -51,7 +51,7 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=10s \
+                --shutdown-delay-duration=15s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --v=2
@@ -61,20 +61,38 @@ spec:
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: healthz
-              port: 8443
               scheme: HTTPS
-            initialDelaySeconds: 30
+              port: 8443
+              path: healthz
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: readyz
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 1
+          startupProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: healthz
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 30
           name: oauth-apiserver
           ports:
             -
               containerPort: 8443
-          readinessProbe:
-            failureThreshold: 10
-            httpGet:
-              path: readyz
-              port: 8443
-              scheme: HTTPS
           resources:
             requests:
               cpu: 150m
@@ -129,7 +147,7 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccountName: oauth-apiserver-sa
-      terminationGracePeriodSeconds: 70
+      terminationGracePeriodSeconds: 90
       tolerations:
         -
           effect: NoSchedule

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "db16037adaa733f9caa55c8ae23e4c3b37674d5027f580ee3091897c2cdcc781"
+    operator.openshift.io/spec-hash: "c6b69eb66aa5315d99749b9562ed2a54f6f4758e71d29929d6d1e4174b373ce2"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -51,7 +51,7 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=10s \
+                --shutdown-delay-duration=15s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --cors-allowed-origins='//127\.0\.0\.1(:|$)' \
@@ -70,20 +70,38 @@ spec:
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: healthz
-              port: 8443
               scheme: HTTPS
-            initialDelaySeconds: 30
+              port: 8443
+              path: healthz
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: readyz
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 1
+          startupProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: healthz
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 30
           name: oauth-apiserver
           ports:
             -
               containerPort: 8443
-          readinessProbe:
-            failureThreshold: 10
-            httpGet:
-              path: readyz
-              port: 8443
-              scheme: HTTPS
           resources:
             requests:
               cpu: 150m
@@ -138,7 +156,7 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccountName: oauth-apiserver-sa
-      terminationGracePeriodSeconds: 70
+      terminationGracePeriodSeconds: 90
       tolerations:
         -
           effect: NoSchedule

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "37da8a4f4ca6182d21131e0d6ca8384e5b0bc4dfeb6ead7eacf5dd1cd815fcdb"
+    operator.openshift.io/spec-hash: "0b7f0eb3f3af25e1b7e70cd3a798c6f694348a5d62e6665dade9964499ce1f24"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -51,7 +51,7 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=10s \
+                --shutdown-delay-duration=15s \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --cors-allowed-origins='//127\.0\.0\.1(:|$)' \
@@ -65,20 +65,38 @@ spec:
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: healthz
-              port: 8443
               scheme: HTTPS
-            initialDelaySeconds: 30
+              port: 8443
+              path: healthz
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: readyz
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 1
+          startupProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: healthz
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 30
           name: oauth-apiserver
           ports:
             -
               containerPort: 8443
-          readinessProbe:
-            failureThreshold: 10
-            httpGet:
-              path: readyz
-              port: 8443
-              scheme: HTTPS
           resources:
             requests:
               cpu: 150m
@@ -133,7 +151,7 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccountName: oauth-apiserver-sa
-      terminationGracePeriodSeconds: 70
+      terminationGracePeriodSeconds: 90
       tolerations:
         -
           effect: NoSchedule


### PR DESCRIPTION
This also uses a startup probe instead of a long initial delay seconds for livez and instead of excessive failure thresholds for readiness.  The failure thresholds were so long that the readiness check never failed.

/assign @tkashem @s-urbaniak 