### PR TITLE
MON-4473: Migrate Prometheus targets discovering from Endpoints to EndpointsSlices

### DIFF
--- a/manifests/0000_90_cluster-authentication-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_01_prometheusrbac.yaml
@@ -19,6 +19,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 # Role for accessing metrics exposed by authentication resources
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,6 +49,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 # oauth-apiserver role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -59,6 +75,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-authentication-operator_02_servicemonitor.yaml
@@ -29,6 +29,7 @@ spec:
   selector:
     matchLabels:
       app: authentication-operator
+  serviceDiscoveryRole: EndpointSlice
 ---
 # Configure cluster-monitoring for cluster authentication resources
 apiVersion: monitoring.coreos.com/v1
@@ -60,6 +61,7 @@ spec:
   selector:
     matchLabels:
       app: oauth-openshift
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -113,3 +115,4 @@ spec:
   selector:
     matchLabels:
       app: openshift-oauth-apiserver
+  serviceDiscoveryRole: EndpointSlice


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**
