### PR TITLE
NO-JIRA: Retry if OIDCAvailable function gets transient not found error

### DIFF
--- a/pkg/controllers/common/external_oidc.go
+++ b/pkg/controllers/common/external_oidc.go
@@ -16,6 +16,7 @@ import (
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 )
 
 type AuthConfigChecker struct {
@@ -61,6 +62,7 @@ func (c *AuthConfigChecker) OIDCAvailable() (bool, error) {
 	err := retry.OnError(retry.DefaultBackoff, errors.IsNotFound, func() error {
 		var retryErr error
 		auth, retryErr = c.authLister.Get("cluster")
+		klog.Infof("Get cluster auth: data: %s err: %v", auth, retryErr)
 		return retryErr
 	})
 	if err != nil {


### PR DESCRIPTION
`OIDCAvailable` function is used as a prerequisite step by almost all controllers in cluster-authentication-operator, in order to determine the resources that need to be managed (Resources vary based on OIDC is configured within the cluster or not). 

However, this function queries the oauth-apiserver for `authentications.config.openshift.io/cluster` resource that may not exist during upgrades. `NotFound` error of this resource consequently causes the degradation of cluster-authentication-operator in a short amount of time (or long amount of time if oauth-apiserver is in trouble). On the other hand, this `NotFound` error is legit for some cluster types such as SNO, etc. during upgrades.

Single `authentications.config.openshift.io/cluster` query is too vulnerable for falling into degraded state. Therefore, this PR embraces retry mechanism to at least retry a couple of more iterations to reduce probability of degradation (DefaultBackoff retries 10ms, 50ms, 250ms, 1250ms which is totally ~1.6 seconds).

This PR partially fixes https://issues.redhat.com/browse/OCPBUGS-20056