### PR TITLE
AUTH-363: make proxy config check less obtrusive

### DIFF
--- a/pkg/controllers/common/config.go
+++ b/pkg/controllers/common/config.go
@@ -4,12 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
-
-	"github.com/openshift/library-go/pkg/controller/factory"
 )
 
 // UnstructuredConfigFrom returns the configuration from the operator's observedConfig field in the subtree given by the prefix
@@ -29,16 +25,4 @@ func UnstructuredConfigFrom(observedBytes []byte, prefix ...string) ([]byte, err
 	}
 
 	return json.Marshal(actualConfig)
-}
-
-// TODO: this should be in library-go
-func NamesFilter(names ...string) factory.EventFilterFunc {
-	nameSet := sets.NewString(names...)
-	return func(obj interface{}) bool {
-		metaObj, ok := obj.(metav1.ObjectMetaAccessor)
-		if !ok {
-			return false
-		}
-		return nameSet.Has(metaObj.GetObjectMeta().GetName())
-	}
 }

--- a/pkg/controllers/oauthclientscontroller/oauthclientscontroller.go
+++ b/pkg/controllers/oauthclientscontroller/oauthclientscontroller.go
@@ -60,11 +60,11 @@ func NewOAuthClientsController(
 		WithSync(c.sync).
 		WithSyncDegradedOnError(operatorClient).
 		WithFilteredEventsInformers(
-			common.NamesFilter("openshift-browser-client", "openshift-challenging-client"),
+			factory.NamesFilter("openshift-browser-client", "openshift-challenging-client"),
 			oauthInformers.Oauth().V1().OAuthClients().Informer(),
 		).
 		WithFilteredEventsInformers(
-			common.NamesFilter("oauth-openshift"),
+			factory.NamesFilter("oauth-openshift"),
 			routeInformers.Route().V1().Routes().Informer(),
 		).
 		WithInformers(ingressInformers.Config().V1().Ingresses().Informer()).

--- a/pkg/controllers/proxyconfig/proxyconfig_controller.go
+++ b/pkg/controllers/proxyconfig/proxyconfig_controller.go
@@ -56,8 +56,9 @@ func NewProxyConfigChecker(
 		ResyncEvery(60 * time.Minute).
 		WithSyncDegradedOnError(operatorClient)
 
-	for ns := range caConfigMaps {
-		c.WithInformers(
+	for ns, configMapNames := range caConfigMaps {
+		c.WithFilteredEventsInformers(
+			factory.NamesFilter(configMapNames...),
 			configMapInformers.InformersFor(ns).Core().V1().ConfigMaps().Informer(),
 		)
 	}

--- a/pkg/controllers/proxyconfig/proxyconfig_controller.go
+++ b/pkg/controllers/proxyconfig/proxyconfig_controller.go
@@ -52,7 +52,7 @@ func NewProxyConfigChecker(
 		WithInformers(
 			routeInformer.Informer(),
 		).
-		ResyncEvery(5 * time.Minute).
+		ResyncEvery(60 * time.Minute).
 		WithSyncDegradedOnError(operatorClient)
 
 	for ns := range caConfigMaps {

--- a/pkg/controllers/proxyconfig/proxyconfig_controller.go
+++ b/pkg/controllers/proxyconfig/proxyconfig_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
@@ -94,22 +95,22 @@ func (p *proxyConfigChecker) sync(ctx context.Context, _ factory.SyncContext) er
 // checkProxyConfig determines any mis-configuration in proxy settings by attempting
 // to connect to endpoint directly and via proxy and comparing the results with expectations.
 func checkProxyConfig(ctx context.Context, endpointURL *url.URL, noProxy string, clientWithProxy, clientWithoutProxy *http.Client) error {
-	withProxyErr := isEndpointReachable(ctx, endpointURL.String(), clientWithProxy)
-	withoutProxyErr := isEndpointReachable(ctx, endpointURL.String(), clientWithoutProxy)
+	withProxy := newLazyChecker(func() error { return isEndpointReachable(ctx, endpointURL.String(), clientWithProxy) })
+	withoutProxy := newLazyChecker(func() error { return isEndpointReachable(ctx, endpointURL.String(), clientWithoutProxy) })
 	noProxyMatchesEndpoint := parseNoProxy(noProxy).matches(canonicalAddr(endpointURL))
 
-	if noProxyMatchesEndpoint && withoutProxyErr != nil {
-		if withProxyErr == nil {
-			return fmt.Errorf("failed to reach endpoint(%q) found in NO_PROXY(%q) with error: %v", endpointURL.String(), noProxy, withoutProxyErr)
+	if noProxyMatchesEndpoint && withoutProxy() != nil {
+		if withProxy() == nil {
+			return fmt.Errorf("failed to reach endpoint(%q) found in NO_PROXY(%q) with error: %v", endpointURL.String(), noProxy, withoutProxy())
 		}
-		return fmt.Errorf("endpoint(%q) found in NO_PROXY(%q) is unreachable with proxy(%v) and without proxy(%v)", endpointURL.String(), noProxy, withProxyErr, withoutProxyErr)
+		return fmt.Errorf("endpoint(%q) found in NO_PROXY(%q) is unreachable with proxy(%v) and without proxy(%v)", endpointURL.String(), noProxy, withProxy(), withoutProxy())
 	}
 
-	if !noProxyMatchesEndpoint && withProxyErr != nil {
-		if withoutProxyErr == nil {
-			return fmt.Errorf("failed to reach endpoint(%q) missing in NO_PROXY(%q) with error: %v", endpointURL.String(), noProxy, withProxyErr)
+	if !noProxyMatchesEndpoint && withProxy() != nil {
+		if withoutProxy() == nil {
+			return fmt.Errorf("failed to reach endpoint(%q) missing in NO_PROXY(%q) with error: %v", endpointURL.String(), noProxy, withProxy())
 		}
-		return fmt.Errorf("endpoint(%q) is unreachable with proxy(%v) and without proxy(%v)", endpointURL.String(), withProxyErr, withoutProxyErr)
+		return fmt.Errorf("endpoint(%q) is unreachable with proxy(%v) and without proxy(%v)", endpointURL.String(), withProxy(), withoutProxy())
 	}
 
 	return nil
@@ -204,4 +205,17 @@ func proxyFunc(req *http.Request) (*url.URL, error) {
 		return nil, err
 	}
 	return proxyURL, nil
+}
+
+// newLazyChecker returns a function that calculates an error value once
+// and returns that error in subsequent calls
+func newLazyChecker(f func() error) func() error {
+	var err error
+	var once sync.Once
+	return func() error {
+		once.Do(func() {
+			err = f()
+		})
+		return err
+	}
 }

--- a/pkg/controllers/proxyconfig/proxyconfig_controller_test.go
+++ b/pkg/controllers/proxyconfig/proxyconfig_controller_test.go
@@ -171,20 +171,17 @@ func Test_checkProxyConfig(t *testing.T) {
 		wantErr            error
 	}{
 		{
-			name:               "good proxy config with endpoint not matching noProxy",
-			clientWithProxy:    goodHTTPClient,
-			clientWithoutProxy: badHTTPClient,
+			name:            "good proxy config with endpoint not matching noProxy",
+			clientWithProxy: goodHTTPClient,
 		},
 		{
 			name:               "good proxy config with endpoint matching noProxy",
 			noProxy:            "proxy.testing.com",
-			clientWithProxy:    badHTTPClient,
 			clientWithoutProxy: goodHTTPClient,
 		},
 		{
 			name:               "good proxy config with endpoint matching domain in noProxy",
 			noProxy:            "testing.com",
-			clientWithProxy:    badHTTPClient,
 			clientWithoutProxy: goodHTTPClient,
 		},
 		{

--- a/pkg/controllers/routercerts/controller.go
+++ b/pkg/controllers/routercerts/controller.go
@@ -79,7 +79,7 @@ func NewRouterCertsDomainValidationController(
 			targetNSsecretInformer.Informer(),
 			configMapInformer.Informer()).
 		WithFilteredEventsInformers(
-			common.NamesFilter("router-certs"),
+			factory.NamesFilter("router-certs"),
 			machineConfigNSSecretInformer.Informer(),
 		).
 		WithSync(controller.sync).


### PR DESCRIPTION
This PR contains the following changes:
- increase check interval to 60 min
- perform the actual endpoint calls with/without proxy only when they are required to deduce the check outcome
- filter configmap events to only the ones used in the context of the proxy config checker