### PR TITLE
OCPBUGS-78403: Do not return error when an IdP returns 500 during a grant check

### DIFF
--- a/pkg/controllers/configobservation/oauth/idp_conversions.go
+++ b/pkg/controllers/configobservation/oauth/idp_conversions.go
@@ -58,7 +58,6 @@ func convertIdentityProviders(
 	secretsLister corelistersv1.SecretLister,
 	identityProviders []configv1.IdentityProvider,
 ) ([]interface{}, *datasync.ConfigSyncData, []error) {
-
 	converted := []osinv1.IdentityProvider{}
 	syncData := datasync.NewConfigSyncData()
 	errs := []error{}
@@ -426,7 +425,8 @@ func checkOIDCPasswordGrantFlow(
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
-		return false, fmt.Errorf("OIDC token endpoint returned server error %d (%s)", resp.StatusCode, tokenURL)
+		klog.Errorf("OIDC token endpoint returned server error %d (%s)", resp.StatusCode, tokenURL)
+		return false, nil // no error returned so that observe_idps.go does not see this and fall back to existing config - it should proceed
 	}
 
 	respJSON := json.NewDecoder(resp.Body)

--- a/pkg/controllers/configobservation/oauth/idp_conversions_test.go
+++ b/pkg/controllers/configobservation/oauth/idp_conversions_test.go
@@ -316,7 +316,7 @@ func TestCheckOIDCPasswordGrantFlowCaching(t *testing.T) {
 			configv1.SecretNameReference{Name: "test-secret"},
 		)
 
-		require.Error(t, err)
+		require.NoError(t, err)
 		require.False(t, result)
 		require.NotContains(t, oidcPasswordChecks, "test-version-1")
 	})
@@ -351,7 +351,7 @@ func TestCheckOIDCPasswordGrantFlowCaching(t *testing.T) {
 			configv1.ConfigMapNameReference{Name: ""},
 			configv1.SecretNameReference{Name: "test-secret"},
 		)
-		require.Error(t, err)
+		require.NoError(t, err)
 		require.False(t, res1)
 		require.NotContains(t, oidcPasswordChecks, "test-version-1")
 


### PR DESCRIPTION
This can be an expected condition with some IdPs, and by returning an error here, we are causing observe_idps.go to see the error and fall back to an existing config rather that proceeding onward without this grant as it should in this case.