### PR TITLE
OCPBUGS-42932: ensure annotations map exists before mutating it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20241001152557-e415140e5d5f
 	github.com/openshift/build-machinery-go v0.0.0-20240613134303-8359781da660
 	github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f
-	github.com/openshift/library-go v0.0.0-20241023193830-022ad9c25e39
+	github.com/openshift/library-go v0.0.0-20241025130148-9b5cf240f209
 	github.com/openshift/multi-operator-manager v0.0.0-20241022160113-b880eaae93fc
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/openshift/build-machinery-go v0.0.0-20240613134303-8359781da660 h1:F0
 github.com/openshift/build-machinery-go v0.0.0-20240613134303-8359781da660/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f h1:FRc0bVNWprihWS0GqQWzb3dY4dkCwpOP3mDw5NwSoR4=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f/go.mod h1:KiZi2mJRH1TOJ3FtBDYS6YvUL30s/iIXaGSUrSa36mo=
-github.com/openshift/library-go v0.0.0-20241023193830-022ad9c25e39 h1:QUoMgNRHKDX0BXCbsdYHwoIyqYBGSJy9dNBAph9WqEU=
-github.com/openshift/library-go v0.0.0-20241023193830-022ad9c25e39/go.mod h1:9B1MYPoLtP9tqjWxcbUNVpwxy68zOH/3EIP6c31dAM0=
+github.com/openshift/library-go v0.0.0-20241025130148-9b5cf240f209 h1:yI/O5/EwFChpJBWuIXmXQjz1OYYfkuQUTr424LJpBO0=
+github.com/openshift/library-go v0.0.0-20241025130148-9b5cf240f209/go.mod h1:9B1MYPoLtP9tqjWxcbUNVpwxy68zOH/3EIP6c31dAM0=
 github.com/openshift/multi-operator-manager v0.0.0-20241022160113-b880eaae93fc h1:DPatMo6iid7ruxVr3LEu0EHe3oll9CYZYO4A8vV3RYU=
 github.com/openshift/multi-operator-manager v0.0.0-20241022160113-b880eaae93fc/go.mod h1:7u7Wj5yctFzwixEJdrnpZCCNuJwdwls3SwqHoxRlN7E=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/manifestclient/context.go
+++ b/vendor/github.com/openshift/library-go/pkg/manifestclient/context.go
@@ -1,0 +1,18 @@
+package manifestclient
+
+import (
+	"context"
+)
+
+type ctxKey struct{}
+
+var controllerNameCtxKey = ctxKey{}
+
+func WithControllerNameInContext(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, controllerNameCtxKey, name)
+}
+
+func ControllerNameFromContext(ctx context.Context) string {
+	val, _ := ctx.Value(controllerNameCtxKey).(string)
+	return val
+}

--- a/vendor/github.com/openshift/library-go/pkg/manifestclient/group_resource_discovery.go
+++ b/vendor/github.com/openshift/library-go/pkg/manifestclient/group_resource_discovery.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"k8s.io/apimachinery/pkg/util/json"
-	"os"
 	"path/filepath"
 	"sigs.k8s.io/yaml"
 	"strings"
@@ -18,13 +17,13 @@ func (mrt *manifestRoundTripper) getGroupResourceDiscovery(requestInfo *apireque
 	switch {
 	case requestInfo.Path == "/api":
 		ret, err := mrt.getAggregatedDiscoveryForURL("aggregated-discovery-api.yaml", requestInfo.Path)
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return mrt.getLegacyGroupResourceDiscovery(requestInfo)
 		}
 		return ret, err
 	case requestInfo.Path == "/apis":
 		ret, err := mrt.getAggregatedDiscoveryForURL("aggregated-discovery-apis.yaml", requestInfo.Path)
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return mrt.getLegacyGroupResourceDiscovery(requestInfo)
 		}
 		return ret, err
