### PR TITLE
Correctly link oauth apiserver ServiceMonitor with its Service

### DIFF
--- a/bindata/oauth-apiserver/svc.yaml
+++ b/bindata/oauth-apiserver/svc.yaml
@@ -7,6 +7,8 @@ metadata:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
+  labels:
+    app: openshift-oauth-apiserver
 spec:
   selector:
     apiserver: "true"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -483,6 +483,8 @@ metadata:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
+  labels:
+    app: openshift-oauth-apiserver
 spec:
   selector:
     apiserver: "true"


### PR DESCRIPTION
The oauth-apiserver ServiceMonitor is not able to find the oauth-apiserver Service because the label selectors don't match causing no metrics to be collected for the apiserver.