### PR TITLE
OCPBUGS-17987: generate only >=0 number of random bits

### DIFF
--- a/pkg/controllers/oauthclientscontroller/oauthclientscontroller.go
+++ b/pkg/controllers/oauthclientscontroller/oauthclientscontroller.go
@@ -146,7 +146,7 @@ func (c *oauthsClientsController) ensureBootstrappedOAuthClients(ctx context.Con
 	return nil
 }
 
-func randomBits(bits int) []byte {
+func randomBits(bits uint) []byte {
 	size := bits / 8
 	if bits%8 != 0 {
 		size++

--- a/pkg/controllers/oauthclientscontroller/oauthclientscontroller_test.go
+++ b/pkg/controllers/oauthclientscontroller/oauthclientscontroller_test.go
@@ -243,7 +243,7 @@ func Test_ensureBootstrappedOAuthClients(t *testing.T) {
 
 func Test_randomBits(t *testing.T) {
 	tests := []struct {
-		bits        int
+		bits        uint
 		expectedLen int
 	}{
 		{0, 0}, {1, 1}, {8, 1}, {16, 2}, {32, 4}, {64, 8}, {128, 16}, {256, 32}, {512, 64},


### PR DESCRIPTION
This PR changes the input type of the `randomBits()` func to `uint` so that it won't accept any negative numbers as input (which cause a panic).