### PR TITLE
Add AES-GCM encryption tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ check: | verify test-unit
 
 IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 
+ENCRYPTION_PROVIDERS=aescbc aesgcm
+ENCRYPTION_PROVIDER?=aescbc
+
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name
 # $1 - target name
@@ -58,28 +61,48 @@ run-e2e-test: GO_TEST_PACKAGES += -count 1
 run-e2e-test: test-unit
 .PHONY: run-e2e-test
 
+TEST_E2E_ENCRYPTION_TARGETS=$(addprefix test-e2e-encryption-,$(ENCRYPTION_PROVIDERS))
+
 # these are extremely slow serial e2e encryption tests that modify the cluster's global state
 test-e2e-encryption: GO_TEST_PACKAGES :=./test/e2e-encryption/...
 test-e2e-encryption: GO_TEST_FLAGS += -v
 test-e2e-encryption: GO_TEST_FLAGS += -timeout 4h
 test-e2e-encryption: GO_TEST_FLAGS += -p 1
-test-e2e-encryption: GO_TEST_FLAGS += -parallel 1
+test-e2e-encryption: GO_TEST_ARGS += -args -provider=$(ENCRYPTION_PROVIDER)
 test-e2e-encryption: test-unit
 .PHONY: test-e2e-encryption
+
+.PHONY: $(TEST_E2E_ENCRYPTION_TARGETS)
+$(TEST_E2E_ENCRYPTION_TARGETS): test-e2e-encryption-%:
+	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption
+
+TEST_E2E_ENCRYPTION_PERF_TARGETS=$(addprefix test-e2e-encryption-perf-,$(ENCRYPTION_PROVIDERS))
 
 test-e2e-encryption-perf: GO_TEST_PACKAGES :=./test/e2e-encryption-perf/...
 test-e2e-encryption-perf: GO_TEST_FLAGS += -v
 test-e2e-encryption-perf: GO_TEST_FLAGS += -timeout 2h
 test-e2e-encryption-perf: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-perf: GO_TEST_ARGS += -args -provider=$(ENCRYPTION_PROVIDER)
 test-e2e-encryption-perf: test-unit
 .PHONY: test-e2e-encryption-perf
+
+.PHONY: $(TEST_E2E_ENCRYPTION_PERF_TARGETS)
+$(TEST_E2E_ENCRYPTION_PERF_TARGETS): test-e2e-encryption-perf-%:
+	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption-perf
+
+TEST_E2E_ENCRYPTION_ROTATION_TARGETS=$(addprefix test-e2e-encryption-rotation-,$(ENCRYPTION_PROVIDERS))
 
 test-e2e-encryption-rotation: GO_TEST_PACKAGES :=./test/e2e-encryption-rotation/...
 test-e2e-encryption-rotation: GO_TEST_FLAGS += -v
 test-e2e-encryption-rotation: GO_TEST_FLAGS += -timeout 4h
 test-e2e-encryption-rotation: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-rotation: GO_TEST_ARGS += -args -provider=$(ENCRYPTION_PROVIDER)
 test-e2e-encryption-rotation: test-unit
 .PHONY: test-e2e-encryption-rotation
+
+.PHONY: $(TEST_E2E_ENCRYPTION_ROTATION_TARGETS)
+$(TEST_E2E_ENCRYPTION_ROTATION_TARGETS): test-e2e-encryption-rotation-%:
+	ENCRYPTION_PROVIDER=$* $(MAKE) test-e2e-encryption-rotation
 
 # Configure the 'telepresence' target
 # See vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh for usage and configuration details

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/google/go-cmp v0.5.9
 	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183
-	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+	github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb
 	github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf
 	github.com/spf13/cobra v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183 h1:t/CahSnpqY46sQR01SoS+Jt0jtjgmhgE6lFmRnO4q70=
 github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183/go.mod h1:4VWG+W22wrB4HfBL88P40DxLEpSOaiBVxUnfalfJo9k=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479 h1:IU2KU1kzg7/dfiZO4uPJY1G5Wp1k/IiXfYesc+quwaE=
