### PR TITLE
[4.11] Bug 2107028: only ever include certificates in the oauth-serving-cert CM

### DIFF
--- a/pkg/controllers/trustdistribution/trustdistribution_controller.go
+++ b/pkg/controllers/trustdistribution/trustdistribution_controller.go
@@ -78,6 +78,7 @@ func (c *trustDistributionController) sync(ctx context.Context, syncContext fact
 		_, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			errs = append(errs, err)
+			continue
 		}
 
 		certsFiltered += "\n" + string(pem.EncodeToMemory(block))


### PR DESCRIPTION
backport of https://github.com/openshift/cluster-authentication-operator/pull/573

/assign @ibihim 