### PR TITLE
AUTH-546: Direct external OIDC e2e test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1
+	k8s.io/apiserver v0.30.1
 	k8s.io/client-go v0.30.1
 	k8s.io/component-base v0.30.1
 	k8s.io/klog/v2 v2.120.1
@@ -106,7 +107,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.1 // indirect
-	k8s.io/apiserver v0.30.1 // indirect
 	k8s.io/kms v0.30.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 // indirect

--- a/test/e2e/external_oidc_test.go
+++ b/test/e2e/external_oidc_test.go
@@ -1,0 +1,450 @@
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	features "github.com/openshift/api/features"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
+	test "github.com/openshift/cluster-authentication-operator/test/library"
+	"github.com/stretchr/testify/require"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	oidcClientId      = "admin-cli"
+	oidcAudience      = "openshift-aud"
+	oidcGroupsClaim   = "groups"
+	oidcUsernameClaim = "email"
+
+	kasNamespace = "openshift-kube-apiserver"
+
+	// set if a specific CA bundle is needed for the OIDC provider
+	oidcCABundleConfigMap          = ""
+	oidcCABundleConfigMapNamespace = ""
+)
+
+type testClient struct {
+	t *testing.T
+
+	kubeConfig           *rest.Config
+	kubeClient           *kubernetes.Clientset
+	configClient         *configclient.Clientset
+	operatorConfigClient *operatorversionedclient.Clientset
+}
+
+type oidcAuthResponse struct {
+	AccessToken      string `json:"access_token"`
+	ExpiresIn        int    `json:"expires_in"`
+	RefreshToken     string `json:"refresh_token"`
+	RefreshExpiresIn int    `json:"refresh_expires_in"`
+	TokenType        string `json:"token_type"`
+	IdToken          string `json:"id_token"`
+	NotBeforePolicy  int    `json:"not_before_policy"`
+	SessionState     string `json:"session_state"`
+	Scope            string `json:"scope"`
+}
+
+func TestExternalOIDCWithKeycloak(t *testing.T) {
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc, err := newTestClient(t)
+	require.NoError(t, err)
+
+	// ===============================
+	// Check ExternalOIDC feature gate
+	// ===============================
+
+	featureGates, err := tc.configClient.ConfigV1().FeatureGates().Get(testCtx, "cluster", metav1.GetOptions{})
+	require.NoError(tc.t, err)
+
+	if len(featureGates.Status.FeatureGates) != 1 {
+		// fail test if there are multiple feature gate versions (i.e. ongoing upgrade)
+		tc.t.Fatalf("multiple feature gate versions detected")
+	} else {
+		for _, fgDisabled := range featureGates.Status.FeatureGates[0].Disabled {
+			if fgDisabled.Name == features.FeatureGateExternalOIDC {
+				tc.t.Skipf("feature gate '%s' disabled", features.FeatureGateExternalOIDC)
+			}
+		}
+	}
+
+	// ==============
+	// Setup Keycloak
+	// ==============
+
+	var kcClient *test.KeycloakClient
+	if keycloakURL := os.Getenv("E2E_KEYCLOAK_URL"); len(keycloakURL) > 0 {
+		t.Logf("will use existing keycloak deployment at URL: %s", keycloakURL)
+		kcClient = tc.setupKeycloakClient(testCtx, keycloakURL)
+
+	} else {
+		t.Logf("no existing keycloak deployment found; will create new")
+		var cleanups []func()
+		kcClient, cleanups = tc.setupExternalOIDCWithKeycloak(testCtx)
+		defer test.IDPCleanupWrapper(func() {
+			for _, c := range cleanups {
+				c()
+			}
+		})()
+		t.Logf("keycloak Admin URL: %s", kcClient.AdminURL())
+	}
+
+	group := names.SimpleNameGenerator.GenerateName("e2e-keycloak-group-")
+	err = kcClient.CreateGroup(group)
+	require.NoError(t, err)
+
+	user := names.SimpleNameGenerator.GenerateName("e2e-keycloak-user-")
+	email := fmt.Sprintf("%s@test.dev", user)
+	password := "password"
+	err = kcClient.CreateUser(user, email, password, []string{group})
+	require.NoError(t, err)
+
+	httpClient := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	formData := url.Values{
+		"grant_type": []string{"password"},
+		"client_id":  []string{oidcClientId},
+		"scope":      []string{"openid"},
+		"username":   []string{user},
+		"password":   []string{password},
+	}
+
+	resp, err := httpClient.PostForm(kcClient.TokenURL(), formData)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	var authResponse oidcAuthResponse
+	err = json.Unmarshal(data, &authResponse)
+	require.NoError(t, err)
+	require.NotEmpty(t, authResponse.AccessToken)
+	require.NotEmpty(t, authResponse.IdToken)
+
+	// ==========================================
+	// Test authentication via the kube-apiserver
+	// ==========================================
+
+	// create a new kube client that uses the OIDC id_token as a bearer token
+	kubeConfig := rest.AnonymousClientConfig(tc.kubeConfig)
+	kubeConfig.BearerToken = authResponse.IdToken
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	require.NoError(tc.t, err)
+
+	// test authentication with the OIDC token using a self subject review
+	ssr, err := kubeClient.AuthenticationV1().SelfSubjectReviews().Create(testCtx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	require.NoError(tc.t, err)
+	require.NotNil(tc.t, ssr)
+	require.Contains(t, ssr.Status.UserInfo.Groups, "system:authenticated")
+	require.Equal(t, email, ssr.Status.UserInfo.Username)
+}
+
+func newTestClient(t *testing.T) (*testClient, error) {
+	tc := &testClient{
+		t:          t,
+		kubeConfig: test.NewClientConfigForTest(t),
+	}
+
+	var err error
+	tc.kubeClient, err = kubernetes.NewForConfig(tc.kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	tc.configClient, err = configclient.NewForConfig(tc.kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	tc.operatorConfigClient, err = operatorversionedclient.NewForConfig(tc.kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return tc, nil
+}
+
+func (tc *testClient) setupKeycloakClient(ctx context.Context, keycloakURL string) *test.KeycloakClient {
+	transport, err := rest.TransportFor(tc.kubeConfig)
+	require.NoError(tc.t, err)
+
+	kcClient := test.KeycloakClientFor(tc.t, transport, keycloakURL, "master")
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := kcClient.AuthenticatePassword(oidcClientId, "", "admin", "password")
+		if err != nil {
+			tc.t.Logf("failed to authenticate to Keycloak: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(tc.t, err)
+
+	return kcClient
+}
+
+func (tc *testClient) setupExternalOIDCWithKeycloak(ctx context.Context) (kcClient *test.KeycloakClient, cleanups []func()) {
+	kcClient, idpName, c := test.AddKeycloakIDP(tc.t, tc.kubeConfig, true)
+	cleanups = append(cleanups, c...)
+
+	// update the authentication CR with the external OIDC configuration
+	authConfig, c, err := tc.updateAuthForOIDC(ctx, kcClient.IssuerURL(), idpName)
+	cleanups = append(cleanups, c...)
+	require.NoError(tc.t, err)
+	require.NotNil(tc.t, authConfig)
+	require.NotEmpty(tc.t, authConfig.Spec.OIDCProviders)
+
+	// patch proxy/cluster to access the default-ingress-cert that now exists in openshift-config
+	c, err = tc.updateProxyForIngressCert(ctx)
+	cleanups = append(cleanups, c...)
+	require.NoError(tc.t, err)
+
+	// sync service-ca signing certificate to the KAS nodes as a static resource so that it can be used with --oidc-ca-file
+	c, err = tc.syncServingCA(ctx, authConfig)
+	cleanups = append(cleanups, c...)
+	require.NoError(tc.t, err)
+
+	// setup kube-apiserver to access the external OIDC directly by modifying its args via UnsupportedConfigOverrides
+	kasOrigRev, c, err := tc.updateKASArgsForOIDC(ctx, authConfig)
+	cleanups = append(cleanups, c...)
+	require.NoError(tc.t, err)
+
+	// wait for serving CA and KAS args overrides to get rolled out
+	tc.t.Log("will wait for KAS rollout")
+	err = test.WaitForNewKASRollout(tc.t, ctx, tc.operatorConfigClient.OperatorV1().KubeAPIServers(), kasOrigRev)
+	require.NoError(tc.t, err)
+
+	return
+}
+
+func (tc *testClient) updateProxyForIngressCert(ctx context.Context) (cleanups []func(), err error) {
+	tc.t.Log("will copy default-ingress-cert and patch proxy")
+
+	defaultIngressCert, err := tc.kubeClient.CoreV1().ConfigMaps("openshift-config-managed").Get(ctx, "default-ingress-cert", metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	cmCopy := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultIngressCert.Name,
+			Namespace: "openshift-config",
+		},
+		Data: defaultIngressCert.Data,
+	}
+
+	_, err = tc.kubeClient.CoreV1().ConfigMaps("openshift-config").Create(ctx, cmCopy, metav1.CreateOptions{})
+	cleanups = append(cleanups, func() {
+		err := tc.kubeClient.CoreV1().ConfigMaps("openshift-config").Delete(ctx, cmCopy.Name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			tc.t.Fatalf("cleanup failed for configmap '%s/%s': %v", cmCopy.Namespace, cmCopy.Name, err)
+		}
+	})
+	if err != nil {
+		return
+	}
+
+	proxy, err := tc.configClient.ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	origTrustedCAName := proxy.Spec.TrustedCA.Name
+	proxy.Spec.TrustedCA.Name = "default-ingress-cert"
+	proxy, err = tc.configClient.ConfigV1().Proxies().Update(ctx, proxy, metav1.UpdateOptions{})
+	cleanups = append(cleanups, func() {
+		proxy.Spec.TrustedCA.Name = origTrustedCAName
+		proxy, err = tc.configClient.ConfigV1().Proxies().Update(ctx, proxy, metav1.UpdateOptions{})
+		if err != nil {
+			tc.t.Fatalf("cleanup failed for proxy '%s': %v", proxy.Name, err)
+		}
+	})
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (tc *testClient) syncServingCA(ctx context.Context, authConfig *configv1.Authentication) (cleanups []func(), err error) {
+	oidcCAConfigMapName := authConfig.Spec.OIDCProviders[0].Issuer.CertificateAuthority.Name
+	if len(oidcCAConfigMapName) == 0 {
+		// no oidc CA present; ignore
+		return nil, nil
+	}
+
+	tc.t.Log("will sync OIDC ca-bundle to KAS static pod resources")
+
+	signingKey, err := tc.kubeClient.CoreV1().ConfigMaps(oidcCABundleConfigMapNamespace).Get(ctx, oidcCABundleConfigMap, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	// This functionality requires defining "oidc-serving-ca" as a RevisionConfigMap at the KAS-o
+	// See example PR: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1720
+	oidcServingCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oidc-serving-ca",
+			Namespace: kasNamespace,
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": string(signingKey.Data["tls.crt"]),
+		},
+	}
+
+	_, err = tc.kubeClient.CoreV1().ConfigMaps(kasNamespace).Create(ctx, oidcServingCA, metav1.CreateOptions{})
+	cleanups = append(cleanups, func() {
+		err := tc.kubeClient.CoreV1().ConfigMaps(kasNamespace).Delete(ctx, oidcServingCA.Name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			tc.t.Fatalf("cleanup failed for secret '%s/%s': %v", oidcServingCA.Namespace, oidcServingCA.Name, err)
+		}
+	})
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (tc *testClient) updateKASArgsForOIDC(ctx context.Context, authConfig *configv1.Authentication) (origRevision int32, cleanups []func(), err error) {
+	tc.t.Log("will update KAS args for OIDC")
+
+	oidcCAFile := "/etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt"
+	if len(authConfig.Spec.OIDCProviders[0].Issuer.CertificateAuthority.Name) > 0 {
+		oidcCAFile = "/etc/kubernetes/static-pod-resources/configmaps/oidc-serving-ca/ca-bundle.crt"
+	}
+
+	unsupportedConfigOverrides := fmt.Sprintf(`{
+		"apiServerArguments": {
+			"oidc-ca-file": ["%s"],
+			"oidc-client-id": ["%s"],
+			"oidc-issuer-url": ["%s"],
+			"oidc-groups-claim": ["%s"],
+			"oidc-username-claim": ["%s"],
+			"oidc-username-prefix":["-"]
+		}
+	}`, oidcCAFile, oidcClientId, authConfig.Spec.OIDCProviders[0].Issuer.URL, oidcGroupsClaim, oidcUsernameClaim)
+
+	kas, err := tc.operatorConfigClient.OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	origRevision = kas.Status.LatestAvailableRevision
+	origUnsupportedConfigOverides := kas.Spec.UnsupportedConfigOverrides
+	kas.Spec.UnsupportedConfigOverrides = runtime.RawExtension{Raw: []byte(unsupportedConfigOverrides)}
+
+	kas, err = tc.operatorConfigClient.OperatorV1().KubeAPIServers().Update(ctx, kas, metav1.UpdateOptions{})
+	cleanups = append(cleanups, func() {
+		kas, err := tc.operatorConfigClient.OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			tc.t.Fatalf("cleanup failed for kube-apiserver '%s', while getting fresh object: %v", kas.Name, err)
+		}
+
+		origRevision := kas.Status.LatestAvailableRevision
+		kas.Spec.UnsupportedConfigOverrides = origUnsupportedConfigOverides
+		kas, err = tc.operatorConfigClient.OperatorV1().KubeAPIServers().Update(ctx, kas, metav1.UpdateOptions{})
+		if err != nil {
+			tc.t.Fatalf("cleanup failed for kube-apiserver '%s': %v", kas.Name, err)
+		}
+
+		err = test.WaitForNewKASRollout(tc.t, ctx, tc.operatorConfigClient.OperatorV1().KubeAPIServers(), origRevision)
+		if err != nil {
+			tc.t.Fatalf("cleanup failed for kube-apiserver '%s': %v", kas.Name, err)
+		}
+	})
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (tc *testClient) updateAuthForOIDC(ctx context.Context, idpURL, idpName string) (auth *configv1.Authentication, cleanups []func(), err error) {
+	tc.t.Log("will update auth CR for OIDC")
+
+	auth, err = tc.configClient.ConfigV1().Authentications().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	origSpec := auth.Spec.DeepCopy()
+	auth.Spec.Type = configv1.AuthenticationTypeOIDC
+	auth.Spec.WebhookTokenAuthenticator = nil
+	auth.Spec.OIDCProviders = []configv1.OIDCProvider{
+		{
+			Name: idpName,
+			Issuer: configv1.TokenIssuer{
+				URL:       idpURL,
+				Audiences: []configv1.TokenAudience{oidcAudience},
+				CertificateAuthority: configv1.ConfigMapNameReference{
+					Name: oidcCABundleConfigMap,
+				},
+			},
+			ClaimMappings: configv1.TokenClaimMappings{
+				Groups: configv1.PrefixedClaimMapping{
+					TokenClaimMapping: configv1.TokenClaimMapping{
+						Claim: oidcGroupsClaim,
+					},
+				},
+				Username: configv1.UsernameClaimMapping{
+					TokenClaimMapping: configv1.TokenClaimMapping{
+						Claim: oidcUsernameClaim,
+					},
+				},
+			},
+			OIDCClients: []configv1.OIDCClientConfig{
+				{
+					ClientID:           "console",
+					ClientSecret:       configv1.SecretNameReference{Name: "console-secret"},
+					ComponentName:      "console",
+					ComponentNamespace: "openshift-console",
+				},
+			},
+		},
+	}
+
+	_, err = tc.configClient.ConfigV1().Authentications().Update(ctx, auth, metav1.UpdateOptions{})
+	cleanups = append(cleanups, func() {
+		auth, err := tc.configClient.ConfigV1().Authentications().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			tc.t.Fatalf("cleanup failed for authentication '%s' while retrieving fresh object: %v", auth.Name, err)
+		}
+
+		auth.Spec = *origSpec
+		_, err = tc.configClient.ConfigV1().Authentications().Update(ctx, auth, metav1.UpdateOptions{})
+		if err != nil {
+			tc.t.Fatalf("cleanup failed for authentication '%s' while updating object: %v", auth.Name, err)
+		}
+	})
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/test/e2e/keycloak_test.go
+++ b/test/e2e/keycloak_test.go
@@ -37,7 +37,7 @@ func TestKeycloakAsOIDCPasswordGrantCheckAndGroupSync(t *testing.T) {
 	userClient, err := userv1client.NewForConfig(kubeConfig)
 	require.NoError(t, err)
 
-	_, idpName, cleanups := test.AddKeycloakIDP(t, kubeConfig)
+	_, idpName, cleanups := test.AddKeycloakIDP(t, kubeConfig, false)
 	defer test.IDPCleanupWrapper(func() {
 		for _, c := range cleanups {
 			c()

--- a/test/e2e/keycloak_test.go
+++ b/test/e2e/keycloak_test.go
@@ -117,7 +117,7 @@ func TestKeycloakAsOIDCPasswordGrantCheckAndGroupSync(t *testing.T) {
 
 	username := "douglasnoeladams"
 	require.NoError(t, kcClient.CreateUser(
-		username, "password42",
+		username, "", "password42",
 		groups,
 	))
 

--- a/test/library/gitlabidp.go
+++ b/test/library/gitlabidp.go
@@ -118,7 +118,7 @@ func AddGitlabIDP( // TODO: possibly make this be a wrapper to a function to sim
 	appID := app["application_id"].(string)
 	appSecret := app["secret"].(string)
 
-	idpCleanups, err := addOIDCIDentityProvider(t, kubeClients, configclients, appID, appSecret, openshiftIDPName, gitlabURL, configv1.OpenIDClaims{})
+	idpCleanups, err := addOIDCIDentityProvider(t, kubeClients, configclients, appID, appSecret, openshiftIDPName, gitlabURL, configv1.OpenIDClaims{}, false)
 	require.NoError(t, err)
 
 	return gitlabURL, openshiftIDPName, append(cleanups, idpCleanups...)

--- a/test/library/idpdeployment.go
+++ b/test/library/idpdeployment.go
@@ -136,7 +136,7 @@ func deployPod(
 	_, err = clients.CoreV1().Services(namespace).Create(testContext, svcTemplate(httpPort, httpsPort), metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	timeLimitedCtx, cancel := context.WithTimeout(testContext, 5*time.Minute)
+	timeLimitedCtx, cancel := context.WithTimeout(testContext, 10*time.Minute)
 	defer cancel()
 	_, err = watchtools.UntilWithSync(timeLimitedCtx,
 		cache.NewListWatchFromClient(

--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -29,6 +29,7 @@ import (
 func AddKeycloakIDP(
 	t *testing.T,
 	kubeconfig *rest.Config,
+	directOIDC bool,
 ) (idpURL, idpName string, cleanups []func()) {
 	kubeClients, err := kubernetes.NewForConfig(kubeconfig)
 	require.NoError(t, err)
@@ -64,7 +65,7 @@ func AddKeycloakIDP(
 		"keycloak",
 		"quay.io/keycloak/keycloak:25.0",
 		[]corev1.EnvVar{
-			// configure password for GitLab root user
+			// configure password for Keycloak root user
 			{Name: "KEYCLOAK_ADMIN", Value: "admin"},
 			{Name: "KEYCLOAK_ADMIN_PASSWORD", Value: "password"},
 			{Name: "KC_HEALTH_ENABLED", Value: "true"},
@@ -178,6 +179,7 @@ func AddKeycloakIDP(
 			PreferredUsername: []string{"preferred_username"},
 			Groups:            []configv1.OpenIDClaim{groupsClaimName},
 		},
+		directOIDC,
 	)
 	cleanups = append(cleanups, idpCleans...)
 	require.NoError(t, err, "failed to configure the identity provider")

--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
@@ -240,7 +239,7 @@ func (kc *KeycloakClient) AuthenticatePassword(clientID, clientSecret, name, pas
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -297,7 +296,7 @@ func (kc *KeycloakClient) CreateClientGroupMapper(clientId, mapperName, groupsCl
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBytes, _ := ioutil.ReadAll(resp.Body)
+		respBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("failed creating mapper %q: %s %s", mapperName, resp.Status, respBytes)
 	}
 
@@ -325,7 +324,7 @@ func (kc *KeycloakClient) CreateGroup(groupName string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBytes, _ := ioutil.ReadAll(resp.Body)
+		respBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("failed creating group %q: %s %s", groupName, resp.Status, respBytes)
 	}
 
@@ -368,7 +367,7 @@ func (kc *KeycloakClient) CreateUser(username, email, password string, groups []
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBytes, _ := ioutil.ReadAll(resp.Body)
+		respBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("failed creating user %q: %s %s", username, resp.Status, respBytes)
 	}
 
@@ -385,7 +384,7 @@ func (kc *KeycloakClient) ListUsers() ([]map[string]interface{}, error) {
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +426,7 @@ func (kc *KeycloakClient) UpdateUser(id string, changes map[string]interface{}) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		respBytes, _ := ioutil.ReadAll(resp.Body)
+		respBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("failed updating user %q: %s: %s", id, resp.Status, respBytes)
 	}
 
@@ -444,7 +443,7 @@ func (kc *KeycloakClient) GetUser(id string) (map[string]interface{}, error) {
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +466,7 @@ func (kc *KeycloakClient) ListUserGroups(id string) ([]map[string]interface{}, e
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +544,7 @@ func (kc *KeycloakClient) UpdateClient(id string, changedFields map[string]inter
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -568,7 +567,7 @@ func (kc *KeycloakClient) GetClient(id string) (map[string]interface{}, error) {
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -608,7 +607,7 @@ func (kc *KeycloakClient) ListClients() ([]map[string]interface{}, error) {
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +631,7 @@ func (kc *KeycloakClient) RegenerateClientSecret(id string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/test/library/keycloakidp.go
+++ b/test/library/keycloakidp.go
@@ -332,12 +332,13 @@ func (kc *KeycloakClient) CreateGroup(groupName string) error {
 	return nil
 }
 
-func (kc *KeycloakClient) CreateUser(username, password string, groups []string) error {
+func (kc *KeycloakClient) CreateUser(username, email, password string, groups []string) error {
 	usersURL := *kc.keycloakAdminURL
 	usersURL.Path += "/users"
 
 	user := map[string]interface{}{
 		"username": username,
+		"email":    fmt.Sprintf("%s@test.dev", username),
 		"credentials": []map[string]interface{}{
 			{
 				"temporary": false,
@@ -348,6 +349,10 @@ func (kc *KeycloakClient) CreateUser(username, password string, groups []string)
 		"enabled":       true,
 		"emailVerified": true,
 		"groups":        groups,
+	}
+
+	if len(email) > 0 {
+		user["email"] = email
 	}
 
 	userBytes, err := json.Marshal(user)

--- a/test/library/waits.go
+++ b/test/library/waits.go
@@ -14,6 +14,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	"github.com/openshift/library-go/pkg/operator/resource/retry"
@@ -137,4 +138,33 @@ func WaitForHTTPStatus(t *testing.T, waitDuration time.Duration, client *http.Cl
 		}
 		return false, nil
 	})
+}
+
+func WaitForNewKASRollout(t *testing.T, ctx context.Context, kasClient operatorv1client.KubeAPIServerInterface, origRevision int32) error {
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+		kas, err := kasClient.Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("kubeapiserver/cluster error: %v", err)
+			return false, nil
+		}
+
+		for _, nodeStatus := range kas.Status.NodeStatuses {
+			if kas.Status.LatestAvailableRevision == origRevision {
+				t.Logf("no KAS rollout has started (latest available revision = %d)", kas.Status.LatestAvailableRevision)
+				return false, nil
+			}
+
+			if nodeStatus.CurrentRevision != kas.Status.LatestAvailableRevision {
+				t.Logf("waiting for KAS rollout on node '%s': current revision = %d (latest available = %d)\n", nodeStatus.NodeName, nodeStatus.CurrentRevision, kas.Status.LatestAvailableRevision)
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -1,0 +1,544 @@
+package features
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func FeatureSets(clusterProfile ClusterProfileName, featureSet configv1.FeatureSet) (*FeatureGateEnabledDisabled, error) {
+	byFeatureSet, ok := allFeatureGates[clusterProfile]
+	if !ok {
+		return nil, fmt.Errorf("no information found for ClusterProfile=%q", clusterProfile)
+	}
+	featureGates, ok := byFeatureSet[featureSet]
+	if !ok {
+		return nil, fmt.Errorf("no information found for FeatureSet=%q under ClusterProfile=%q", featureSet, clusterProfile)
+	}
+	return featureGates.DeepCopy(), nil
+}
+
+func AllFeatureSets() map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled {
+	ret := map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+	for clusterProfile, byFeatureSet := range allFeatureGates {
+		newByFeatureSet := map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+		for featureSet, enabledDisabled := range byFeatureSet {
+			newByFeatureSet[featureSet] = enabledDisabled.DeepCopy()
+		}
+		ret[clusterProfile] = newByFeatureSet
+	}
+
+	return ret
+}
+
+var (
+	allFeatureGates = map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+	FeatureGateServiceAccountTokenNodeBindingValidation = newFeatureGate("ServiceAccountTokenNodeBindingValidation").
+								reportProblemsToJiraComponent("apiserver-auth").
+								contactPerson("stlaz").
+								productScope(kubernetes).
+								enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateServiceAccountTokenNodeBinding = newFeatureGate("ServiceAccountTokenNodeBinding").
+							reportProblemsToJiraComponent("apiserver-auth").
+							contactPerson("stlaz").
+							productScope(kubernetes).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateServiceAccountTokenPodNodeInfo = newFeatureGate("ServiceAccountTokenPodNodeInfo").
+							reportProblemsToJiraComponent("apiserver-auth").
+							contactPerson("stlaz").
+							productScope(kubernetes).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateValidatingAdmissionPolicy = newFeatureGate("ValidatingAdmissionPolicy").
+						reportProblemsToJiraComponent("kube-apiserver").
+						contactPerson("benluddy").
+						productScope(kubernetes).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateGatewayAPI = newFeatureGate("GatewayAPI").
+				reportProblemsToJiraComponent("Routing").
+				contactPerson("miciah").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateOpenShiftPodSecurityAdmission = newFeatureGate("OpenShiftPodSecurityAdmission").
+							reportProblemsToJiraComponent("auth").
+							contactPerson("stlaz").
+							productScope(ocpSpecific).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateExternalCloudProvider = newFeatureGate("ExternalCloudProvider").
+						reportProblemsToJiraComponent("cloud-provider").
+						contactPerson("jspeed").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateExternalCloudProviderAzure = newFeatureGate("ExternalCloudProviderAzure").
+						reportProblemsToJiraComponent("cloud-provider").
+						contactPerson("jspeed").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateExternalCloudProviderGCP = newFeatureGate("ExternalCloudProviderGCP").
+						reportProblemsToJiraComponent("cloud-provider").
+						contactPerson("jspeed").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateExternalCloudProviderExternal = newFeatureGate("ExternalCloudProviderExternal").
+							reportProblemsToJiraComponent("cloud-provider").
+							contactPerson("elmiko").
+							productScope(ocpSpecific).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateCSIDriverSharedResource = newFeatureGate("CSIDriverSharedResource").
+						reportProblemsToJiraComponent("builds").
+						contactPerson("adkaplan").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateBuildCSIVolumes = newFeatureGate("BuildCSIVolumes").
+					reportProblemsToJiraComponent("builds").
+					contactPerson("adkaplan").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNodeSwap = newFeatureGate("NodeSwap").
+				reportProblemsToJiraComponent("node").
+				contactPerson("ehashman").
+				productScope(kubernetes).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateMachineAPIProviderOpenStack = newFeatureGate("MachineAPIProviderOpenStack").
+						reportProblemsToJiraComponent("openstack").
+						contactPerson("egarcia").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsConfigAPI = newFeatureGate("InsightsConfigAPI").
+					reportProblemsToJiraComponent("insights").
+					contactPerson("tremes").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateDynamicResourceAllocation = newFeatureGate("DynamicResourceAllocation").
+						reportProblemsToJiraComponent("scheduling").
+						contactPerson("jchaloup").
+						productScope(kubernetes).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateAzureWorkloadIdentity = newFeatureGate("AzureWorkloadIdentity").
+						reportProblemsToJiraComponent("cloud-credential-operator").
+						contactPerson("abutcher").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateMaxUnavailableStatefulSet = newFeatureGate("MaxUnavailableStatefulSet").
+						reportProblemsToJiraComponent("apps").
+						contactPerson("atiratree").
+						productScope(kubernetes).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateEventedPLEG = newFeatureGate("EventedPLEG").
+				reportProblemsToJiraComponent("node").
+				contactPerson("sairameshv").
+				productScope(kubernetes).
+				mustRegister()
+
+	FeatureGatePrivateHostedZoneAWS = newFeatureGate("PrivateHostedZoneAWS").
+					reportProblemsToJiraComponent("Routing").
+					contactPerson("miciah").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateSigstoreImageVerification = newFeatureGate("SigstoreImageVerification").
+						reportProblemsToJiraComponent("node").
+						contactPerson("sgrunert").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateGCPLabelsTags = newFeatureGate("GCPLabelsTags").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("bhb").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAlibabaPlatform = newFeatureGate("AlibabaPlatform").
+					reportProblemsToJiraComponent("cloud-provider").
+					contactPerson("jspeed").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateCloudDualStackNodeIPs = newFeatureGate("CloudDualStackNodeIPs").
+						reportProblemsToJiraComponent("machine-config-operator/platform-baremetal").
+						contactPerson("mkowalsk").
+						productScope(kubernetes).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateVSphereMultiVCenters = newFeatureGate("VSphereMultiVCenters").
+					reportProblemsToJiraComponent("splat").
+					contactPerson("vr4manta").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateVSphereStaticIPs = newFeatureGate("VSphereStaticIPs").
+					reportProblemsToJiraComponent("splat").
+					contactPerson("rvanderp3").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateRouteExternalCertificate = newFeatureGate("RouteExternalCertificate").
+						reportProblemsToJiraComponent("router").
+						contactPerson("thejasn").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateAdminNetworkPolicy = newFeatureGate("AdminNetworkPolicy").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("tssurya").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkLiveMigration = newFeatureGate("NetworkLiveMigration").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("pliu").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkDiagnosticsConfig = newFeatureGate("NetworkDiagnosticsConfig").
+						reportProblemsToJiraComponent("Networking/cluster-network-operator").
+						contactPerson("kyrtapz").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateHardwareSpeed = newFeatureGate("HardwareSpeed").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateBackendQuotaGiB = newFeatureGate("EtcdBackendQuota").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAutomatedEtcdBackup = newFeatureGate("AutomatedEtcdBackup").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMachineAPIOperatorDisableMachineHealthCheckController = newFeatureGate("MachineAPIOperatorDisableMachineHealthCheckController").
+										reportProblemsToJiraComponent("ecoproject").
+										contactPerson("msluiter").
+										productScope(ocpSpecific).
+										mustRegister()
+
+	FeatureGateDNSNameResolver = newFeatureGate("DNSNameResolver").
+					reportProblemsToJiraComponent("dns").
+					contactPerson("miciah").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateVSphereControlPlaneMachineset = newFeatureGate("VSphereControlPlaneMachineSet").
+							reportProblemsToJiraComponent("splat").
+							contactPerson("rvanderp3").
+							productScope(ocpSpecific).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateMachineConfigNodes = newFeatureGate("MachineConfigNodes").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("cdoern").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateClusterAPIInstall = newFeatureGate("ClusterAPIInstall").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("vincepri").
+					productScope(ocpSpecific).
+					mustRegister()
+
+	FeatureGateMetricsServer = newFeatureGate("MetricsServer").
+					reportProblemsToJiraComponent("Monitoring").
+					contactPerson("slashpai").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateInstallAlternateInfrastructureAWS = newFeatureGate("InstallAlternateInfrastructureAWS").
+							reportProblemsToJiraComponent("Installer").
+							contactPerson("padillon").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateGCPClusterHostedDNS = newFeatureGate("GCPClusterHostedDNS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("barbacbd").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMixedCPUsAllocation = newFeatureGate("MixedCPUsAllocation").
+					reportProblemsToJiraComponent("NodeTuningOperator").
+					contactPerson("titzhak").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateManagedBootImages = newFeatureGate("ManagedBootImages").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("djoshy").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateDisableKubeletCloudCredentialProviders = newFeatureGate("DisableKubeletCloudCredentialProviders").
+								reportProblemsToJiraComponent("cloud-provider").
+								contactPerson("jspeed").
+								productScope(kubernetes).
+								enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateOnClusterBuild = newFeatureGate("OnClusterBuild").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("dkhater").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateSignatureStores = newFeatureGate("SignatureStores").
+					reportProblemsToJiraComponent("Cluster Version Operator").
+					contactPerson("lmohanty").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateKMSv1 = newFeatureGate("KMSv1").
+				reportProblemsToJiraComponent("kube-apiserver").
+				contactPerson("dgrisonnet").
+				productScope(kubernetes).
+				enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGatePinnedImages = newFeatureGate("PinnedImages").
+				reportProblemsToJiraComponent("MachineConfigOperator").
+				contactPerson("jhernand").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateUpgradeStatus = newFeatureGate("UpgradeStatus").
+					reportProblemsToJiraComponent("Cluster Version Operator").
+					contactPerson("pmuller").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateTranslateStreamCloseWebsocketRequests = newFeatureGate("TranslateStreamCloseWebsocketRequests").
+								reportProblemsToJiraComponent("kube-apiserver").
+								contactPerson("akashem").
+								productScope(kubernetes).
+								enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateVolumeGroupSnapshot = newFeatureGate("VolumeGroupSnapshot").
+					reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+					contactPerson("fbertina").
+					productScope(kubernetes).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateExternalOIDC = newFeatureGate("ExternalOIDC").
+				reportProblemsToJiraComponent("authentication").
+				contactPerson("stlaz").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				enableForClusterProfile(Hypershift, configv1.Default, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateExample = newFeatureGate("Example").
+				reportProblemsToJiraComponent("cluster-config").
+				contactPerson("deads").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGatePlatformOperators = newFeatureGate("PlatformOperators").
+					reportProblemsToJiraComponent("olm").
+					contactPerson("joe").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNewOLM = newFeatureGate("NewOLM").
+				reportProblemsToJiraComponent("olm").
+				contactPerson("joe").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateExternalRouteCertificate = newFeatureGate("ExternalRouteCertificate").
+						reportProblemsToJiraComponent("network-edge").
+						contactPerson("miciah").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").
+						reportProblemsToJiraComponent("insights").
+						contactPerson("tremes").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateBareMetalLoadBalancer = newFeatureGate("BareMetalLoadBalancer").
+						reportProblemsToJiraComponent("metal").
+						contactPerson("EmilienM").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsConfig = newFeatureGate("InsightsConfig").
+					reportProblemsToJiraComponent("insights").
+					contactPerson("tremes").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateImagePolicy = newFeatureGate("ImagePolicy").
+				reportProblemsToJiraComponent("node").
+				contactPerson("rphillips").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateNodeDisruptionPolicy = newFeatureGate("NodeDisruptionPolicy").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("jerzhang").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMetricsCollectionProfiles = newFeatureGate("MetricsCollectionProfiles").
+						reportProblemsToJiraComponent("Monitoring").
+						contactPerson("rexagod").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateVSphereDriverConfiguration = newFeatureGate("VSphereDriverConfiguration").
+						reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+						contactPerson("rbednar").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallAWS = newFeatureGate("ClusterAPIInstallAWS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateClusterAPIInstallAzure = newFeatureGate("ClusterAPIInstallAzure").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("jhixson74").
+						productScope(ocpSpecific).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallGCP = newFeatureGate("ClusterAPIInstallGCP").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("bfournie").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateClusterAPIInstallIBMCloud = newFeatureGate("ClusterAPIInstallIBMCloud").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("cjschaef").
+						productScope(ocpSpecific).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallNutanix = newFeatureGate("ClusterAPIInstallNutanix").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("yanhua121").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallOpenStack = newFeatureGate("ClusterAPIInstallOpenStack").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("stephenfin").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallPowerVS = newFeatureGate("ClusterAPIInstallPowerVS").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("mjturek").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallVSphere = newFeatureGate("ClusterAPIInstallVSphere").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("rvanderp3").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateChunkSizeMiB = newFeatureGate("ChunkSizeMiB").
+				reportProblemsToJiraComponent("Image Registry").
+				contactPerson("flavianmissi").
+				productScope(ocpSpecific).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateMachineAPIMigration = newFeatureGate("MachineAPIMigration").
+					reportProblemsToJiraComponent("OCPCLOUD").
+					contactPerson("jspeed").
+					productScope(ocpSpecific).
+					mustRegister()
+)

--- a/vendor/github.com/openshift/api/features/util.go
+++ b/vendor/github.com/openshift/api/features/util.go
@@ -1,0 +1,193 @@
+package features
+
+import (
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// FeatureGateDescription is a golang-only interface used to contains details for a feature gate.
+type FeatureGateDescription struct {
+	// FeatureGateAttributes is the information that appears in the API
+	FeatureGateAttributes configv1.FeatureGateAttributes
+
+	// OwningJiraComponent is the jira component that owns most of the impl and first assignment for the bug.
+	// This is the team that owns the feature long term.
+	OwningJiraComponent string
+	// ResponsiblePerson is the person who is on the hook for first contact.  This is often, but not always, a team lead.
+	// It is someone who can make the promise on the behalf of the team.
+	ResponsiblePerson string
+	// OwningProduct is the product that owns the lifecycle of the gate.
+	OwningProduct OwningProduct
+}
+
+type FeatureGateEnabledDisabled struct {
+	Enabled  []FeatureGateDescription
+	Disabled []FeatureGateDescription
+}
+
+type ClusterProfileName string
+
+var (
+	Hypershift         = ClusterProfileName("include.release.openshift.io/ibm-cloud-managed")
+	SelfManaged        = ClusterProfileName("include.release.openshift.io/self-managed-high-availability")
+	AllClusterProfiles = []ClusterProfileName{Hypershift, SelfManaged}
+)
+
+type OwningProduct string
+
+var (
+	ocpSpecific = OwningProduct("OCP")
+	kubernetes  = OwningProduct("Kubernetes")
+)
+
+type featureGateBuilder struct {
+	name                string
+	owningJiraComponent string
+	responsiblePerson   string
+	owningProduct       OwningProduct
+
+	statusByClusterProfileByFeatureSet map[ClusterProfileName]map[configv1.FeatureSet]bool
+}
+
+// newFeatureGate featuregate are disabled in every FeatureSet and selectively enabled
+func newFeatureGate(name string) *featureGateBuilder {
+	b := &featureGateBuilder{
+		name:                               name,
+		statusByClusterProfileByFeatureSet: map[ClusterProfileName]map[configv1.FeatureSet]bool{},
+	}
+	for _, clusterProfile := range AllClusterProfiles {
+		byFeatureSet := map[configv1.FeatureSet]bool{}
+		for _, featureSet := range configv1.AllFixedFeatureSets {
+			byFeatureSet[featureSet] = false
+		}
+		b.statusByClusterProfileByFeatureSet[clusterProfile] = byFeatureSet
+	}
+	return b
+}
+
+func (b *featureGateBuilder) reportProblemsToJiraComponent(owningJiraComponent string) *featureGateBuilder {
+	b.owningJiraComponent = owningJiraComponent
+	return b
+}
+
+func (b *featureGateBuilder) contactPerson(responsiblePerson string) *featureGateBuilder {
+	b.responsiblePerson = responsiblePerson
+	return b
+}
+
+func (b *featureGateBuilder) productScope(owningProduct OwningProduct) *featureGateBuilder {
+	b.owningProduct = owningProduct
+	return b
+}
+
+func (b *featureGateBuilder) enableIn(featureSets ...configv1.FeatureSet) *featureGateBuilder {
+	for clusterProfile := range b.statusByClusterProfileByFeatureSet {
+		for _, featureSet := range featureSets {
+			b.statusByClusterProfileByFeatureSet[clusterProfile][featureSet] = true
+		}
+	}
+	return b
+}
+
+func (b *featureGateBuilder) enableForClusterProfile(clusterProfile ClusterProfileName, featureSets ...configv1.FeatureSet) *featureGateBuilder {
+	for _, featureSet := range featureSets {
+		b.statusByClusterProfileByFeatureSet[clusterProfile][featureSet] = true
+	}
+	return b
+}
+
+func (b *featureGateBuilder) register() (configv1.FeatureGateName, error) {
+	if len(b.name) == 0 {
+		return "", fmt.Errorf("missing name")
+	}
+	if len(b.owningJiraComponent) == 0 {
+		return "", fmt.Errorf("missing owningJiraComponent")
+	}
+	if len(b.responsiblePerson) == 0 {
+		return "", fmt.Errorf("missing responsiblePerson")
+	}
+	if len(b.owningProduct) == 0 {
+		return "", fmt.Errorf("missing owningProduct")
+	}
+
+	featureGateName := configv1.FeatureGateName(b.name)
+	description := FeatureGateDescription{
+		FeatureGateAttributes: configv1.FeatureGateAttributes{
+			Name: featureGateName,
+		},
+		OwningJiraComponent: b.owningJiraComponent,
+		ResponsiblePerson:   b.responsiblePerson,
+		OwningProduct:       b.owningProduct,
+	}
+
+	// statusByClusterProfileByFeatureSet is initialized by constructor to be false for every combination
+	for clusterProfile, byFeatureSet := range b.statusByClusterProfileByFeatureSet {
+		for featureSet, enabled := range byFeatureSet {
+			if _, ok := allFeatureGates[clusterProfile]; !ok {
+				allFeatureGates[clusterProfile] = map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+			}
+			if _, ok := allFeatureGates[clusterProfile][featureSet]; !ok {
+				allFeatureGates[clusterProfile][featureSet] = &FeatureGateEnabledDisabled{}
+			}
+
+			if enabled {
+				allFeatureGates[clusterProfile][featureSet].Enabled = append(allFeatureGates[clusterProfile][featureSet].Enabled, description)
+			} else {
+				allFeatureGates[clusterProfile][featureSet].Disabled = append(allFeatureGates[clusterProfile][featureSet].Disabled, description)
+			}
+		}
+	}
+
+	return featureGateName, nil
+}
+
+func (b *featureGateBuilder) mustRegister() configv1.FeatureGateName {
+	ret, err := b.register()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *FeatureGateEnabledDisabled) DeepCopyInto(out *FeatureGateEnabledDisabled) {
+	*out = *in
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		*out = make([]FeatureGateDescription, len(*in))
+		copy(*out, *in)
+	}
+	if in.Disabled != nil {
+		in, out := &in.Disabled, &out.Disabled
+		*out = make([]FeatureGateDescription, len(*in))
+		copy(*out, *in)
+	}
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new FeatureGateEnabledDisabled.
+func (in *FeatureGateEnabledDisabled) DeepCopy() *FeatureGateEnabledDisabled {
+	if in == nil {
+		return nil
+	}
+	out := new(FeatureGateEnabledDisabled)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *FeatureGateDescription) DeepCopyInto(out *FeatureGateDescription) {
+	*out = *in
+	out.FeatureGateAttributes = in.FeatureGateAttributes
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new FeatureGateDescription.
+func (in *FeatureGateDescription) DeepCopy() *FeatureGateDescription {
+	if in == nil {
+		return nil
+	}
+	out := new(FeatureGateDescription)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,6 +183,7 @@ github.com/openshift/api/config/v1
 github.com/openshift/api/config/v1alpha1
 github.com/openshift/api/console
 github.com/openshift/api/console/v1
+github.com/openshift/api/features
 github.com/openshift/api/helm
 github.com/openshift/api/helm/v1beta1
 github.com/openshift/api/image


### PR DESCRIPTION
This PR adds an e2e test for the direct external OIDC authentication type (BYO-OIDC). It requires the `ExternalOIDC` feature gate to be enabled.

Currently, the e2e works as follows:
- deploy keycloak in the cluster, to use as an OIDC provider
- configure the OIDC as a direct provider in the KAS
   - update the authentication CR with the oidc provider configuration
   - sync the oidc provider's CA, if necessary, to the KAS pods static resources
   - patch the cluster proxy and the KAS CLI args to provide the OIDC configuration
   - wait for the changes to get rolled out
- run some basic keycloak sanity checks
- run some baseline authentication checks via the KAS

The goal of this test is to incrementally add more test cases, as development of the external OIDC feature progresses. Some upcoming TODOs:
- prove that oauth tokens won't work after the change
- ~~adjust user permissions so that the actions tested using an OIDC bearer token can succeed (currently authentication succeeds but authorization fails)~~ (this is done via a self subject review now)