### PR TITLE
OCPBUGS-51981: fix: update starter path to account for mom integration

### DIFF
--- a/test-data/apply-configuration/overall/minimal-cluster/expected-output/controller-results.yaml
+++ b/test-data/apply-configuration/overall/minimal-cluster/expected-output/controller-results.yaml
@@ -59,6 +59,10 @@ controllerResults:
       endpoints/host-etcd-2 in the openshift-etcd namespace: not found
       oauth.config.openshift.io "cluster" not found
   status: Failed
+- controllerName: TODO-other-externalOIDCController
+  errors:
+  - message: 'could not get authentication/cluster: authentication.config.openshift.io "cluster" not found'
+  status: Failed
 - controllerName: TODO-payloadConfigController
   status: Succeeded
 - controllerName: TODO-proxyConfigController


### PR DESCRIPTION
updatedinitialization to parameterize feature gate accessor to allow mom to call the binary in CI
updated test to include OIDC check