### PR TITLE
API-1835: Set Unknown conditions in WellKnownReadyController

### DIFF
--- a/pkg/controllers/readiness/wellknown_ready_controller.go
+++ b/pkg/controllers/readiness/wellknown_ready_controller.go
@@ -141,11 +141,11 @@ func (c *wellKnownReadyController) sync(ctx context.Context, controllerContext f
 	}
 	if err != nil {
 		available = available.
-			WithStatus(operatorv1.ConditionFalse).
+			WithStatus(operatorv1.ConditionUnknown).
 			WithReason("SyncError").
 			WithMessage(err.Error())
 		progressing = progressing.
-			WithStatus(operatorv1.ConditionTrue)
+			WithStatus(operatorv1.ConditionUnknown)
 		return err
 	}
 


### PR DESCRIPTION
This is a follow-up requirements from David:

https://github.com/openshift/cluster-authentication-operator/pull/705#discussion_r1797248619

/assign @deads2k @p0lyn0mial 