### PR TITLE
e2e: Use Keycloak v18.0.0

### DIFF
--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -43,7 +43,7 @@ func AddKeycloakIDP(
 			// configure password for GitLab root user
 			{Name: "KEYCLOAK_ADMIN", Value: "admin"},
 			{Name: "KEYCLOAK_ADMIN_PASSWORD", Value: "password"},
-			{Name: "KC_METRICS_ENABLED", Value: "true"},
+			{Name: "KC_HEALTH_ENABLED", Value: "true"},
 			{Name: "KC_HOSTNAME_STRICT", Value: "false"},
 			{Name: "KC_PROXY", Value: "reencrypt"},
 			{Name: "KC_HTTPS_CERTIFICATE_FILE", Value: "/etc/x509/https/tls.crt"},


### PR DESCRIPTION
With v18, the Keycloak configuration switch "metrics-enabled" does not
enable health endpoints any more: those are enabled with
"health-enabled". This PR fixes the tests to use this configuration
switch, as the Keycloak test-dependency is not pinned.