### PR TITLE
NO-JIRA: Bump library go rm co dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20250723112524-86ad96c9f1fd
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
-	github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e
+	github.com/openshift/library-go v0.0.0-20250828105733-480b7a0ebfd5
 	github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8hK3eEsHqxsXurq/D6LcINGfprkQC3hqY=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=
-github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e h1:xYT+P++PSc9G+Y47pIcU9fm8IDV/tg6tMi3i+0m23pU=
-github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
+github.com/openshift/library-go v0.0.0-20250828105733-480b7a0ebfd5 h1:4z0zAMP49ARcZnVjiHe+D+Ee/SEcgv+Ohe+cNbTMHTs=
+github.com/openshift/library-go v0.0.0-20250828105733-480b7a0ebfd5/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d h1:Rzx23P63JFNNz5D23ubhC0FCN5rK8CeJhKcq5QKcdyU=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d/go.mod h1:iVi9Bopa5cLhjG5ie9DoZVVqkH8BGb1FQVTtecOLn4I=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/pkg/controllers/deployment/deployment_controller.go
+++ b/pkg/controllers/deployment/deployment_controller.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
@@ -77,7 +76,6 @@ func NewOAuthServerWorkloadController(
 	ensureAtMostOnePodPerNode ensureAtMostOnePodPerNodeFunc,
 	kubeClient kubernetes.Interface,
 	nodeInformer coreinformers.NodeInformer,
-	openshiftClusterConfigClient configv1client.ClusterOperatorInterface,
 	configInformers configinformer.SharedInformerFactory,
 	routeInformersForTargetNamespace routeinformers.SharedInformerFactory,
 	bootstrapUserDataGetter bootstrap.BootstrapUserDataGetter,
@@ -138,7 +136,6 @@ func NewOAuthServerWorkloadController(
 			routeInformersForTargetNamespace.Route().V1().Routes().Informer(),
 		},
 		oauthDeploymentSyncer,
-		openshiftClusterConfigClient,
 		eventsRecorder,
 		versionRecorder,
 	)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -266,7 +266,6 @@ func prepareOauthOperator(
 		workloadcontroller.EnsureAtMostOnePodPerNode,
 		authOperatorInput.kubeClient,
 		informerFactories.kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes(),
-		authOperatorInput.configClient.ConfigV1().ClusterOperators(),
 		informerFactories.operatorConfigInformer,
 		informerFactories.namespacedOpenshiftAuthenticationRoutes,
 		bootstrapauthenticator.NewBootstrapUserDataGetter(authOperatorInput.kubeClient.CoreV1(), authOperatorInput.kubeClient.CoreV1()),
@@ -491,7 +490,6 @@ func prepareOauthAPIServerOperator(
 		apiServerConditionsPrefix,
 		authOperatorInput.kubeClient,
 		authAPIServerWorkload,
-		authOperatorInput.configClient.ConfigV1().ClusterOperators(),
 		versionRecorder,
 		informerFactories.kubeInformersForNamespaces,
 		authOperatorInput.authenticationOperatorClient.Informer(), // TODO update the library so that the operator client informer is automatically added.

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controller/workload/workload.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controller/workload/workload.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	openshiftconfigclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	"github.com/openshift/library-go/pkg/apps/deployment"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -65,9 +64,8 @@ type Controller struct {
 
 	podsLister corev1listers.PodLister
 
-	operatorClient               v1helpers.OperatorClient
-	kubeClient                   kubernetes.Interface
-	openshiftClusterConfigClient openshiftconfigclientv1.ClusterOperatorInterface
+	operatorClient v1helpers.OperatorClient
+	kubeClient     kubernetes.Interface
 
 	delegate           Delegate
 	queue              workqueue.RateLimitingInterface
@@ -90,24 +88,22 @@ func NewController(instanceName, operatorNamespace, targetNamespace, targetOpera
 	informers []factory.Informer,
 	tagetNamespaceInformers []factory.Informer,
 	delegate Delegate,
-	openshiftClusterConfigClient openshiftconfigclientv1.ClusterOperatorInterface,
 	eventRecorder events.Recorder,
 	versionRecorder status.VersionGetter,
 ) factory.Controller {
 	controllerRef := &Controller{
-		controllerInstanceName:       factory.ControllerInstanceName(instanceName, "Workload"),
-		operatorNamespace:            operatorNamespace,
-		targetNamespace:              targetNamespace,
-		targetOperandVersion:         targetOperandVersion,
-		operandNamePrefix:            operandNamePrefix,
-		conditionsPrefix:             conditionsPrefix,
-		operatorClient:               operatorClient,
-		kubeClient:                   kubeClient,
-		podsLister:                   podLister,
-		delegate:                     delegate,
-		openshiftClusterConfigClient: openshiftClusterConfigClient,
-		versionRecorder:              versionRecorder,
-		queue:                        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), instanceName),
+		controllerInstanceName: factory.ControllerInstanceName(instanceName, "Workload"),
+		operatorNamespace:      operatorNamespace,
+		targetNamespace:        targetNamespace,
+		targetOperandVersion:   targetOperandVersion,
+		operandNamePrefix:      operandNamePrefix,
+		conditionsPrefix:       conditionsPrefix,
+		operatorClient:         operatorClient,
+		kubeClient:             kubeClient,
+		podsLister:             podLister,
+		delegate:               delegate,
+		versionRecorder:        versionRecorder,
+		queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), instanceName),
 	}
 
 	c := factory.New()

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	openshiftconfigclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -267,7 +266,6 @@ func (cs *APIServerControllerSet) WithWorkloadController(
 	name, operatorNamespace, targetNamespace, targetOperandVersion, operandNamePrefix, conditionsPrefix string,
 	kubeClient kubernetes.Interface,
 	delegate workload.Delegate,
-	openshiftClusterConfigClient openshiftconfigclientv1.ClusterOperatorInterface,
 	versionRecorder status.VersionGetter,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	informers ...factory.Informer) *APIServerControllerSet {
@@ -292,7 +290,6 @@ func (cs *APIServerControllerSet) WithWorkloadController(
 		[]factory.Informer{kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Namespaces().Informer()},
 
 		delegate,
-		openshiftClusterConfigClient,
 		cs.eventRecorder,
 		versionRecorder)
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -142,6 +142,9 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 	if required.Annotations == nil {
 		required.Annotations = map[string]string{}
 	}
+	if required.Labels == nil {
+		required.Labels = map[string]string{}
+	}
 	if err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec); err != nil {
 		return nil, false, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -316,7 +316,7 @@ github.com/openshift/client-go/user/applyconfigurations/internal
 github.com/openshift/client-go/user/applyconfigurations/user/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e
+# github.com/openshift/library-go v0.0.0-20250828105733-480b7a0ebfd5
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/deployment


### PR DESCRIPTION
xref: https://github.com/openshift/library-go/pull/2005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed an unused cluster-config dependency from workload controller initialization.
  - Simplified controller construction to reduce internal coupling.

- Bug Fix
  - Prevented potential nil-map write when preparing storage driver metadata.

- Performance
  - Reduced certificate-rotation noise by filtering events to only relevant ConfigMaps/Secrets, lowering reconciliation churn.

- Chores
  - Bumped an upstream library dependency to a newer patched version.

- Notes
  - No user-facing API or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->