+github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb h1:Nij5OnaECrkmcRQMAE9LMbQXPo95aqFnf+12B7SyFVI=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb/go.mod h1:Rhb3moCqeiTuGHAbXBOlwPubUMlOZEkrEWTRjIF3jzs=
 github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf h1:ZpFAN2qprgp7jEhGPrOAwP8mmuYC9BRYzvDefg+k4GM=

--- a/test/e2e-encryption-perf/encryption_perf_test.go
+++ b/test/e2e-encryption-perf/encryption_perf_test.go
@@ -3,6 +3,7 @@ package e2e_encryption_perf
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"testing"
 	"time"
@@ -25,7 +26,9 @@ const (
 	tokenStatsKey = "created oauthaccesstokens"
 )
 
-func TestPerfEncryptionTypeAESCBC(tt *testing.T) {
+var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
+
+func TestPerfEncryption(tt *testing.T) {
 	ctx := context.TODO()
 	clientSet := getPerfClients(tt)
 	library.TestPerfEncryption(tt, library.PerfScenario{
@@ -38,6 +41,7 @@ func TestPerfEncryptionTypeAESCBC(tt *testing.T) {
 			TargetGRs:                       operatorencryption.DefaultTargetGRs,
 			AssertFunc:                      operatorencryption.AssertTokens,
 		},
+		EncryptionProvider: configv1.EncryptionType(*provider),
 		GetOperatorConditionsFunc: func(t testing.TB) ([]operatorv1.OperatorCondition, error) {
 			apiServerOperator, err := clientSet.OperatorClient.Get(ctx, "cluster", metav1.GetOptions{})
 			if err != nil {

--- a/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
+++ b/test/e2e-encryption-rotation/e2e-encryption-rotation_test.go
@@ -3,6 +3,7 @@ package e2e_encryption_rotation
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"testing"
 
@@ -11,10 +12,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	configv1 "github.com/openshift/api/config/v1"
 	oauthapiconfigobservercontroller "github.com/openshift/cluster-authentication-operator/pkg/operator/configobservation/configobservercontroller"
 	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
 )
+
+var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
 
 // TestEncryptionRotation first encrypts data with aescbc key
 // then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
@@ -30,6 +34,7 @@ func TestEncryptionRotation(t *testing.T) {
 			TargetGRs:                       operatorencryption.DefaultTargetGRs,
 			AssertFunc:                      operatorencryption.AssertTokens,
 		},
+		EncryptionProvider: configv1.EncryptionType(*provider),
 		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, _ string) runtime.Object {
 			return operatorencryption.CreateAndStoreTokenOfLife(ctx, t, operatorencryption.GetClients(t))
 		},

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -2,6 +2,7 @@ package e2eencryption
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"testing"
 
@@ -11,6 +12,8 @@ import (
 	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
 )
+
+var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
 
 func TestEncryptionTypeIdentity(t *testing.T) {
 	library.TestEncryptionTypeIdentity(t, library.BasicScenario{
@@ -54,6 +57,6 @@ func TestEncryptionTurnOnAndOff(t *testing.T) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertTokenOfLifeNotEncrypted,
 		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.TokenOfLife(t) },
 		ResourceName:                   "TokenOfLife",
-		EncryptionProvider:             configv1.EncryptionType("aescbc"),
+		EncryptionProvider:             configv1.EncryptionType(*provider),
 	})
 }

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
@@ -4,11 +4,11 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 test-unit:
 ifndef JUNITFILE
-	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES)
+	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES) $(GO_TEST_ARGS)
 else
 ifeq (, $(shell which gotest2junit 2>/dev/null))
 	$(error gotest2junit not found! Get it by `go get -mod='' -u github.com/openshift/release/tools/gotest2junit`.)
 endif
-	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) | gotest2junit > $(JUNITFILE)
+	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) $(GO_TEST_ARGS) | gotest2junit > $(JUNITFILE)
 endif
 .PHONY: test-unit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+# github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 ## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
This PR brings the changes from https://github.com/openshift/cluster-kube-apiserver-operator/pull/1449 over to cluster-authentication-operator.

Separately new jobs are being added in https://github.com/openshift/release/pull/40120 in order to run the new AES-GCM encryption tests.