### PR TITLE
[release-4.17] NO-JIRA: Fix templates config test

### DIFF
--- a/test/e2e/templates_test.go
+++ b/test/e2e/templates_test.go
@@ -55,7 +55,7 @@ func TestTemplatesConfig(t *testing.T) {
 
 	oauthConfigCopy.Spec.IdentityProviders = []configv1.IdentityProvider{
 		{
-			Name: "super duper production-ready htpasswd idp",
+			Name: "super-duper-production-ready-htpasswd-idp",
 			IdentityProviderConfig: configv1.IdentityProviderConfig{
 				Type: configv1.IdentityProviderTypeHTPasswd,
 				HTPasswd: &configv1.HTPasswdIdentityProvider{
@@ -109,7 +109,7 @@ func TestTemplatesConfig(t *testing.T) {
 
 	// modify URL to go to the IdP login
 	oauthURL.Path = "/oauth/token/display"
-	oauthURL.RawQuery = fmt.Sprintf("client_id=openshift-browser-client&idp=super+duper+production-ready+htpasswd+idp&redirect_uri=%s&response_type=code", url.QueryEscape(oauthURL.String()))
+	oauthURL.RawQuery = fmt.Sprintf("client_id=openshift-browser-client&idp=super-duper-production-ready-htpasswd-idp&redirect_uri=%s&response_type=code", url.QueryEscape(oauthURL.String()))
 	oauthURL.Path = "/oauth/authorize"
 	resp, err = httpClient.Get(oauthURL.String())
 	require.NoError(t, err)


### PR DESCRIPTION
Due to the [enhanced routing patterns](https://tip.golang.org/doc/go1.22#enhanced_routing_patterns) of go 1.22, and because with multiple providers the provider's name is used as part of the login url (`/login/<provider-name>`), it is now impossible to use provider names that include spaces.

This PR fixes a test that uses spaces in its provider name.