### PR TITLE
OCPBUGS-42745: manifests should not use APIs that are removed in upcoming releases

### DIFF
--- a/manifests/09_flowschema.yaml
+++ b/manifests/09_flowschema.yaml
@@ -100,7 +100,7 @@ spec:
         name: authentication-operator
         namespace: openshift-authentication-operator
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
+apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:
   name: openshift-oauth-server


### PR DESCRIPTION
bump flowcontrol v1beta3 to v1

looking for sources of:

```
  I1003 15:59:34.909915 109482 api_requests.go:76] api flowschemas.v1beta3.flowcontrol.apiserver.k8s.io, removed in release 1.32, was accessed 18 times
  I1003 15:59:34.909991 109482 api_requests.go:76] api prioritylevelconfigurations.v1beta3.flowcontrol.apiserver.k8s.io, removed in release 1.32, was accessed 9 times
  I1003 15:59:34.910022 109482 api_requests.go:125] user/system:serviceaccount:openshift-cluster-version:default accessed flowschemas.v1beta3.flowcontrol.apiserver.k8s.io 18 times
    [FAILED] in [It] - github.com/openshift/origin/test/extended/apiserver/api_requests.go:134 @ 10/03/24 15:59:34.91
  • [FAILED] [0.500 seconds]
  [sig-arch][Late] [It] clients should not use APIs that are removed in upcoming releases [apigroup:apiserver.openshift.io] [Suite:openshift/conformance/parallel]
  github.com/openshift/origin/test/extended/apiserver/api_requests.go:44

    [FAILED] user/system:serviceaccount:openshift-cluster-version:default accessed flowschemas.v1beta3.flowcontrol.apiserver.k8s.io 18 times
    In [It] at: github.com/openshift/origin/test/extended/apiserver/api_requests.go:134 @ 10/03/24 15:59:34.91
```