### PR TITLE
CONSOLE-3322: Update cluster-authentication-operator not to go degraded without console

### DIFF
--- a/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
@@ -40,6 +40,7 @@ func NewConfigObserver(
 		configInformer.Config().V1().Infrastructures().Informer().HasSynced,
 		configInformer.Config().V1().OAuths().Informer().HasSynced,
 		configInformer.Config().V1().Ingresses().Informer().HasSynced,
+		configInformer.Config().V1().ClusterVersions().Informer().HasSynced,
 	}
 
 	informers := []factory.Informer{
@@ -48,6 +49,7 @@ func NewConfigObserver(
 		configInformer.Config().V1().Infrastructures().Informer(),
 		configInformer.Config().V1().OAuths().Informer(),
 		configInformer.Config().V1().Ingresses().Informer(),
+		configInformer.Config().V1().ClusterVersions().Informer(),
 	}
 
 	for _, ns := range interestingNamespaces {

--- a/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/controllers/configobservation/configobservercontroller/observe_config_controller.go
@@ -1,6 +1,7 @@
 package configobservercontroller
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
@@ -24,6 +25,7 @@ func NewConfigObserver(
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	configInformer configinformers.SharedInformerFactory,
 	resourceSyncer resourcesynccontroller.ResourceSyncer,
+	enabledClusterCapabilities sets.String,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	interestingNamespaces := []string{
@@ -35,7 +37,6 @@ func NewConfigObserver(
 	preRunCacheSynced := []cache.InformerSynced{
 		operatorClient.Informer().HasSynced,
 		configInformer.Config().V1().APIServers().Informer().HasSynced,
-		configInformer.Config().V1().Consoles().Informer().HasSynced,
 		configInformer.Config().V1().Infrastructures().Informer().HasSynced,
 		configInformer.Config().V1().OAuths().Informer().HasSynced,
 		configInformer.Config().V1().Ingresses().Informer().HasSynced,
@@ -44,7 +45,6 @@ func NewConfigObserver(
 	informers := []factory.Informer{
 		operatorClient.Informer(),
 		configInformer.Config().V1().APIServers().Informer(),
-		configInformer.Config().V1().Consoles().Informer(),
 		configInformer.Config().V1().Infrastructures().Informer(),
 		configInformer.Config().V1().OAuths().Informer(),
 		configInformer.Config().V1().Ingresses().Informer(),
@@ -79,21 +79,30 @@ func NewConfigObserver(
 			configobserver.WithPrefix(o, configobservation.OAuthServerConfigPrefix))
 	}
 
+	listers := configobservation.Listers{
+		ConfigMapLister: kubeInformersForNamespaces.ConfigMapLister(),
+		SecretsLister:   kubeInformersForNamespaces.SecretLister(),
+		IngressLister:   configInformer.Config().V1().Ingresses().Lister(),
+
+		APIServerLister_:     configInformer.Config().V1().APIServers().Lister(),
+		ClusterVersionLister: configInformer.Config().V1().ClusterVersions().Lister(),
+		InfrastructureLister: configInformer.Config().V1().Infrastructures().Lister(),
+		OAuthLister_:         configInformer.Config().V1().OAuths().Lister(),
+		ResourceSync:         resourceSyncer,
+		PreRunCachesSynced:   preRunCacheSynced,
+	}
+
+	// Check if the Console capability is enabled on the cluster and sync and add its informer and lister.
+	if enabledClusterCapabilities.Has("Console") {
+		preRunCacheSynced = append(preRunCacheSynced, configInformer.Config().V1().Consoles().Informer().HasSynced)
+		informers = append(informers, configInformer.Config().V1().Consoles().Informer())
+		listers.ConsoleLister = configInformer.Config().V1().Consoles().Lister()
+	}
+
 	return configobserver.NewNestedConfigObserver(
 		operatorClient,
 		eventRecorder,
-		configobservation.Listers{
-			ConfigMapLister: kubeInformersForNamespaces.ConfigMapLister(),
-			SecretsLister:   kubeInformersForNamespaces.SecretLister(),
-			IngressLister:   configInformer.Config().V1().Ingresses().Lister(),
-
-			APIServerLister_:     configInformer.Config().V1().APIServers().Lister(),
-			ConsoleLister:        configInformer.Config().V1().Consoles().Lister(),
-			InfrastructureLister: configInformer.Config().V1().Infrastructures().Lister(),
-			OAuthLister_:         configInformer.Config().V1().OAuths().Lister(),
-			ResourceSync:         resourceSyncer,
-			PreRunCachesSynced:   preRunCacheSynced,
-		},
+		listers,
 		informers,
 		[]string{configobservation.OAuthServerConfigPrefix},
 		"OAuthServer",

--- a/pkg/controllers/configobservation/interfaces.go
+++ b/pkg/controllers/configobservation/interfaces.go
@@ -21,6 +21,7 @@ type Listers struct {
 
 	APIServerLister_     configlistersv1.APIServerLister
 	ConsoleLister        configlistersv1.ConsoleLister
+	ClusterVersionLister configlistersv1.ClusterVersionLister
 	InfrastructureLister configlistersv1.InfrastructureLister
 	OAuthLister_         configlistersv1.OAuthLister
 	IngressLister        configlistersv1.IngressLister

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -237,6 +237,8 @@ func prepareOauthOperator(controllerContext *controllercmd.ControllerContext, op
 
 	clusterVersionLister := operatorCtx.operatorConfigInformer.Config().V1().ClusterVersions().Lister()
 	clusterVersionConfig, err := clusterVersionLister.Get("version")
+	fmt.Printf("\nclusterVersionConfig - %#v", clusterVersionConfig)
+	fmt.Printf("\nerr - %#v\n", err)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -195,6 +195,13 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	for _, informerToRunFn := range operatorCtx.informersToRunFunc {
 		informerToRunFn(ctx.Done())
 	}
+	allSynced := operatorCtx.operatorConfigInformer.WaitForCacheSync(ctx.Done())
+	for t, synced := range allSynced {
+		if !synced {
+			return fmt.Errorf("informer cache not synchronized for %v", t)
+		}
+	}
+
 	for _, controllerRunFn := range operatorCtx.controllersToRunFunc {
 		go controllerRunFn(ctx, 1)
 	}


### PR DESCRIPTION
Adding check if the Console capability is disabled in the ClusterVersion in case the console config is not present on the cluster. In this case cluster-authentication-operator should not get degraded.

/assign @stlaz 