### PR TITLE
Exclude etcd readiness checks from /readyz to ignore temporary etcd hiccups

### DIFF
--- a/bindata/oauth-apiserver/deploy.yaml
+++ b/bindata/oauth-apiserver/deploy.yaml
@@ -130,7 +130,7 @@ spec:
           httpGet:
             scheme: HTTPS
             port: 8443
-            path: readyz
+            path: readyz?exclude=etcd&exclude=etcd-readiness
           initialDelaySeconds: 0
           periodSeconds: 5
           timeoutSeconds: 10

--- a/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_1.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "1986a56f7e54d5a8fb43656056b747bf93c3eeea535b79bb2866562a001a3778"
+    operator.openshift.io/spec-hash: "dc41cb7ec4f6f82f4a8637ae233969f202c36f6acd376aca21980313af7c9f50"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -87,7 +87,7 @@ spec:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: readyz
+              path: readyz?exclude=etcd&exclude=etcd-readiness
             initialDelaySeconds: 0
             periodSeconds: 5
             timeoutSeconds: 10
@@ -213,4 +213,3 @@ spec:
             path: /var/log/oauth-apiserver
           name: audit-dir
 status: {}
-

--- a/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_2.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "fbe2e5bff6b8355967db0b9d904e66a2a56018f85b6e488362d6d5161bde1f93"
+    operator.openshift.io/spec-hash: "857876e78675ca8630c8a1ef114cc9487d714ab30b0e22178ccc77ffd95012d5"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -96,7 +96,7 @@ spec:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: readyz
+              path: readyz?exclude=etcd&exclude=etcd-readiness
             initialDelaySeconds: 0
             periodSeconds: 5
             timeoutSeconds: 10
@@ -222,4 +222,3 @@ spec:
             path: /var/log/oauth-apiserver
           name: audit-dir
 status: {}
-

--- a/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_3.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
-    operator.openshift.io/spec-hash: "ccb8d879eec9cdde0c99dd71a28ec2f55d94ffce29e96b74a2b126c3014f223d"
+    operator.openshift.io/spec-hash: "a4574abdfafd21fb9a70db6c0cd6064f940ec4d3f199a0f5d9e0ac8392500f9d"
   creationTimestamp: ~
   labels:
     apiserver: "true"
@@ -91,7 +91,7 @@ spec:
             httpGet:
               scheme: HTTPS
               port: 8443
-              path: readyz
+              path: readyz?exclude=etcd&exclude=etcd-readiness
             initialDelaySeconds: 0
             periodSeconds: 5
             timeoutSeconds: 10
@@ -217,4 +217,3 @@ spec:
             path: /var/log/oauth-apiserver
           name: audit-dir
 status: {}
-


### PR DESCRIPTION
Explicitly exclude etcd and etcd-readiness checks (OCPBUGS-48177) and have etcd operator take responsibility for properly reporting etcd readiness. Justification: kube-apiserver instances get removed from a load balancer when etcd starts to report not ready (as will KA's /readyz). Client connections can withstand etcd unreadiness longer than the readiness timeout is. Thus, it is not necessary to drop connections in case etcd resumes its readiness before a client connection times out naturally.

Porting https://github.com/openshift/cluster-authentication-operator/pull/753 to 4.18.