### PR TITLE
OCPBUGS-65473: fix: remove route and oauth service from clusteroperator expected output

### DIFF
--- a/test-data/apply-configuration/overall/minimal-cluster/expected-output/Management/UpdateStatus/cluster-scoped-resources/config.openshift.io/clusteroperators/85c3-body-authentication.yaml
+++ b/test-data/apply-configuration/overall/minimal-cluster/expected-output/Management/UpdateStatus/cluster-scoped-resources/config.openshift.io/clusteroperators/85c3-body-authentication.yaml
@@ -40,14 +40,6 @@ status:
   - group: config.openshift.io
     name: cluster
     resource: oauths
-  - group: route.openshift.io
-    name: oauth-openshift
-    namespace: openshift-authentication
-    resource: routes
-  - group: ""
-    name: oauth-openshift
-    namespace: openshift-authentication
-    resource: services
   - group: ""
     name: openshift-config
     resource: namespaces


### PR DESCRIPTION
Initial cluster output changed with https://github.com/openshift/cluster-authentication-operator/pull/800, now that the route and service for oauth are reconciled later