### PR TITLE
NO-JIRA: OWNERS: add ibihim, liouk, rm old

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
-  - stlaz
+  - ibihim
+  - liouk
 approvers:
-  - stlaz
-  - sttts
   - deads2k
 components: apiserver-auth


### PR DESCRIPTION
## What

Add ibihim as approver, add liouk as reviewer.

## Why

Both of us have contributed to the repository. I had the pleasure to refactor and work with the observed config to deliver an audit policy to the oauth-server.

Liouk worked on the proxy config.