### PR TITLE
OCPBUGS-43587: bindata/oauth-openshift - set httpmux121

### DIFF
--- a/bindata/oauth-openshift/deployment.yaml
+++ b/bindata/oauth-openshift/deployment.yaml
@@ -53,6 +53,9 @@ spec:
       containers:
         - name: oauth-openshift
           image: ${IMAGE}
+          env:
+            - name: GODEBUG
+              value: httpmuxgo121=1
           command:
             - /bin/bash
             - '-ec'


### PR DESCRIPTION
## What

Set `GODEBUG=httpmuxgo121=1`,

## Why

`http.ServeMux` changed massively in behavior in Go 1.22. We allowed customers to create IDPs with whitespaces in their names and used that as their path. This will now cause a panic with the new handler behavior.

## Notes

### How to reproduce

- Run oauth-server with Go >= 1.22.
- Create two htpasswd IDPs with whitespaces in their names.