### PR TITLE
API-1835: Migrate WellKnownReadyController to SSA

### DIFF
--- a/pkg/controllers/common/conditions.go
+++ b/pkg/controllers/common/conditions.go
@@ -44,13 +44,12 @@ func (e *ControllerProgressingError) Unwrap() error {
 	return e.err
 }
 
-func (e *ControllerProgressingError) ToCondition(controllerName string) operatorv1.OperatorCondition {
-	return operatorv1.OperatorCondition{
-		Type:    ControllerProgressingConditionName(controllerName),
-		Status:  operatorv1.ConditionTrue,
-		Reason:  e.reason,
-		Message: e.err.Error(),
-	}
+func (e *ControllerProgressingError) ToCondition(controllerName string) *applyoperatorv1.OperatorConditionApplyConfiguration {
+	return applyoperatorv1.OperatorCondition().
+		WithType(ControllerProgressingConditionName(controllerName)).
+		WithStatus(operatorv1.ConditionTrue).
+		WithReason(e.reason).
+		WithMessage(e.err.Error())
 }
 
 // IsDegraded returns true if the condition matching this error (same type, reason and message)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -318,6 +318,7 @@ func prepareOauthOperator(ctx context.Context, controllerContext *controllercmd.
 		controllerContext.EventRecorder)
 
 	wellKnownReadyController := readiness.NewWellKnownReadyController(
+		"openshift-authentication",
 		operatorCtx.kubeInformersForNamespaces,
 		operatorCtx.operatorConfigInformer,
 		routeInformersNamespaced.Route().V1().Routes(),


### PR DESCRIPTION
Compared **e2e-operator** job from https://github.com/openshift/cluster-authentication-operator/pull/709 with the same job from this PR:

![verb_usage_comparison_auth](https://github.com/user-attachments/assets/4267679f-eb18-4f57-a6d3-5fae4ed727d9)