@@ -36,7 +35,7 @@ func (mrt *manifestRoundTripper) getGroupResourceDiscovery(requestInfo *apireque
 
 func (mrt *manifestRoundTripper) getAggregatedDiscoveryForURL(filename, url string) ([]byte, error) {
 	discoveryBytes, err := fs.ReadFile(mrt.sourceFS, filename)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		discoveryBytes, err = fs.ReadFile(defaultDiscovery, filepath.Join("default-discovery", filename))
 	}
 	if err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/manifestclient/mutation_directory_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/manifestclient/mutation_directory_reader.go
@@ -33,7 +33,7 @@ func readMutationFS(inFS fs.FS) (*AllActionsTracker[FileOriginatedSerializedRequ
 			file.Close()
 		}
 		switch {
-		case os.IsNotExist(err):
+		case errors.Is(err, fs.ErrNotExist):
 			continue
 		case err != nil:
 			errs = append(errs, fmt.Errorf("unable to read %q : %w", action, err))
@@ -115,7 +115,7 @@ func serializedRequestFromFile(action Action, actionFS fs.FS, bodyFilename strin
 	optionsExist := false
 	optionsContent, err := fs.ReadFile(actionFS, optionsFilename)
 	switch {
-	case os.IsNotExist(err):
+	case errors.Is(err, fs.ErrNotExist):
 	// not required, do nothing
 	case err != nil:
 		return nil, fmt.Errorf("failed to read %q: %w", optionsFilename, err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -309,7 +309,7 @@ github.com/openshift/client-go/user/applyconfigurations/internal
 github.com/openshift/client-go/user/applyconfigurations/user/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20241023193830-022ad9c25e39
+# github.com/openshift/library-go v0.0.0-20241025130148-9b5cf240f209
 ## explicit; go 1.22.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/deployment


### PR DESCRIPTION
From failed run: https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.18-multi-nightly-4.18-cpou-upgrade-from-4.15-aws-ipi-mini-perm-arm-f14/1842004955238502400

noteworthy log message:

```
2024-10-04T10:05:42.236079365Z E1004 10:05:42.236012       1 runtime.go:79] Observed a panic: "assignment to entry in nil map" (assignment to entry in nil map)
2024-10-04T10:05:42.236079365Z goroutine 2202 [running]:
2024-10-04T10:05:42.236079365Z k8s.io/apimachinery/pkg/util/runtime.logPanic({0x26081a0, 0x3005130})
2024-10-04T10:05:42.236079365Z 	/go/src/github.com/openshift/cluster-authentication-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
2024-10-04T10:05:42.236079365Z k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x40014f7340, 0x1, 0x4003036000?})
2024-10-04T10:05:42.236079365Z 	/go/src/github.com/openshift/cluster-authentication-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
2024-10-04T10:05:42.236079365Z panic({0x26081a0?, 0x3005130?})
2024-10-04T10:05:42.236079365Z 	/usr/lib/golang/src/runtime/panic.go:770 +0x124
2024-10-04T10:05:42.236079365Z github.com/openshift/library-go/pkg/operator/revisioncontroller.RevisionController.createNewRevision({{0x4000612de0, 0x22}, {0x2ac219c, 0x19}, {0x40016043a8, 0x1, 0x1}, {0x40016043c0, 0x1, 0x1}, ...}, ...)
2024-10-04T10:05:42.236079365Z 	/go/src/github.com/openshift/cluster-authentication-operator/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go:308 +0x980
2024-10-04T10:05:42.236079365Z github.com/openshift/library-go/pkg/operator/revisioncontroller.RevisionController.createRevisionIfNeeded({{0x4000612de0, 0x22}, {0x2ac219c, 0x19}, {0x40016043a8, 0x1, 0x1}, {0x40016043c0, 0x1, 0x1}, ...}, ...)
2024-10-04T10:05:42.236079365Z 	/go/src/github.com/openshift/cluster-authentication-operator/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go:118 +0x1c0

```