### PR TITLE
OCPBUGS-41586: increase oauth-apiserver failureThreshold

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -72,7 +72,9 @@ spec:
               --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
               --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
               --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-              --shutdown-delay-duration=15s \
+              --etcd-healthcheck-timeout=9s \
+              --etcd-readycheck-timeout=9s \
+              --shutdown-delay-duration=50s \
               --shutdown-send-retry-after=true \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
@@ -118,7 +120,7 @@ spec:
           httpGet:
             scheme: HTTPS
             port: 8443
-            path: healthz
+            path: livez?exclude=etcd
           initialDelaySeconds: 0
           periodSeconds: 10
           timeoutSeconds: 10
@@ -133,18 +135,18 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 10
           successThreshold: 1
-          failureThreshold: 1
+          failureThreshold: 3
         startupProbe:
           httpGet:
             scheme: HTTPS
             port: 8443
-            path: healthz
+            path: livez
           initialDelaySeconds: 0
           periodSeconds: 5
           timeoutSeconds: 10
           successThreshold: 1
           failureThreshold: 30
-      terminationGracePeriodSeconds: 90 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
+      terminationGracePeriodSeconds: 120 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
       volumes:
       - name: audit-policies
         configMap:

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "b918854185d0765a284a5e090a23dba21dbba0fb66852e2f5488ef1b6b7a90ca"
+    operator.openshift.io/spec-hash: "ebf731cc0240f9619bfc159abfd6e040d5be778b5bb83495578397ceeba5695f"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -52,7 +52,9 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=15s \
+                --etcd-healthcheck-timeout=9s \
+                --etcd-readycheck-timeout=9s \
+                --shutdown-delay-duration=50s \
                 --shutdown-send-retry-after=true \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
@@ -75,7 +77,7 @@ spec:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: healthz
+              path: livez?exclude=etcd
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 10
@@ -90,12 +92,12 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
             successThreshold: 1
-            failureThreshold: 1
+            failureThreshold: 3
           startupProbe:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: healthz
+              path: livez
             initialDelaySeconds: 0
             periodSeconds: 5
             timeoutSeconds: 10
@@ -159,7 +161,7 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccountName: oauth-apiserver-sa
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 120
       tolerations:
         -
           effect: NoSchedule

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "99c373b251b542c21ba9785f84ddbacd2d3cef516fdac81300afd85670dd95f9"
+    operator.openshift.io/spec-hash: "4a3913c6b7de6cc904a56ca6eca455b1523fc78778377f69e21918ada6375184"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -52,7 +52,9 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=15s \
+                --etcd-healthcheck-timeout=9s \
+                --etcd-readycheck-timeout=9s \
+                --shutdown-delay-duration=50s \
                 --shutdown-send-retry-after=true \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
@@ -84,7 +86,7 @@ spec:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: healthz
+              path: livez?exclude=etcd
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 10
@@ -99,12 +101,12 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
             successThreshold: 1
-            failureThreshold: 1
+            failureThreshold: 3
           startupProbe:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: healthz
+              path: livez
             initialDelaySeconds: 0
             periodSeconds: 5
             timeoutSeconds: 10
@@ -168,7 +170,7 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccountName: oauth-apiserver-sa
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 120
       tolerations:
         -
           effect: NoSchedule

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "79a62b10580f4198a67bd248ff2d1499533ca3726defa5808d3211c3cf56322a"
+    operator.openshift.io/spec-hash: "8b99dae430de336d76a2055fd625624638a57cd44e10b58554f445115a37627e"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -52,7 +52,9 @@ spec:
                 --etcd-cafile=/var/run/configmaps/etcd-serving-ca/ca-bundle.crt \
                 --etcd-keyfile=/var/run/secrets/etcd-client/tls.key \
                 --etcd-certfile=/var/run/secrets/etcd-client/tls.crt \
-                --shutdown-delay-duration=15s \
+                --etcd-healthcheck-timeout=9s \
+                --etcd-readycheck-timeout=9s \
+                --shutdown-delay-duration=50s \
                 --shutdown-send-retry-after=true \
                 --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
                 --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
@@ -79,7 +81,7 @@ spec:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: healthz
+              path: livez?exclude=etcd
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 10
@@ -94,12 +96,12 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
             successThreshold: 1
-            failureThreshold: 1
+            failureThreshold: 3
           startupProbe:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: healthz
+              path: livez
             initialDelaySeconds: 0
             periodSeconds: 5
             timeoutSeconds: 10
@@ -163,7 +165,7 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccountName: oauth-apiserver-sa
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 120
       tolerations:
         -
           effect: NoSchedule


### PR DESCRIPTION
This PR improves the liveness/readiness checks of the oauth-apiserver.

In particular:
- set `etcd-healthcheck-timeout` and `etcd-readycheck-timeout` to 1sec less than the respective probe timeouts
- replace liveness probe path `healthz` with `livez`, and exclude `etcd` from the probe
- increase the readiness probe failure threshold to 3
- set `shutdown-delay-duration` to 50s; the kubelet won't wait for another period if the previous probe fails (see note below), so if `timeoutSeconds > periodSeconds` it'll fire the subsequent probes immediately, therefore worst case is `5s + 3*10s + 15s (buffer)`
- set `terminationGracePeriodSeconds` to 120s: non-long-running requests timeout (60s) + shutdown delay (50s) + 10s buffer

Note (thanks @benluddy): the probes are implemented using a ticker, which internally has a buffered channel of length 1; if a tick fires and the buffered object hasn't been read yet (i.e. the previous probe is still running), that tick is dropped. See https://github.com/kubernetes/kubernetes/blob/5639b4b29cbf1ce7acab1e307ec2c0bdab1a65f5/pkg/kubelet/prober/worker.go#L175-L184