### PR TITLE
OCPBUGS-18115: Remove "include.release.openshift.io/ibm-cloud-managed:" annotation 

### DIFF
--- a/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
@@ -37,7 +37,6 @@ metadata:
   name: oauth-openshift
   namespace: openshift-authentication
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:


### PR DESCRIPTION
Remove "include.release.openshift.io/ibm-cloud-managed:" annotation in order to CVO not deploy the service monitor

