### PR TITLE
OKD-226: Dockerfile.rhel7: Add ARG TAGS=ocp

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,8 +1,10 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+# This pattern is documented in https://github.com/openshift/enhancements/pull/1672. Use ARG to build images based on platform.
+ARG TAGS=ocp
 WORKDIR /go/src/github.com/openshift/cluster-authentication-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-authentication-operator
-RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" -tags="ocp" -o authentication-operator ./cmd/authentication-operator
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" -tags="${TAGS}" -o authentication-operator ./cmd/authentication-operator
 
 FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/authentication-operator /usr/bin/


### PR DESCRIPTION
Allow this ARG to be overriden by builds so that OKD builds may have the correct branding by default. OKD/SCOS builds pass the build-arg TAGS=scos so pkg/controllers/configobservation/oauth/brand_okd.go which has //go:build !ocp will be built instead of pkg/controllers/configobservation/oauth/brand_ocp.go which has //go:build ocp. This change should not affect the OCP build of the operator image.