### PR TITLE
WRKLDS-1004: use AlwaysAllow UnhealthyPodEvictionPolicy in PDBs

### DIFF
--- a/bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
+++ b/bindata/oauth-apiserver/oauth-apiserver-pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-oauth-apiserver
 spec:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: openshift-oauth-apiserver

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -442,6 +442,7 @@ metadata:
   namespace: openshift-oauth-apiserver
 spec:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: openshift-oauth-apiserver


### PR DESCRIPTION
allow eviction of unhealthy (not ready) pods even if there are no disruptions allowed on a PodDisruptionBudget. This can help to drain/maintain a node and recover without a manual intervention when multiple instances of nodes or pods are misbehaving. Use this with caution, as this option can disrupt perspective pods that have not yet had a chance to become healthy.