### PR TITLE
manifests: specify pod security level

### DIFF
--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -10,3 +10,6 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-authentication-operator/deployments/authentication-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"authentication-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"authentication-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"authentication-operator\" must set securityContext.runAsNonRoot=true), runAsUser=0 (container \"authentication-operator\" must not set runAsUser=0), seccompProfile (pod or container \"authentication-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Since cluster-authentication-operator requires "runAsUser=0" we have to set `baseline` policy

/cc @stlaz 