### PR TITLE
AUTH-133: bindata/oauth-openshift: specify pod security level

### DIFF
--- a/bindata/oauth-openshift/ns.yaml
+++ b/bindata/oauth-openshift/ns.yaml
@@ -7,3 +7,6 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -830,6 +830,9 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
 `)
 
 func oauthOpenshiftNsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
baseline:

Failure: pods "oauth-openshift" is forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volume "audit-dir"), privileged (container "oauth-openshift" must not set securityContext.privileged=true)
```

```
restricted:

Failure: pods "oauth-openshift" is forbidden: violates PodSecurity "restricted:latest": hostPath volumes (volume "audit-dir"), privileged (container "oauth-openshift" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "oauth-openshift" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "oauth-openshift" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "audit-dir" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "oauth-openshift" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "oauth-openshift" must not set runAsUser=0), seccompProfile (pod or container "oauth-openshift" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

The above violations are valid, the namespace has to be marked as privileged.

/cc @stlaz @ibihim 