### PR TITLE
OCPBUGS-8093: properly set the pod name and namespace in graceful termination lifecycle events

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -75,6 +75,17 @@ spec:
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}
+        env:
+          # used to emit shutdown lifecycles events in the correct namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          # used to emit shutdown lifecycles events in the correct namespace
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         resources:
           requests:
             memory: 200Mi

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -275,6 +275,17 @@ spec:
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}
+        env:
+          # used to emit shutdown lifecycles events in the correct namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          # used to emit shutdown lifecycles events in the correct namespace
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         resources:
           requests:
             memory: 200Mi

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "8ee33dafe676726b34f44c7d7ea1db1d8e318c29232044323695da5d52342f56"
+    operator.openshift.io/spec-hash: "a3388d2173a2b31e4859bf0a2aaf399244095d1f07b564ef1ff462cb702c8526"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -58,6 +58,15 @@ spec:
           command:
             - /bin/bash
             - "-ec"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "fc856dccb78052f4091e81833aaad06e7354f1e3a2a6fd15927b75e91f0cafde"
+    operator.openshift.io/spec-hash: "994140f3479dd5b763c4b8e94b37a37d257354f16b8b35806ed6a532a41dc19f"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -67,6 +67,15 @@ spec:
           command:
             - /bin/bash
             - "-ec"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "12ebf32bd21d3cd5a2a3a2eb7f7689fdcced34406acd9b62dfd3859b97e2b931"
+    operator.openshift.io/spec-hash: "0ac23e4834469cabe09a8436adbc50a839d21736e9750fd62b73d57ec35164af"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -62,6 +62,15 @@ spec:
           command:
             - /bin/bash
             - "-ec"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
…ycle events

used here: https://github.com/openshift/oauth-apiserver/blob/release-4.14/vendor/k8s.io/apiserver/pkg/server/config.go#L694-L725