### PR TITLE
API-1835: separate apply-configuration-live from apply-configuration

### DIFF
--- a/pkg/cmd/mom/apply_configuration_live_command.go
+++ b/pkg/cmd/mom/apply_configuration_live_command.go
@@ -11,16 +11,16 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
-func NewApplyConfigurationCommand(streams genericiooptions.IOStreams) *cobra.Command {
+func NewApplyConfigurationLiveCommand(streams genericiooptions.IOStreams) *cobra.Command {
 	return libraryapplyconfiguration.NewApplyConfigurationCommand(RunApplyConfiguration, streams)
 }
 
-func RunApplyConfiguration(ctx context.Context, input libraryapplyconfiguration.ApplyConfigurationInput) (libraryapplyconfiguration.AllDesiredMutationsGetter, error) {
+func RunApplyConfigurationLive(ctx context.Context, input libraryapplyconfiguration.ApplyConfigurationInput) (libraryapplyconfiguration.AllDesiredMutationsGetter, error) {
 	authenticationOperatorInput, err := operator.CreateOperatorInputFromMOM(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("unable to configure operator input: %w", err)
 	}
-	operatorStarter, err := operator.CreateOperatorStarter(ctx, authenticationOperatorInput)
+	operatorStarter, err := operator.CreateOperatorStarterLive(ctx, authenticationOperatorInput)
 	if err != nil {
 		return nil, fmt.Errorf("unable to configure operators: %w", err)
 	}

--- a/pkg/operator/replacement_starter.go
+++ b/pkg/operator/replacement_starter.go
@@ -306,3 +306,20 @@ func CreateOperatorStarter(ctx context.Context, authOperatorInput *authenticatio
 
 	return ret, nil
 }
+
+func CreateOperatorStarterLive(ctx context.Context, authOperatorInput *authenticationOperatorInput) (libraryapplyconfiguration.OperatorStarter, error) {
+	ret := &libraryapplyconfiguration.SimpleOperatorStarter{
+		Informers: append([]libraryapplyconfiguration.SimplifiedInformerFactory{}, authOperatorInput.informerFactories...),
+	}
+
+	informerFactories := newInformerFactories(authOperatorInput)
+	ret.Informers = append(ret.Informers, informerFactories.simplifiedInformerFactories()...)
+
+	oauthRunOnceFns, err := prepareOauthOperatorLive(ctx, authOperatorInput, informerFactories)
+	if err != nil {
+		return nil, fmt.Errorf("unable to prepare oauth server: %w", err)
+	}
+	ret.ControllerRunOnceFns = append(ret.ControllerRunOnceFns, oauthRunOnceFns...)
+
+	return ret, nil
+}

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -232,6 +232,11 @@ func (c *OAuthAPIServerWorkload) syncDeployment(ctx context.Context, operatorSpe
 	}
 	required.Spec.Replicas = masterNodeCount
 
+	// TODO MOM this call here is the one that fails.  Using the return value of ApplyDeployment to make decisions doesn't work in a MOM world.
+	// TODO MOM workload.NewController needs to (somehow) use the data read *after* this write, without  using data *in* this write.
+	// TODO MOM this may be possible by storing a hash of the desired content.  If the hash of the desired content matches
+	// TODO MOM then there is no new deployment required.  This would not prevent rapid writes to fields we aren't controlling.
+	// TODO MOM perhaps we actually need to find a way to request MOM inject a generation after a write?  It is an operator standard.
 	deployment, _, err := resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), eventRecorder, required, resourcemerge.ExpectedDeploymentGeneration(required, operatorStatus.Generations))
 	return deployment, err
 }


### PR DESCRIPTION
This does the initial split of live functions (things that must reach out to external services and may or may not work on hypershift due to networking configuration), from things that don't have that problem.

Builds on top of some library-go and multi-operator-manager PRs that need to land.