### PR TITLE
update inject cert to beta

### DIFF
--- a/bindata/oauth-apiserver/svc.yaml
+++ b/bindata/oauth-apiserver/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: openshift-oauth-apiserver
   name: api
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
   labels:

--- a/bindata/oauth-openshift/oauth-service.yaml
+++ b/bindata/oauth-openshift/oauth-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
   labels:
     app: oauth-openshift
   name: oauth-openshift

--- a/manifests/02_service.yaml
+++ b/manifests/02_service.yaml
@@ -6,7 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: serving-cert
   labels:
     app: authentication-operator
   name: metrics

--- a/pkg/controllers/serviceca/service_ca_controller.go
+++ b/pkg/controllers/serviceca/service_ca_controller.go
@@ -106,7 +106,7 @@ func getServiceCAConfig() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "v4-0-config-system-service-ca",
-			Annotations: map[string]string{"service.alpha.openshift.io/inject-cabundle": "true"},
+			Annotations: map[string]string{"service.beta.openshift.io/inject-cabundle": "true"},
 			Namespace:   "openshift-authentication",
 			Labels: map[string]string{
 				"app": "oauth-openshift",
@@ -141,7 +141,7 @@ func (c *serviceCAController) getServiceCA(ctx context.Context, recorder events.
 		}}, nil
 	}
 
-	if serviceCA.Annotations["service.alpha.openshift.io/inject-cabundle"] != "true" {
+	if serviceCA.Annotations["service.beta.openshift.io/inject-cabundle"] != "true" {
 		// return fmt.Errorf("config map missing injection annotation: %#v", ca)
 		// delete the service CA config map so that it is replaced with the proper one in next reconcile loop
 		opts := metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &serviceCA.UID}}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -819,7 +819,7 @@ func apiServices() []*apiregistrationv1.APIService {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: apiServiceGroupVersion.Version + "." + apiServiceGroupVersion.Group,
 				Annotations: map[string]string{
-					"service.alpha.openshift.io/inject-cabundle": "true",
+					"service.beta.openshift.io/inject-cabundle": "true",
 				},
 			},
 			Spec: apiregistrationv1.APIServiceSpec{

--- a/test-data/apply-configuration/overall/minimal-cluster/expected-output/Management/Create/namespaces/openshift-authentication/core/services/421e-body-oauth-openshift.yaml
+++ b/test-data/apply-configuration/overall/minimal-cluster/expected-output/Management/Create/namespaces/openshift-authentication/core/services/421e-body-oauth-openshift.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     operator.openshift.io/spec-hash: d9e6d53076d47ab2d123d8b1ba8ec6543488d973dcc4e02349493cd1c33bce83
-    service.alpha.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
   labels:
     app: oauth-openshift
   name: oauth-openshift

--- a/test-data/apply-configuration/overall/minimal-cluster/expected-output/UserWorkload/Create/namespaces/openshift-oauth-apiserver/core/services/dfd1-body-api.yaml
+++ b/test-data/apply-configuration/overall/minimal-cluster/expected-output/UserWorkload/Create/namespaces/openshift-oauth-apiserver/core/services/dfd1-body-api.yaml
@@ -5,7 +5,7 @@ metadata:
     operator.openshift.io/spec-hash: 9c74227d7f96d723d980c50373a5e91f08c5893365bfd5a5040449b1b6585a23
     prometheus.io/scheme: https
     prometheus.io/scrape: "true"
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: serving-cert
   labels:
     app: openshift-oauth-apiserver
   name: api

--- a/test-data/apply-configuration/overall/oauth-server-creation-minimal/input-dir/namespaces/openshift-authentication/core/configmaps.yaml
+++ b/test-data/apply-configuration/overall/oauth-server-creation-minimal/input-dir/namespaces/openshift-authentication/core/configmaps.yaml
@@ -86,7 +86,7 @@ items:
       openshift.io/description: Configmap is added/updated with a data item containing
         the CA signing bundle that can be used to verify service-serving certificates
       openshift.io/owning-component: service-ca
-      service.alpha.openshift.io/inject-cabundle: "true"
+      service.beta.openshift.io/inject-cabundle: "true"
     creationTimestamp: "2025-08-01T18:34:35Z"
     labels:
       app: oauth-openshift
@@ -97,7 +97,7 @@ items:
           f:metadata:
             f:annotations:
               .: {}
-              f:service.alpha.openshift.io/inject-cabundle: {}
+              f:service.beta.openshift.io/inject-cabundle: {}
             f:labels:
               .: {}
               f:app: {}

--- a/test-data/apply-configuration/overall/oauth-server-payloadcontroller/input-dir/namespaces/openshift-authentication/core/services/oauth-openshift.yaml
+++ b/test-data/apply-configuration/overall/oauth-server-payloadcontroller/input-dir/namespaces/openshift-authentication/core/services/oauth-openshift.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   annotations:
     operator.openshift.io/spec-hash: d9e6d53076d47ab2d123d8b1ba8ec6543488d973dcc4e02349493cd1c33bce83
-    service.alpha.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
     service.alpha.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@1754073255
     service.beta.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@1754073255
   creationTimestamp: "2025-08-01T18:34:31Z"
@@ -18,7 +18,7 @@ metadata:
         f:annotations:
           .: {}
           f:operator.openshift.io/spec-hash: {}
-          f:service.alpha.openshift.io/serving-cert-secret-name: {}
+          f:service.beta.openshift.io/serving-cert-secret-name: {}
         f:labels:
           .: {}
           f:app: {}

--- a/test-data/apply-configuration/overall/oauth-server-staticresource/expected-output/Management/Create/namespaces/openshift-authentication/core/services/421e-body-oauth-openshift.yaml
+++ b/test-data/apply-configuration/overall/oauth-server-staticresource/expected-output/Management/Create/namespaces/openshift-authentication/core/services/421e-body-oauth-openshift.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     operator.openshift.io/spec-hash: d9e6d53076d47ab2d123d8b1ba8ec6543488d973dcc4e02349493cd1c33bce83
-    service.alpha.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert
   labels:
     app: oauth-openshift
   name: oauth-openshift


### PR DESCRIPTION
- the serving-cert-secret  description can be found in https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/security_and_compliance/configuring-certificates#add-service-certificate_service-serving-certificate
- the ca bundle description can be found in https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/security_and_compliance/configuring-certificates#add-service-certificate-configmap_service-serving-certificate
- this is the change of beta version in service ca operator : https://github.com/openshift/service-ca-operator/commit/9820fea69bd7c38dc24861bd7b1354e341dc4088#diff-81a43fd4d98d3cb6bac44c7a083efc4f5ad81887646dce6ea0c744dc786369b7
- this is kind of clean up:
```
kubectl get svc -n openshift-authentication-operator metrics -oyaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
    service.alpha.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@1772155313
    service.beta.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@1772155313
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift service annotations from alpha to beta across configuration and test data.
  * Replaced service.alpha.openshift.io/serving-cert-secret-name with service.beta.openshift.io/serving-cert-secret-name.
  * Replaced service.alpha.openshift.io/inject-cabundle with service.beta.openshift.io/inject-cabundle for CA bundle injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->