### PR TITLE
NO-ISSUE: oauth-apiserver: enable shutdown-send-retry-after 

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -72,6 +72,7 @@ spec:
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
               --shutdown-delay-duration=15s \
+              --shutdown-send-retry-after=true \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -272,6 +272,7 @@ spec:
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
               --shutdown-delay-duration=15s \
+              --shutdown-send-retry-after=true \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
               ${FLAGS}

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "a3388d2173a2b31e4859bf0a2aaf399244095d1f07b564ef1ff462cb702c8526"
+    operator.openshift.io/spec-hash: "9afc5895a397b7bc091476c1f6cf21f1fa1cc69bd07ccb993b61c7a6adc826a6"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -52,6 +52,7 @@ spec:
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
                 --shutdown-delay-duration=15s \
+                --shutdown-send-retry-after=true \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --v=2

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "994140f3479dd5b763c4b8e94b37a37d257354f16b8b35806ed6a532a41dc19f"
+    operator.openshift.io/spec-hash: "cd2180074a02a06393c103f7da40f1c9e3fd3f4d5ff1ba657e6d74d552ae84b4"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -52,6 +52,7 @@ spec:
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
                 --shutdown-delay-duration=15s \
+                --shutdown-send-retry-after=true \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --cors-allowed-origins='//127\.0\.0\.1(:|$)' \

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "0ac23e4834469cabe09a8436adbc50a839d21736e9750fd62b73d57ec35164af"
+    operator.openshift.io/spec-hash: "35fc064337e00a8e3ea5fc2ddf09b2fa4595868462f99dfe0301a842eefa9571"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -52,6 +52,7 @@ spec:
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
                 --shutdown-delay-duration=15s \
+                --shutdown-send-retry-after=true \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
                 --cors-allowed-origins='//127\.0\.0\.1(:|$)' \


### PR DESCRIPTION
if true the HTTP Server will continue listening until all non long running request(s) in flight have been drained,
during this window all incoming requests will be rejected with a status code 429 and a 'Retry-After' response header,
in addition 'Connection: close' response header is set in order to tear down the TCP connection when idle.

without this flag requests that arrive after the shutdown delay duration will get a network error.

which might explain failures seen in: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.15-e2e-azure-sdn-upgrade/1759779765541146624



The other issue is that `TerminationMinimalShutdownDurationFinished` says `The minimal shutdown duration of 0s finished` which means that the server can be immediately terminated when all in-flight requests are completed.


