### PR TITLE
[release-4.15]  OCPBUGS-34795: set required-scc for openshift workloads

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -30,6 +30,7 @@ spec:
         apiserver: "true"
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       serviceAccountName: oauth-apiserver-sa
       priorityClassName: system-node-critical

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app: oauth-openshift
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app: authentication-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: anyuid
     spec:
       serviceAccountName: authentication-operator
       containers:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -230,6 +230,7 @@ spec:
         apiserver: "true"
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       serviceAccountName: oauth-apiserver-sa
       priorityClassName: system-node-critical
@@ -656,6 +657,7 @@ spec:
         app: oauth-openshift
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "a3388d2173a2b31e4859bf0a2aaf399244095d1f07b564ef1ff462cb702c8526"
+    operator.openshift.io/spec-hash: "667ad1f983f43b07fc26fb6e402c9bab65275cd6787b952d3035022a248c178d"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -32,6 +32,7 @@ spec:
       name: openshift-oauth-apiserver
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "994140f3479dd5b763c4b8e94b37a37d257354f16b8b35806ed6a532a41dc19f"
+    operator.openshift.io/spec-hash: "f61a64bf402a1f920421017f1f26d7618b39038d5278c1ce10949b23e6c050b1"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -32,6 +32,7 @@ spec:
       name: openshift-oauth-apiserver
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "0ac23e4834469cabe09a8436adbc50a839d21736e9750fd62b73d57ec35164af"
+    operator.openshift.io/spec-hash: "20615b7f57b5fb7819dc8d4af11a28feb70d470a57123184ff0fee37c147001f"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -32,6 +32,7 @@ spec:
       name: openshift-oauth-apiserver
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       containers:
         -


### PR DESCRIPTION
This is a manual cherry-pick of #656. This PR does not include the refactoring changes of bindata, instead only the required-scc changes.