### PR TITLE
OCPBUGS-59909: Don't cache server errors when checking for password grant support

### DIFF
--- a/pkg/controllers/configobservation/oauth/idp_conversions.go
+++ b/pkg/controllers/configobservation/oauth/idp_conversions.go
@@ -425,6 +425,10 @@ func checkOIDCPasswordGrantFlow(
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
+		return false, fmt.Errorf("OIDC token endpoint returned server error %d (%s)", resp.StatusCode, tokenURL)
+	}
+
 	respJSON := json.NewDecoder(resp.Body)
 	respMap := map[string]interface{}{}
 	if err = respJSON.Decode(&respMap); err != nil {


### PR DESCRIPTION
~~If we encounter an OIDC server which is not properly responding using JSON, we should occasionally retry pinging it for the purpose of checking password grant support rather than assuming that it doesn't support password grant forever.~~

Now: Reject and don't cache 5xx errors outright while checking for password grant support.