### PR TITLE
OCPBUGS-12907: pkg/operator/starter: add InvalidProviderInvalidCertsUpgradeable to stale conditions

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -265,6 +265,8 @@ func prepareOauthOperator(ctx context.Context, controllerContext *controllercmd.
 			"OAuthVersionRouteAvailable",
 			"OAuthVersionRouteSecretDegraded",
 			"OAuthVersionIngressConfigDegraded",
+			// condition type only present in 4.9, removed in 4.10
+			"InvalidProviderInvalidCertsUpgradeable",
 		},
 		operatorCtx.operatorClient,
 		controllerContext.EventRecorder,


### PR DESCRIPTION
This removes the `InvalidProviderInvalidCertsUpgradeable` condition present in 4.9. This condition is not present in 4.10 any more as the controller setting it is removed.

The underlying reason is that invalid certs were tolerated in 4.9, however in 4.10 they won't work at all any more because of the Go version being used, see https://bugzilla.redhat.com/show_bug.cgi?id=2037274#c23.

/cc @deads2k @stlaz @mfojtik 