### PR TITLE
OCPEDGE-1510: feat: add minimum count for DualReplica

### DIFF
--- a/pkg/controllers/readiness/unsupported_override.go
+++ b/pkg/controllers/readiness/unsupported_override.go
@@ -61,7 +61,7 @@ func getExpectedMinimumNumberOfMasters(spec *operatorv1.OperatorSpec, topologyMo
 	switch {
 	case topologyMode == configv1.SingleReplicaTopologyMode:
 		return 1
-	case topologyMode == configv1.HighlyAvailableArbiterMode:
+	case topologyMode == configv1.HighlyAvailableArbiterMode || topologyMode == configv1.DualReplicaTopologyMode:
 		return 2
 	case err != nil:
 		utilruntime.HandleError(err)


### PR DESCRIPTION
bumped ocp/api to pull in DualReplica control plane topology type, minimum count for masters is 2 under DualReplica