### PR TITLE
OCPBUGS-36199: set required-scc for openshift workloads

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -30,7 +30,7 @@ spec:
         apiserver: "true"
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: node-exporter
     spec:
       serviceAccountName: oauth-apiserver-sa
       priorityClassName: system-node-critical

--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: oauth-openshift
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: node-exporter
     spec:
       terminationGracePeriodSeconds: 40
       serviceAccountName: oauth-openshift

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "b918854185d0765a284a5e090a23dba21dbba0fb66852e2f5488ef1b6b7a90ca"
+    operator.openshift.io/spec-hash: "ba6383ded0364a3e31fc9973dc96b8da6572c6f7edaf5a72ca9b40199fc615fd"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -32,7 +32,7 @@ spec:
       name: openshift-oauth-apiserver
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: node-exporter
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "99c373b251b542c21ba9785f84ddbacd2d3cef516fdac81300afd85670dd95f9"
+    operator.openshift.io/spec-hash: "023fa2b47e80e3b600c6cf1eee7c27f4a6caf6a40e302a40f7190fdf05fadf24"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -32,7 +32,7 @@ spec:
       name: openshift-oauth-apiserver
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: node-exporter
     spec:
       containers:
         -

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "79a62b10580f4198a67bd248ff2d1499533ca3726defa5808d3211c3cf56322a"
+    operator.openshift.io/spec-hash: "7c09283f02bf7ad6809b3420907e2c778b1878e71106da68f42f8280049d9465"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -32,7 +32,7 @@ spec:
       name: openshift-oauth-apiserver
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: node-exporter
     spec:
       containers:
         -


### PR DESCRIPTION
[OCPBUGS-36199](https://issues.redhat.com/browse/OCPBUGS-36199)

Reduced the SCC for `oauth-openshift` and `oauth-apiserver` pods from `privileged` to `node-exporter` to enforce the principle of least privilege.