### PR TITLE
CNTRLPLANE-2523: deploy oauth-apiserver in new OIDC mode when authentication type is OIDC

### DIFF
--- a/bindata/oauth-apiserver/externaloidc-deploy.yaml
+++ b/bindata/oauth-apiserver/externaloidc-deploy.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-oauth-apiserver
+  name: apiserver
+  labels:
+    app: openshift-oauth-apiserver
+    apiserver: "true"
+# The number of replicas will be set in code to the number of master nodes.
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # To ensure that only one pod at a time writes to the node's
+      # audit log, require the update strategy to proceed a node at a
+      # time. Only when a master node has its existing
+      # oauth-apiserver pod stopped will a new one be allowed to
+      # start.
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver
+      apiserver: "true"
+  template:
+    metadata:
+      name: openshift-oauth-apiserver
+      labels:
+        app: openshift-oauth-apiserver
+        apiserver: "true"
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+    spec:
+      serviceAccountName: oauth-apiserver-sa
+      priorityClassName: system-node-critical
+      containers:
+      - name: oauth-apiserver
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: ${IMAGE}
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-ec"]
+        args:
+          - |
+            if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
+              echo "Copying system trust bundle"
+              cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+            fi
+            exec oauth-apiserver external-oidc \
+              --secure-port=8443 \
+              --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
+              --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
+              --config=/var/run/configmaps/auth-config/auth-config.json \
+              ${FLAGS}
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 150m
+        # we need to set this to privileged to be able to copy trust bundles to /etc/pki/ca-trust/extracted/pem/...
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        ports:
+        - containerPort: 8443
+        volumeMounts:
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
+          name: trusted-ca-bundle
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+        - mountPath: /var/run/configmaps/auth-config
+          name: auth-config
+      terminationGracePeriodSeconds: 120 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
+          optional: true
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+      - name: auth-config
+        configMap:
+          name: auth-config
+          items:
+          - key: auth-config.json
+            path: auth-config.json
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        # Ensure pod can be scheduled on master nodes
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+          # Ensure pod can be evicted if the node is unreachable
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+          # Ensure scheduling is delayed until node readiness
+          # (i.e. network operator configures CNI on the node)
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+      # Anti-affinity is configured in code due to the need to scope
+      # selection to the computed pod template.

--- a/pkg/controllers/common/external_oidc.go
+++ b/pkg/controllers/common/external_oidc.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -19,23 +21,30 @@ import (
 )
 
 type AuthConfigChecker struct {
-	authenticationsInformer        cache.SharedIndexInformer
-	kubeAPIServersInformer         cache.SharedIndexInformer
-	kasNamespaceConfigMapsInformer cache.SharedIndexInformer
+	authenticationsInformer         cache.SharedIndexInformer
+	kubeAPIServersInformer          cache.SharedIndexInformer
+	kasNamespaceConfigMapsInformer  cache.SharedIndexInformer
+	oaasNamespaceConfigMapsInformer cache.SharedIndexInformer
 
-	authLister         configv1listers.AuthenticationLister
-	kasLister          operatorv1listers.KubeAPIServerLister
-	kasConfigMapLister corelistersv1.ConfigMapLister
+	authLister          configv1listers.AuthenticationLister
+	kasLister           operatorv1listers.KubeAPIServerLister
+	kasConfigMapLister  corelistersv1.ConfigMapLister
+	oaasConfigMapLister corelistersv1.ConfigMapLister
+
+	featureGateAccessor featuregates.FeatureGateAccess
 }
 
-func NewAuthConfigChecker(authentications configv1informers.AuthenticationInformer, kubeapiservers operatorv1informers.KubeAPIServerInformer, configmaps corev1informers.ConfigMapInformer) AuthConfigChecker {
+func NewAuthConfigChecker(authentications configv1informers.AuthenticationInformer, kubeapiservers operatorv1informers.KubeAPIServerInformer, kasConfigMaps, oaasConfigMaps corev1informers.ConfigMapInformer, featureGateAccessor featuregates.FeatureGateAccess) AuthConfigChecker {
 	return AuthConfigChecker{
-		authenticationsInformer:        authentications.Informer(),
-		kubeAPIServersInformer:         kubeapiservers.Informer(),
-		kasNamespaceConfigMapsInformer: configmaps.Informer(),
-		authLister:                     authentications.Lister(),
-		kasLister:                      kubeapiservers.Lister(),
-		kasConfigMapLister:             configmaps.Lister(),
+		authenticationsInformer:         authentications.Informer(),
+		kubeAPIServersInformer:          kubeapiservers.Informer(),
+		kasNamespaceConfigMapsInformer:  kasConfigMaps.Informer(),
+		oaasNamespaceConfigMapsInformer: oaasConfigMaps.Informer(),
+		authLister:                      authentications.Lister(),
+		kasLister:                       kubeapiservers.Lister(),
+		kasConfigMapLister:              kasConfigMaps.Lister(),
+		oaasConfigMapLister:             oaasConfigMaps.Lister(),
+		featureGateAccessor:             featureGateAccessor,
 	}
 }
 
@@ -48,6 +57,7 @@ func AuthConfigCheckerInformers[T factory.Informer](c *AuthConfigChecker) []T {
 		c.authenticationsInformer.(T),
 		c.kubeAPIServersInformer.(T),
 		c.kasNamespaceConfigMapsInformer.(T),
+		c.oaasNamespaceConfigMapsInformer.(T),
 	}
 }
 
@@ -65,13 +75,51 @@ func (c *AuthConfigChecker) OIDCAvailable() (bool, error) {
 	}
 
 	if !c.kasNamespaceConfigMapsInformer.HasSynced() {
-		return false, fmt.Errorf("AuthConfigChecker configmaps informer has not synced yet")
+		return false, fmt.Errorf("AuthConfigChecker kube-apiserver namespace configmaps informer has not synced yet")
+	}
+
+	if !c.oaasNamespaceConfigMapsInformer.HasSynced() {
+		return false, fmt.Errorf("AuthConfigChecker oauth-apiserver namespace configmaps informer has not synced yet")
+	}
+
+	if !c.featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return false, fmt.Errorf("AuthConfigChecker initial feature gates not yet observed")
+	}
+
+	featureGates, err := c.featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return false, fmt.Errorf("AuthConfigChecker getting current feature gates: %w", err)
 	}
 
 	if auth, err := c.authLister.Get("cluster"); err != nil {
 		return false, fmt.Errorf("getting authentications.config.openshift.io/cluster: %v", err)
 	} else if auth.Spec.Type != configv1.AuthenticationTypeOIDC {
 		return false, nil
+	}
+
+	// If the ExternalOIDCExternalClaimsSourcing feature gate is enabled then we are attempting to use the new
+	// external oidc architecture that re-uses the oauth-apiserver as a webhook authenticator
+	// with a new mode of operation. Because of this shift back to using the oauth-apiserver, it is
+	// safe to assume that if the authentications/cluster resource has its spec.type set to OIDC
+	// that OIDC is "available" as we no longer have to actually wait for a kube-apiserver revision rollout
+	// to have completed prior to switching to the external OIDC operational mode.
+	// The only thing we need to ensure is that there is _some_ configuration that has been successfully
+	// synced to the openshift-oauth-apiserver namespace before attempting to rollout any new configurations.
+	// Doing so ensures that any errors encountered during the generation of the authentication configuration
+	// file doesn't cause the entirety of our authentication stack from falling over.
+	if featureGates.Enabled(features.FeatureGateExternalOIDCExternalClaimsSourcing) {
+		cm, err := c.oaasConfigMapLister.ConfigMaps("openshift-oauth-apiserver").Get("auth-config")
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, fmt.Errorf("getting configmap openshift-oauth-apiserver/auth-config: %w", err)
+		}
+
+		if _, ok := cm.Data["auth-config.json"]; !ok {
+			return false, fmt.Errorf("configmap openshift-oauth-apiserver/auth-config does not contain auth-config.json key")
+		}
+
+		return true, nil
 	}
 
 	kas, err := c.kasLister.Get("cluster")

--- a/pkg/controllers/common/external_oidc_test.go
+++ b/pkg/controllers/common/external_oidc_test.go
@@ -1,13 +1,16 @@
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
 	test "github.com/openshift/cluster-authentication-operator/test/library"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +34,7 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 		nodeStatuses       []operatorv1.NodeStatus
 		expectAvailable    bool
 		expectError        bool
+		featureGates       featuregates.FeatureGateAccess
 	}{
 		{
 			name:               "no node statuses observed",
@@ -40,6 +44,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			authType:           configv1.AuthenticationTypeOIDC,
 			expectAvailable:    false,
 			expectError:        true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "some node revisions are zero",
@@ -54,6 +64,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "node revisions are zero",
@@ -68,13 +84,19 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc disabled, no rollout",
 			authInformerSynced: true,
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
-			configMaps:         []*corev1.ConfigMap{cm("config-10", "config.yaml", kasConfigJSONWithoutOIDC)},
+			configMaps:         []*corev1.ConfigMap{cm(kasNamespace, "config-10", "config.yaml", kasConfigJSONWithoutOIDC)},
 			authType:           configv1.AuthenticationTypeIntegratedOAuth,
 			nodeStatuses: []operatorv1.NodeStatus{
 				{CurrentRevision: 10},
@@ -83,6 +105,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc getting enabled, rollout in progress",
@@ -90,9 +118,9 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-10", "config.yaml", kasConfigJSONWithoutOIDC),
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
+				cm(kasNamespace, "config-10", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -102,6 +130,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc getting enabled, rollout in progress, one node ready",
@@ -109,9 +143,9 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-10", "config.yaml", kasConfigJSONWithoutOIDC),
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
+				cm(kasNamespace, "config-10", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -121,6 +155,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc getting enabled, rollout in progress, two nodes ready",
@@ -128,9 +168,9 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-10", "config.yaml", kasConfigJSONWithoutOIDC),
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
+				cm(kasNamespace, "config-10", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -140,6 +180,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc got enabled",
@@ -147,8 +193,8 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -158,6 +204,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: true,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc enabled, rollout in progress",
@@ -165,10 +217,10 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-12", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-12", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -178,6 +230,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: true,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc enabled, rollout in progress, one node ready",
@@ -185,10 +243,10 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-12", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-12", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -198,6 +256,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: true,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc enabled, rollout in progress, two nodes ready",
@@ -205,10 +269,10 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-12", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-12", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -218,6 +282,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: true,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc still enabled",
@@ -225,10 +295,10 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-12", "config.yaml", kasConfigJSONWithOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-12", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			authType: configv1.AuthenticationTypeOIDC,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -238,6 +308,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: true,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc getting disabled, rollout in progress",
@@ -245,11 +321,11 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-12", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-13", "config.yaml", kasConfigJSONWithoutOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-12", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-13", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			authType: configv1.AuthenticationTypeIntegratedOAuth,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -259,6 +335,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc getting disabled, rollout in progress, one node ready",
@@ -266,11 +348,11 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-12", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-13", "config.yaml", kasConfigJSONWithoutOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-12", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-13", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			authType: configv1.AuthenticationTypeIntegratedOAuth,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -280,6 +362,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc getting disabled, rollout in progress, two nodes ready",
@@ -288,11 +376,11 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			cmInformerSynced:   true,
 			authType:           configv1.AuthenticationTypeIntegratedOAuth,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-13", "config.yaml", kasConfigJSONWithoutOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-13", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			nodeStatuses: []operatorv1.NodeStatus{
 				{CurrentRevision: 13},
@@ -301,6 +389,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "oidc got disabled",
@@ -308,11 +402,11 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			kasInformerSynced:  true,
 			cmInformerSynced:   true,
 			configMaps: []*corev1.ConfigMap{
-				cm("config-11", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-12", "config.yaml", kasConfigJSONWithOIDC),
-				cm("config-13", "config.yaml", kasConfigJSONWithoutOIDC),
-				cm("auth-config-11", "", ""),
-				cm("auth-config-12", "", ""),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-12", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "config-13", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+				cm(kasNamespace, "auth-config-12", "", ""),
 			},
 			authType: configv1.AuthenticationTypeIntegratedOAuth,
 			nodeStatuses: []operatorv1.NodeStatus{
@@ -322,6 +416,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "auth informer not synced",
@@ -331,6 +431,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			authType:           configv1.AuthenticationTypeOIDC,
 			expectAvailable:    false,
 			expectError:        true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "kas informer not synced",
@@ -345,6 +451,12 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
 		},
 		{
 			name:               "configmap informer not synced",
@@ -359,10 +471,108 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 			},
 			expectAvailable: false,
 			expectError:     true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+			),
+		},
+		{
+			name:               "initial feature gates not observed",
+			authInformerSynced: true,
+			kasInformerSynced:  true,
+			cmInformerSynced:   true,
+			authType:           configv1.AuthenticationTypeOIDC,
+			nodeStatuses: []operatorv1.NodeStatus{
+				{CurrentRevision: 10},
+				{CurrentRevision: 10},
+				{CurrentRevision: 10},
+			},
+			expectAvailable: false,
+			expectError:     true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccessForTesting(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				make(chan struct{}),
+				nil,
+			),
+		},
+		{
+			name:               "current feature gates not available",
+			authInformerSynced: true,
+			kasInformerSynced:  true,
+			cmInformerSynced:   true,
+			authType:           configv1.AuthenticationTypeOIDC,
+			nodeStatuses: []operatorv1.NodeStatus{
+				{CurrentRevision: 10},
+				{CurrentRevision: 10},
+				{CurrentRevision: 10},
+			},
+			expectAvailable: false,
+			expectError:     true,
+			featureGates: featuregates.NewHardcodedFeatureGateAccessForTesting(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				makeClosedChannel(),
+				fmt.Errorf("boom"),
+			),
+		},
+		{
+			name:               "oidc getting enabled, rollout in progress, FeatureGateExternalOIDCExternalClaimsSourcing enabled, oauth-apiserver/auth-config not exists, oidc not available",
+			authInformerSynced: true,
+			kasInformerSynced:  true,
+			cmInformerSynced:   true,
+			// Keeping existing configmap revisions shows that we ignore them
+			configMaps: []*corev1.ConfigMap{
+				cm(kasNamespace, "config-10", "config.yaml", kasConfigJSONWithoutOIDC),
+				cm(kasNamespace, "config-11", "config.yaml", kasConfigJSONWithOIDC),
+				cm(kasNamespace, "auth-config-11", "", ""),
+			},
+			authType: configv1.AuthenticationTypeOIDC,
+			nodeStatuses: []operatorv1.NodeStatus{
+				{CurrentRevision: 10, TargetRevision: 11},
+				{CurrentRevision: 10},
+				{CurrentRevision: 10},
+			},
+			expectAvailable: false,
+			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{},
+			),
+		},
+		{
+			name:               "oidc getting enabled, rollout complete, FeatureGateExternalOIDCExternalClaimsSourcing enabled, oauth-apiserver/auth-config exists, oidc available",
+			authInformerSynced: true,
+			kasInformerSynced:  true,
+			cmInformerSynced:   true,
+			configMaps: []*corev1.ConfigMap{
+				cm("openshift-oauth-apiserver", "auth-config", "auth-config.json", ""),
+			},
+			authType: configv1.AuthenticationTypeOIDC,
+			nodeStatuses: []operatorv1.NodeStatus{
+				{CurrentRevision: 10, TargetRevision: 11},
+				{CurrentRevision: 10},
+				{CurrentRevision: 10},
+			},
+			expectAvailable: true,
+			expectError:     false,
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{},
+			),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-
 			cmIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			for _, cm := range tt.configMaps {
 				cmIndexer.Add(cm)
@@ -397,6 +607,8 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 				test.NewFakeSharedIndexInformerWithSync(configv1listers.NewAuthenticationLister(authIndexer), tt.authInformerSynced),
 				test.NewFakeSharedIndexInformerWithSync(operatorv1listers.NewKubeAPIServerLister(kasIndexer), tt.kasInformerSynced),
 				test.NewFakeSharedIndexInformerWithSync(corelistersv1.NewConfigMapLister(cmIndexer), tt.cmInformerSynced),
+				test.NewFakeSharedIndexInformerWithSync(corelistersv1.NewConfigMapLister(cmIndexer), tt.cmInformerSynced),
+				tt.featureGates,
 			)
 
 			available, err := authConfigChecker.OIDCAvailable()
@@ -412,11 +624,13 @@ func TestExternalOIDCConfigAvailable(t *testing.T) {
 	}
 }
 
-func cm(name, dataKey, dataValue string) *corev1.ConfigMap {
+const kasNamespace = "openshift-kube-apiserver"
+
+func cm(namespace, name, dataKey, dataValue string) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "openshift-kube-apiserver",
+			Namespace: namespace,
 		},
 	}
 
@@ -427,4 +641,10 @@ func cm(name, dataKey, dataValue string) *corev1.ConfigMap {
 	}
 
 	return cm
+}
+
+func makeClosedChannel() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }

--- a/pkg/controllers/routercerts/controller_test.go
+++ b/pkg/controllers/routercerts/controller_test.go
@@ -26,12 +26,14 @@ import (
 	clocktesting "k8s.io/utils/clock/testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
 	"github.com/openshift/cluster-authentication-operator/pkg/controllers/common"
 	test "github.com/openshift/cluster-authentication-operator/test/library"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -267,6 +269,13 @@ func TestValidateRouterCertificates(t *testing.T) {
 					test.NewFakeSharedIndexInformerWithSync(configv1listers.NewAuthenticationLister(authIndexer), true),
 					test.NewFakeSharedIndexInformerWithSync[operatorv1listers.KubeAPIServerLister](nil, true),
 					test.NewFakeSharedIndexInformerWithSync[corelistersv1.ConfigMapLister](nil, true),
+					test.NewFakeSharedIndexInformerWithSync[corelistersv1.ConfigMapLister](nil, true),
+					featuregates.NewHardcodedFeatureGateAccess(
+						[]configv1.FeatureGateName{},
+						[]configv1.FeatureGateName{
+							features.FeatureGateExternalOIDCExternalClaimsSourcing,
+						},
+					),
 				),
 			}
 			err = controller.sync(context.TODO(), factory.NewSyncContext("testctx", events.NewInMemoryRecorder("test-recorder", clocktesting.NewFakePassiveClock(time.Now()))))

--- a/pkg/controllers/webhookauthenticator/webhookauthenticator_controller.go
+++ b/pkg/controllers/webhookauthenticator/webhookauthenticator_controller.go
@@ -124,14 +124,16 @@ func (c *webhookAuthenticatorController) sync(ctx context.Context, syncCtx facto
 		return fmt.Errorf("observing feature gates: %w", err)
 	}
 
-	if oidcAvailable, err := c.authConfigChecker.OIDCAvailable(); err != nil {
-		return err
-	} else if oidcAvailable {
-		if err := c.removeOperands(ctx); err != nil {
+	if !featureGates.Enabled(features.FeatureGateExternalOIDCExternalClaimsSourcing) {
+		if oidcAvailable, err := c.authConfigChecker.OIDCAvailable(); err != nil {
 			return err
-		}
+		} else if oidcAvailable {
+			if err := c.removeOperands(ctx); err != nil {
+				return err
+			}
 
-		return c.operatorClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, applyoperatorv1.OperatorStatus())
+			return c.operatorClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, applyoperatorv1.OperatorStatus())
+		}
 	}
 
 	authConfig, err := c.authentication.Get(ctx, "cluster", metav1.GetOptions{})

--- a/pkg/operator/replacement_starter.go
+++ b/pkg/operator/replacement_starter.go
@@ -143,7 +143,7 @@ func CreateOperatorInputFromMOM(ctx context.Context, momInput libraryapplyconfig
 		apiextensionClient:           apiextensionClient,
 		eventRecorder:                eventRecorder,
 		clock:                        momInput.Clock,
-		featureGateAccessor:          staticFeatureGateAccessor([]ocpconfigv1.FeatureGateName{features.FeatureGateExternalOIDC}, []ocpconfigv1.FeatureGateName{features.FeatureGateKMSEncryption}),
+		featureGateAccessor:          staticFeatureGateAccessor([]ocpconfigv1.FeatureGateName{features.FeatureGateExternalOIDC}, []ocpconfigv1.FeatureGateName{features.FeatureGateKMSEncryption, features.FeatureGateExternalOIDCExternalClaimsSourcing}),
 		informerFactories: []libraryapplyconfiguration.SimplifiedInformerFactory{
 			libraryapplyconfiguration.DynamicInformerFactoryAdapter(dynamicInformers), // we don't share the dynamic informers, but we only want to start when requested
 		},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -130,10 +130,17 @@ func prepareOauthOperator(
 		authOperatorInput.eventRecorder,
 	)
 
+	featureGateAccessor, err := authOperatorInput.featureGateAccessor(ctx, authOperatorInput, informerFactories)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	authConfigChecker := common.NewAuthConfigChecker(
 		informerFactories.operatorConfigInformer.Config().V1().Authentications(),
 		informerFactories.operatorInformer.Operator().V1().KubeAPIServers(),
 		informerFactories.kubeInformersForNamespaces.InformersFor("openshift-kube-apiserver").Core().V1().ConfigMaps(),
+		informerFactories.kubeInformersForNamespaces.InformersFor("openshift-oauth-apiserver").Core().V1().ConfigMaps(),
+		featureGateAccessor,
 	)
 
 	staticResourceController := staticresourcecontroller.NewStaticResourceController(
@@ -447,14 +454,49 @@ func prepareOauthAPIServerOperator(
 	}
 	migrator := migrators.NewKubeStorageVersionMigrator(authOperatorInput.migrationClient, informerFactories.migrationInformer.Migration().V1alpha1(), authOperatorInput.kubeClient.Discovery())
 
+	featureGateAccessor, err := authOperatorInput.featureGateAccessor(ctx, authOperatorInput, informerFactories)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	authConfigChecker := common.NewAuthConfigChecker(
 		informerFactories.operatorConfigInformer.Config().V1().Authentications(),
 		informerFactories.operatorInformer.Operator().V1().KubeAPIServers(),
 		informerFactories.kubeInformersForNamespaces.InformersFor("openshift-kube-apiserver").Core().V1().ConfigMaps(),
+		informerFactories.kubeInformersForNamespaces.InformersFor("openshift-oauth-apiserver").Core().V1().ConfigMaps(),
+		featureGateAccessor,
 	)
 
-	featureGateAccessor, err := authOperatorInput.featureGateAccessor(ctx, authOperatorInput, informerFactories)
-	if err != nil {
+	// conditionally sync the auth-config configmap from the openshift-config-managed namespace
+	// to the openshift-oauth-apiserver if OIDC is available and FeatureGateExternalOIDCExternalClaimsSourcing is enabled.
+	// This precondition never returns an error to prevent unnecessary degradation.
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: "openshift-oauth-apiserver", Name: "auth-config"},
+		resourcesynccontroller.ResourceLocation{Namespace: "openshift-config-managed", Name: "auth-config"},
+		func() (bool, error) {
+			if !featureGateAccessor.AreInitialFeatureGatesObserved() {
+				klog.Error("checking oauth-apiserver auth-config sync preconditions failed: initial feature gates not observed")
+				return false, nil
+			}
+			featureGates, err := featureGateAccessor.CurrentFeatureGates()
+			if err != nil {
+				klog.Errorf("checking oauth-apiserver auth-config sync preconditions failed: getting current feature gates: %v", err)
+				return false, nil
+			}
+
+			if featureGates.Enabled(features.FeatureGateExternalOIDCExternalClaimsSourcing) {
+				authConfig, err := authConfigChecker.AuthConfig()
+				if err != nil {
+					klog.Errorf("checking oauth-apiserver auth-config sync preconditions failed: getting authentications/cluster: %v", err)
+					return false, nil
+				}
+
+				return authConfig.Spec.Type == configv1.AuthenticationTypeOIDC, nil
+			}
+
+			return false, nil
+		},
+	); err != nil {
 		return nil, nil, err
 	}
 
@@ -467,7 +509,7 @@ func prepareOauthAPIServerOperator(
 		os.Getenv("OPERATOR_IMAGE"),
 		authOperatorInput.kubeClient,
 		informerFactories.kubeInformersForNamespaces.InformersFor("openshift-oauth-apiserver").Apps().V1().Deployments().Lister(),
-		authConfigChecker,
+		&authConfigChecker,
 		featureGateAccessor,
 		versionRecorder)
 
@@ -574,9 +616,6 @@ func prepareOauthAPIServerOperator(
 			{
 				// OAuth specific resources; deleted when OIDC is enabled
 				Files: []string{
-					"oauth-apiserver/apiserver-clusterrolebinding.yaml",
-					"oauth-apiserver/svc.yaml",
-					"oauth-apiserver/sa.yaml",
 					"oauth-apiserver/RBAC/useroauthaccesstokens_binding.yaml",
 					"oauth-apiserver/RBAC/useroauthaccesstokens_clusterrole.yaml",
 				},
@@ -584,6 +623,33 @@ func prepareOauthAPIServerOperator(
 					return !oidcAvailable(authConfigChecker)
 				},
 				ShouldDeleteFn: func() bool {
+					return oidcAvailable(authConfigChecker)
+				},
+			},
+			{
+				// OAuth specific resources; deleted when OIDC is enabled and FeatureGateExternalOIDCExternalClaimsSourcing is disabled.
+				// Not deleted when OIDC is enabled when FeatureGateExternalOIDCExternalClaimsSourcing gate is enabled.
+				Files: []string{
+					"oauth-apiserver/sa.yaml",
+					"oauth-apiserver/apiserver-clusterrolebinding.yaml",
+					"oauth-apiserver/svc.yaml",
+				},
+				ShouldCreateFn: func() bool {
+					// If this call errors out, fallback to the existing approach
+					gates, err := featureGateAccessor.CurrentFeatureGates()
+					if err == nil && gates.Enabled(features.FeatureGateExternalOIDCExternalClaimsSourcing) {
+						return true
+					}
+
+					return !oidcAvailable(authConfigChecker)
+				},
+				ShouldDeleteFn: func() bool {
+					// If this call errors out, fallback to the existing approach
+					gates, err := featureGateAccessor.CurrentFeatureGates()
+					if err == nil && gates.Enabled(features.FeatureGateExternalOIDCExternalClaimsSourcing) {
+						return false
+					}
+
 					return oidcAvailable(authConfigChecker)
 				},
 			},
@@ -766,7 +832,6 @@ func prepareExternalOIDC(
 	authOperatorInput *authenticationOperatorInput,
 	informerFactories authenticationOperatorInformerFactories,
 ) ([]libraryapplyconfiguration.NamedRunOnce, []libraryapplyconfiguration.RunFunc, error) {
-
 	featureGateAccessor, err := authOperatorInput.featureGateAccessor(ctx, authOperatorInput, informerFactories)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -18,6 +18,8 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	libgoetcd "github.com/openshift/library-go/pkg/operator/configobserver/etcd"
@@ -43,6 +45,11 @@ type nodeCountFunc func(nodeSelector map[string]string) (*int32, error)
 // one pod of a given replicaset from landing on a node.
 type ensureAtMostOnePodPerNodeFunc func(spec *appsv1.DeploymentSpec, componentName string) error
 
+type authConfigChecker interface {
+	OIDCAvailable() (bool, error)
+	AuthConfig() (*configv1.Authentication, error)
+}
+
 // OAuthAPIServerWorkload is a struct that holds necessary data to install OAuthAPIServer
 type OAuthAPIServerWorkload struct {
 	operatorClient v1helpers.OperatorClient
@@ -57,7 +64,7 @@ type OAuthAPIServerWorkload struct {
 	kubeClient                kubernetes.Interface
 	versionRecorder           status.VersionGetter
 	deploymentsLister         appsv1listers.DeploymentLister
-	authConfigChecker         common.AuthConfigChecker
+	authConfigChecker         authConfigChecker
 	featureGateAccessor       featuregates.FeatureGateAccess
 }
 
@@ -71,7 +78,7 @@ func NewOAuthAPIServerWorkload(
 	operatorImagePullSpec string,
 	kubeClient kubernetes.Interface,
 	deploymentsLister appsv1listers.DeploymentLister,
-	authConfigChecker common.AuthConfigChecker,
+	authConfigChecker authConfigChecker,
 	featureGateAccessor featuregates.FeatureGateAccess,
 	versionRecorder status.VersionGetter,
 ) *OAuthAPIServerWorkload {
@@ -98,6 +105,21 @@ func (c *OAuthAPIServerWorkload) WorkloadDeleted(ctx context.Context) (bool, str
 	}
 
 	// OIDC has been configured and rolled out; delete deployment if it exists
+
+	if !c.featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return false, "", fmt.Errorf("initial feature gates not yet observed")
+	}
+
+	featureGates, err := c.featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return false, "", fmt.Errorf("getting current feature gates: %w", err)
+	}
+
+	// If the ExternalOIDCExternalClaimsSourcing feature gate is enabled, we are attempting
+	// to use our new external OIDC architecture that always deploys the oauth-apiserver.
+	if featureGates.Enabled(features.FeatureGateExternalOIDCExternalClaimsSourcing) {
+		return false, "", nil
+	}
 
 	deployment := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("oauth-apiserver/deploy.yaml"))
 	if _, err := c.deploymentsLister.Deployments(deployment.Namespace).Get(deployment.Name); errors.IsNotFound(err) {
@@ -176,6 +198,30 @@ func (c *OAuthAPIServerWorkload) syncDeployment(ctx context.Context, operatorSpe
 		return nil, fmt.Errorf(".status.latestAvailableRevision is not yet available")
 	}
 
+	if !c.featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return nil, fmt.Errorf("initial feature gates not yet observed")
+	}
+
+	featureGates, err := c.featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return nil, fmt.Errorf("getting current feature gates: %w", err)
+	}
+
+	if featureGates.Enabled(features.FeatureGateExternalOIDCExternalClaimsSourcing) {
+		oidcAvailable, err := c.authConfigChecker.OIDCAvailable()
+		if err != nil {
+			return nil, fmt.Errorf("checking if OIDC configuration is available: %w", err)
+		}
+
+		if oidcAvailable {
+			return c.syncExternalOIDCDeployment(ctx, operatorSpec, operatorStatus, eventRecorder)
+		}
+	}
+
+	return c.syncStandardDeployment(ctx, operatorSpec, operatorStatus, eventRecorder)
+}
+
+func (c *OAuthAPIServerWorkload) syncStandardDeployment(ctx context.Context, operatorSpec *operatorv1.OperatorSpec, operatorStatus *operatorv1.OperatorStatus, eventRecorder events.Recorder) (*appsv1.Deployment, error) {
 	tmpl, err := bindata.Asset("oauth-apiserver/deploy.yaml")
 	if err != nil {
 		return nil, err
@@ -272,6 +318,97 @@ func (c *OAuthAPIServerWorkload) syncDeployment(ctx context.Context, operatorSpe
 	if err := encryptionkms.AddKMSPluginVolumeAndMountToPodSpec(&required.Spec.Template.Spec, "oauth-apiserver", c.featureGateAccessor); err != nil {
 		return nil, fmt.Errorf("failed to add KMS encryption volumes: %w", err)
 	}
+
+	deployment, _, err := resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), eventRecorder, required, resourcemerge.ExpectedDeploymentGeneration(required, operatorStatus.Generations))
+	return deployment, err
+}
+
+func (c *OAuthAPIServerWorkload) syncExternalOIDCDeployment(ctx context.Context, operatorSpec *operatorv1.OperatorSpec, operatorStatus *operatorv1.OperatorStatus, eventRecorder events.Recorder) (*appsv1.Deployment, error) {
+	tmpl, err := bindata.Asset("oauth-apiserver/externaloidc-deploy.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	argsRaw, err := GetAPIServerArgumentsRaw(*operatorSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := arguments.Parse(argsRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	// log level verbosity is taken from the spec always
+	args["v"] = []string{loglevelToKlog(operatorSpec.LogLevel)}
+
+	// use string replacer for simple things
+	r := strings.NewReplacer(
+		"${IMAGE}", c.targetImagePullSpec,
+		"${REVISION}", strconv.Itoa(int(operatorStatus.LatestAvailableRevision)),
+	)
+
+	excludedReferences := sets.NewString("${FLAGS}")
+	tmpl = []byte(r.Replace(string(tmpl)))
+	re := regexp.MustCompile(`\$\{[^}]*}`)
+	if match := re.Find(tmpl); len(match) > 0 && !excludedReferences.Has(string(match)) {
+		return nil, fmt.Errorf("invalid template reference %q", string(match))
+	}
+
+	required := resourceread.ReadDeploymentV1OrDie(tmpl)
+
+	// use the following routine for things that would require special formatting/padding (yaml)
+	encodedArgs := arguments.EncodeWithDelimiter(args, " \\\n  ")
+	r = strings.NewReplacer(
+		"${FLAGS}", encodedArgs,
+	)
+	for containerIndex, container := range required.Spec.Template.Spec.Containers {
+		for argIndex, arg := range container.Args {
+			required.Spec.Template.Spec.Containers[containerIndex].Args[argIndex] = r.Replace(arg)
+		}
+	}
+
+	// we set this so that when the requested image pull spec changes, we always have a diff.  Remember that we don't directly
+	// diff any fields on the deployment because they can be rewritten by admission and we don't want to constantly be fighting
+	// against admission or defaults.  That was a problem with original versions of apply.
+	if required.Annotations == nil {
+		required.Annotations = map[string]string{}
+	}
+	required.Annotations["openshiftapiservers.operator.openshift.io/operator-pull-spec"] = c.operatorImagePullSpec
+
+	required.Labels["revision"] = strconv.Itoa(int(operatorStatus.LatestAvailableRevision))
+	required.Spec.Template.Labels["revision"] = strconv.Itoa(int(operatorStatus.LatestAvailableRevision))
+
+	// we watch some resources so that our deployment will redeploy without explicitly and carefully ordered resource creation
+	inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferences(
+		ctx,
+		c.kubeClient,
+		resourcehash.NewObjectRef().ForConfigMap().InNamespace(c.targetNamespace).Named("trusted-ca-bundle"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dependency reference: %q", err)
+	}
+
+	for k, v := range inputHashes {
+		annotationKey := fmt.Sprintf("operator.openshift.io/dep-%s", k)
+		required.Annotations[annotationKey] = v
+		if required.Spec.Template.Annotations == nil {
+			required.Spec.Template.Annotations = map[string]string{}
+		}
+		required.Spec.Template.Annotations[annotationKey] = v
+	}
+
+	err = c.ensureAtMostOnePodPerNode(&required.Spec, "oauth-apiserver")
+	if err != nil {
+		return nil, fmt.Errorf("unable to ensure at most one pod per node: %v", err)
+	}
+
+	// Set the replica count to the number of master nodes.
+	masterNodeCount, err := c.countNodes(required.Spec.Template.Spec.NodeSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine number of master nodes: %v", err)
+	}
+	required.Spec.Replicas = masterNodeCount
 
 	deployment, _, err := resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), eventRecorder, required, resourcemerge.ExpectedDeploymentGeneration(required, operatorStatus.Generations))
 	return deployment, err

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver_test.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -63,10 +65,13 @@ var unsupportedConfigOverridesAPIServerArgsJSON = `
 
 func TestSyncOAuthAPIServerDeployment(t *testing.T) {
 	scenarios := []struct {
-		name            string
-		goldenFile      string
-		operator        *operatorv1.Authentication
-		expectedActions []string
+		name               string
+		goldenFile         string
+		operator           *operatorv1.Authentication
+		expectedActions    []string
+		featureGates       featuregates.FeatureGateAccess
+		authenticationType configv1.AuthenticationType
+		authConfigChecker  authConfigChecker
 	}{
 		// scenario 1
 		{
@@ -87,6 +92,13 @@ func TestSyncOAuthAPIServerDeployment(t *testing.T) {
 				"get:deployments:openshift-oauth-apiserver:apiserver",
 				"create:deployments:openshift-oauth-apiserver:apiserver",
 			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+					features.FeatureGateKMSEncryption,
+				},
+			),
 		},
 
 		// scenario 2
@@ -110,6 +122,13 @@ func TestSyncOAuthAPIServerDeployment(t *testing.T) {
 				"get:deployments:openshift-oauth-apiserver:apiserver",
 				"create:deployments:openshift-oauth-apiserver:apiserver",
 			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+					features.FeatureGateKMSEncryption,
+				},
+			),
 		},
 
 		// scenario 3
@@ -134,6 +153,198 @@ func TestSyncOAuthAPIServerDeployment(t *testing.T) {
 				"get:deployments:openshift-oauth-apiserver:apiserver",
 				"create:deployments:openshift-oauth-apiserver:apiserver",
 			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+					features.FeatureGateKMSEncryption,
+				},
+			),
+		},
+		{
+			name:       "happy path: a deployment with default values is created with ExternalOIDCExternalClaimsSourcing gate enabled but OIDC not configured",
+			goldenFile: "./testdata/sync_ds_scenario_1.yaml",
+			operator: &operatorv1.Authentication{
+				Spec: operatorv1.AuthenticationSpec{OperatorSpec: operatorv1.OperatorSpec{}},
+				Status: operatorv1.AuthenticationStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						LatestAvailableRevision: 1,
+					},
+				},
+			},
+			expectedActions: []string{
+				"get:secrets:etcd-client",
+				"get:configmaps:etcd-serving-ca",
+				"get:configmaps:trusted-ca-bundle",
+				"get:deployments:openshift-oauth-apiserver:apiserver",
+				"create:deployments:openshift-oauth-apiserver:apiserver",
+			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{
+					features.FeatureGateKMSEncryption,
+				},
+			),
+			authConfigChecker: &mockAuthConfigChecker{
+				oidcAvailable: false,
+			},
+		},
+		{
+			name:       "a deployment with custom flags (for oauthapi server) is created with ExternalOIDCExternalClaimsSourcing gate enabled but OIDC not configured",
+			goldenFile: "./testdata/sync_ds_scenario_2.yaml",
+			operator: &operatorv1.Authentication{
+				Spec: operatorv1.AuthenticationSpec{OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig: runtime.RawExtension{Raw: []byte(customAPIServerArgsJSON)},
+				}},
+				Status: operatorv1.AuthenticationStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						LatestAvailableRevision: 1,
+					},
+				},
+			},
+			expectedActions: []string{
+				"get:secrets:etcd-client",
+				"get:configmaps:etcd-serving-ca",
+				"get:configmaps:trusted-ca-bundle",
+				"get:deployments:openshift-oauth-apiserver:apiserver",
+				"create:deployments:openshift-oauth-apiserver:apiserver",
+			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{
+					features.FeatureGateKMSEncryption,
+				},
+			),
+			authConfigChecker: &mockAuthConfigChecker{
+				oidcAvailable: false,
+			},
+		},
+
+		{
+			name:       "a deployment with custom flags (for oauthapi server) is created with UnsupportedConfigOverrides with ExternalOIDCExternalClaimsSourcing gate enabled but OIDC not configured",
+			goldenFile: "./testdata/sync_ds_scenario_3.yaml",
+			operator: &operatorv1.Authentication{
+				Spec: operatorv1.AuthenticationSpec{OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig:             runtime.RawExtension{Raw: []byte(customAPIServerArgsJSON)},
+					UnsupportedConfigOverrides: runtime.RawExtension{Raw: []byte(unsupportedConfigOverridesAPIServerArgsJSON)},
+				}},
+				Status: operatorv1.AuthenticationStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						LatestAvailableRevision: 1,
+					},
+				},
+			},
+			expectedActions: []string{
+				"get:secrets:etcd-client",
+				"get:configmaps:etcd-serving-ca",
+				"get:configmaps:trusted-ca-bundle",
+				"get:deployments:openshift-oauth-apiserver:apiserver",
+				"create:deployments:openshift-oauth-apiserver:apiserver",
+			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{
+					features.FeatureGateKMSEncryption,
+				},
+			),
+			authConfigChecker: &mockAuthConfigChecker{
+				oidcAvailable: false,
+			},
+		},
+		{
+			name:       "happy path: a default deployment configuring the new oauth-apiserver external OIDC mode is created",
+			goldenFile: "./testdata/sync_ds_scenario_4.yaml",
+			operator: &operatorv1.Authentication{
+				Spec: operatorv1.AuthenticationSpec{OperatorSpec: operatorv1.OperatorSpec{}},
+				Status: operatorv1.AuthenticationStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						LatestAvailableRevision: 1,
+					},
+				},
+			},
+			expectedActions: []string{
+				"get:configmaps:trusted-ca-bundle",
+				"get:deployments:openshift-oauth-apiserver:apiserver",
+				"create:deployments:openshift-oauth-apiserver:apiserver",
+			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{
+					features.FeatureGateKMSEncryption,
+				},
+			),
+			authConfigChecker: &mockAuthConfigChecker{
+				oidcAvailable: true,
+			},
+		},
+		{
+			name:       "a deployment with custom flags (for oauthapi server) for the external OIDC mode is created",
+			goldenFile: "./testdata/sync_ds_scenario_5.yaml",
+			operator: &operatorv1.Authentication{
+				Spec: operatorv1.AuthenticationSpec{OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig: runtime.RawExtension{Raw: []byte(customAPIServerArgsJSON)},
+				}},
+				Status: operatorv1.AuthenticationStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						LatestAvailableRevision: 1,
+					},
+				},
+			},
+			expectedActions: []string{
+				"get:configmaps:trusted-ca-bundle",
+				"get:deployments:openshift-oauth-apiserver:apiserver",
+				"create:deployments:openshift-oauth-apiserver:apiserver",
+			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{
+					features.FeatureGateKMSEncryption,
+				},
+			),
+			authConfigChecker: &mockAuthConfigChecker{
+				oidcAvailable: true,
+			},
+		},
+		{
+			name:       "a deployment with custom flags (for oauthapi server) and external OIDC mode is created with UnsupportedConfigOverrides",
+			goldenFile: "./testdata/sync_ds_scenario_6.yaml",
+			operator: &operatorv1.Authentication{
+				Spec: operatorv1.AuthenticationSpec{OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig:             runtime.RawExtension{Raw: []byte(customAPIServerArgsJSON)},
+					UnsupportedConfigOverrides: runtime.RawExtension{Raw: []byte(unsupportedConfigOverridesAPIServerArgsJSON)},
+				}},
+				Status: operatorv1.AuthenticationStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						LatestAvailableRevision: 1,
+					},
+				},
+			},
+			expectedActions: []string{
+				"get:configmaps:trusted-ca-bundle",
+				"get:deployments:openshift-oauth-apiserver:apiserver",
+				"create:deployments:openshift-oauth-apiserver:apiserver",
+			},
+			featureGates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{
+					features.FeatureGateKMSEncryption,
+				},
+			),
+			authConfigChecker: &mockAuthConfigChecker{
+				oidcAvailable: true,
+			},
 		},
 	}
 
@@ -146,7 +357,8 @@ func TestSyncOAuthAPIServerDeployment(t *testing.T) {
 				countNodes:                func(nodeSelector map[string]string) (*int32, error) { var i int32; i = 1; return &i, nil },
 				ensureAtMostOnePodPerNode: func(spec *appsv1.DeploymentSpec, componentName string) error { return nil },
 				kubeClient:                fakeKubeClient,
-				featureGateAccessor:       featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, make(chan struct{}), nil),
+				featureGateAccessor:       scenario.featureGates,
+				authConfigChecker:         scenario.authConfigChecker,
 			}
 
 			actualDeployment, err := target.syncDeployment(context.TODO(), &scenario.operator.Spec.OperatorSpec, &scenario.operator.Status.OperatorStatus, eventRecorder)
@@ -339,4 +551,18 @@ func readBytesFromFile(t *testing.T, filename string) []byte {
 	}
 
 	return data
+}
+
+type mockAuthConfigChecker struct {
+	authentication *configv1.Authentication
+	err            error
+	oidcAvailable  bool
+}
+
+func (macc *mockAuthConfigChecker) AuthConfig() (*configv1.Authentication, error) {
+	return macc.authentication, macc.err
+}
+
+func (macc *mockAuthConfigChecker) OIDCAvailable() (bool, error) {
+	return macc.oidcAvailable, macc.err
 }

--- a/pkg/operator/workload/testdata/sync_ds_scenario_4.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_4.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-oauth-apiserver
+  name: apiserver
+  labels:
+    app: openshift-oauth-apiserver
+    apiserver: "true"
+    revision: "1"
+  annotations:
+    openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
+    operator.openshift.io/spec-hash: "881cf9b086402c9dfc70e1daa0a27de2b62eec5e21cefd02e081e65ca10bfc0d"
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver
+      apiserver: "true"
+  replicas: 1
+  template:
+    metadata:
+      name: openshift-oauth-apiserver
+      labels:
+        app: openshift-oauth-apiserver
+        apiserver: "true"
+        revision: "1"
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+    spec:
+      serviceAccountName: oauth-apiserver-sa
+      priorityClassName: system-node-critical
+      containers:
+        - name: oauth-apiserver
+          terminationMessagePolicy: FallbackToLogsOnError
+          image: ""
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-ec"]
+          args:
+            - |
+              if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
+                echo "Copying system trust bundle"
+                cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+              fi
+              exec oauth-apiserver external-oidc \
+                --secure-port=8443 \
+                --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
+                --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
+                --config=/var/run/configmaps/auth-config/auth-config.json \
+                --v=2
+          resources:
+            requests:
+              memory: 200Mi
+              cpu: 150m
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - mountPath: /var/run/configmaps/trusted-ca-bundle
+              name: trusted-ca-bundle
+            - mountPath: /var/run/secrets/serving-cert
+              name: serving-cert
+            - mountPath: /var/run/configmaps/auth-config
+              name: auth-config
+      terminationGracePeriodSeconds: 120 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
+      volumes:
+        - name: serving-cert
+          secret:
+            secretName: serving-cert
+        - name: trusted-ca-bundle
+          configMap:
+            name: trusted-ca-bundle
+            optional: true
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
+        - name: auth-config
+          configMap:
+            name: auth-config
+            items:
+              - key: auth-config.json
+                path: auth-config.json
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        # Ensure pod can be scheduled on master nodes
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+          # Ensure pod can be evicted if the node is unreachable
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+          # Ensure scheduling is delayed until node readiness
+          # (i.e. network operator configures CNI on the node)
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+      # Anti-affinity is configured in code due to the need to scope
+      # selection to the computed pod template.

--- a/pkg/operator/workload/testdata/sync_ds_scenario_5.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_5.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-oauth-apiserver
+  name: apiserver
+  labels:
+    app: openshift-oauth-apiserver
+    apiserver: "true"
+    revision: "1"
+  annotations:
+    openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
+    operator.openshift.io/spec-hash: "335886e6d1e86f0ee7e09c68d1de2bc976de2ee2579ada87f8d500a1ef981e96"
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver
+      apiserver: "true"
+  replicas: 1
+  template:
+    metadata:
+      name: openshift-oauth-apiserver
+      labels:
+        app: openshift-oauth-apiserver
+        apiserver: "true"
+        revision: "1"
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+    spec:
+      serviceAccountName: oauth-apiserver-sa
+      priorityClassName: system-node-critical
+      containers:
+      - name: oauth-apiserver
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: ""
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-ec"]
+        args:
+          - |
+            if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
+              echo "Copying system trust bundle"
+              cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+            fi
+            exec oauth-apiserver external-oidc \
+              --secure-port=8443 \
+              --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
+              --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
+              --config=/var/run/configmaps/auth-config/auth-config.json \
+              --cors-allowed-origins='//127\.0\.0\.1(:|$)' \
+              --cors-allowed-origins='//localhost(:|$)' \
+              --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
+              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 \
+              --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 \
+              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 \
+              --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 \
+              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 \
+              --tls-min-version=VersionTLS12 \
+              --v=2
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 150m
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        ports:
+        - containerPort: 8443
+        volumeMounts:
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
+          name: trusted-ca-bundle
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+        - mountPath: /var/run/configmaps/auth-config
+          name: auth-config
+      terminationGracePeriodSeconds: 120 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
+          optional: true
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+      - name: auth-config
+        configMap:
+          name: auth-config
+          items:
+          - key: auth-config.json
+            path: auth-config.json
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        # Ensure pod can be scheduled on master nodes
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+          # Ensure pod can be evicted if the node is unreachable
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+          # Ensure scheduling is delayed until node readiness
+          # (i.e. network operator configures CNI on the node)
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+      # Anti-affinity is configured in code due to the need to scope
+      # selection to the computed pod template.

--- a/pkg/operator/workload/testdata/sync_ds_scenario_6.yaml
+++ b/pkg/operator/workload/testdata/sync_ds_scenario_6.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-oauth-apiserver
+  name: apiserver
+  labels:
+    app: openshift-oauth-apiserver
+    apiserver: "true"
+    revision: "1"
+  annotations:
+    openshiftapiservers.operator.openshift.io/operator-pull-spec: ""
+    operator.openshift.io/spec-hash: "f971259e7c772ec2d9710f5e627559833b44c514e04be299e8d140ccf48af58c"
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver
+      apiserver: "true"
+  replicas: 1
+  template:
+    metadata:
+      name: openshift-oauth-apiserver
+      labels:
+        app: openshift-oauth-apiserver
+        apiserver: "true"
+        revision: "1"
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+    spec:
+      serviceAccountName: oauth-apiserver-sa
+      priorityClassName: system-node-critical
+      containers:
+      - name: oauth-apiserver
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: ""
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-ec"]
+        args:
+          - |
+            if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
+              echo "Copying system trust bundle"
+              cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+            fi
+            exec oauth-apiserver external-oidc \
+              --secure-port=8443 \
+              --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
+              --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \
+              --config=/var/run/configmaps/auth-config/auth-config.json \
+              --cors-allowed-origins='//127\.0\.0\.1(:|$)' \
+              --cors-allowed-origins='//localhost(:|$)' \
+              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 \
+              --tls-min-version=VersionTLS13 \
+              --v=2
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 150m
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        ports:
+        - containerPort: 8443
+        volumeMounts:
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
+          name: trusted-ca-bundle
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+        - mountPath: /var/run/configmaps/auth-config
+          name: auth-config
+      terminationGracePeriodSeconds: 120 # a bit more than the 60 seconds timeout of non-long-running requests + the shutdown delay
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
+          optional: true
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+      - name: auth-config
+        configMap:
+          name: auth-config
+          items:
+          - key: auth-config.json
+            path: auth-config.json
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        # Ensure pod can be scheduled on master nodes
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+          # Ensure pod can be evicted if the node is unreachable
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+          # Ensure scheduling is delayed until node readiness
+          # (i.e. network operator configures CNI on the node)
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+      # Anti-affinity is configured in code due to the need to scope
+      # selection to the computed pod template.

--- a/test/e2e-oidc/external_oidc_test.go
+++ b/test/e2e-oidc/external_oidc_test.go
@@ -65,6 +65,8 @@ func TestExternalOIDCWithKeycloak(t *testing.T) {
 
 	checkFeatureGatesOrSkip(t, testCtx, testClient.configClient, features.FeatureGateExternalOIDC, features.FeatureGateExternalOIDCWithAdditionalClaimMappings)
 
+	newExternalOIDCArchitectureEnabled := featureGateEnabled(testCtx, testClient.configClient, features.FeatureGateExternalOIDCExternalClaimsSourcing)
+
 	// post-test cluster cleanup
 	var cleanups []func()
 	defer test.IDPCleanupWrapper(func() {
@@ -83,10 +85,15 @@ func TestExternalOIDCWithKeycloak(t *testing.T) {
 		err := testClient.authResourceRollback(testCtx, origAuthSpec)
 		require.NoError(t, err, "failed to rollback auth resource during cleanup")
 
-		err = test.WaitForNewKASRollout(t, testCtx, testClient.operatorConfigClient.OperatorV1().KubeAPIServers(), kasOriginalRevision)
-		require.NoError(t, err, "failed to wait for KAS rollout during cleanup")
+		// KAS should not need to perform a rollout when the new architecture is enabled.
+		// The oauth-apiserver will, but that should be fairly quick and handled by cluster operator
+		// stability checks prior to running tests.
+		if !newExternalOIDCArchitectureEnabled {
+			err = test.WaitForNewKASRollout(t, testCtx, testClient.operatorConfigClient.OperatorV1().KubeAPIServers(), kasOriginalRevision)
+			require.NoError(t, err, "failed to wait for KAS rollout during cleanup")
+		}
 
-		testClient.validateOAuthState(t, testCtx, false)
+		testClient.validateOAuthState(t, testCtx, false, newExternalOIDCArchitectureEnabled)
 	})
 
 	// keycloak setup
@@ -227,7 +234,7 @@ func TestExternalOIDCWithKeycloak(t *testing.T) {
 
 				require.NoError(t, test.WaitForClusterOperatorDegraded(t, testClient.configClient.ConfigV1(), "authentication"))
 
-				testClient.validateOAuthState(t, testCtx, false)
+				testClient.validateOAuthState(t, testCtx, false, newExternalOIDCArchitectureEnabled)
 			})
 		}
 	})
@@ -266,11 +273,13 @@ func TestExternalOIDCWithKeycloak(t *testing.T) {
 				require.NoError(t, err, "failed to update authentication/cluster")
 
 				require.NoError(t, test.WaitForClusterOperatorStatusAlwaysAvailable(t, testCtx, testClient.configClient.ConfigV1(), "authentication"))
-				require.NoError(t, test.WaitForClusterOperatorStatusAlwaysAvailable(t, testCtx, testClient.configClient.ConfigV1(), "kube-apiserver"))
 
-				testClient.requireKASRolloutSuccessful(t, testCtx, &auth.Spec, kasOriginalRevision, tt.expectedPrefix)
+				if !newExternalOIDCArchitectureEnabled {
+					require.NoError(t, test.WaitForClusterOperatorStatusAlwaysAvailable(t, testCtx, testClient.configClient.ConfigV1(), "kube-apiserver"))
+					testClient.requireKASRolloutSuccessful(t, testCtx, &auth.Spec, kasOriginalRevision, tt.expectedPrefix)
+				}
 
-				testClient.validateOAuthState(t, testCtx, true)
+				testClient.validateOAuthState(t, testCtx, true, newExternalOIDCArchitectureEnabled)
 
 				testClient.testOIDCAuthentication(t, testCtx, kcClient, tt.claim, tt.expectedPrefix, true)
 			})
@@ -318,11 +327,13 @@ func TestExternalOIDCWithKeycloak(t *testing.T) {
 		require.NoError(t, err, "failed to update authentication/cluster")
 
 		require.NoError(t, test.WaitForClusterOperatorStatusAlwaysAvailable(t, testCtx, testClient.configClient.ConfigV1(), "authentication"))
-		require.NoError(t, test.WaitForClusterOperatorStatusAlwaysAvailable(t, testCtx, testClient.configClient.ConfigV1(), "kube-apiserver"))
 
-		testClient.requireKASRolloutSuccessful(t, testCtx, &auth.Spec, kasOriginalRevision, "")
+		if !newExternalOIDCArchitectureEnabled {
+			require.NoError(t, test.WaitForClusterOperatorStatusAlwaysAvailable(t, testCtx, testClient.configClient.ConfigV1(), "kube-apiserver"))
+			testClient.requireKASRolloutSuccessful(t, testCtx, &auth.Spec, kasOriginalRevision, "")
+		}
 
-		testClient.validateOAuthState(t, testCtx, true)
+		testClient.validateOAuthState(t, testCtx, true, newExternalOIDCArchitectureEnabled)
 
 		testClient.testOIDCAuthentication(t, testCtx, kcClient, "", "", false)
 	})
@@ -718,17 +729,17 @@ func (tc *testClient) validateAuthConfigJSON(t *testing.T, ctx context.Context, 
 	}
 }
 
-func (tc *testClient) validateOAuthState(t *testing.T, ctx context.Context, requireMissing bool) {
+func (tc *testClient) validateOAuthState(t *testing.T, ctx context.Context, requireMissing, newExternalOIDCArchitectureEnabled bool) {
 	dynamicClient, err := dynamic.NewForConfig(tc.kubeConfig)
 	require.NoError(t, err, "unexpected error while creating dynamic client")
 
 	var validationErrs []error
 	waitErr := wait.PollUntilContextTimeout(ctx, 30*time.Second, 5*time.Minute, false, func(_ context.Context) (bool, error) {
 		validationErrs = make([]error, 0)
-		validationErrs = append(validationErrs, validateOAuthResources(ctx, dynamicClient, requireMissing)...)
+		validationErrs = append(validationErrs, validateOAuthResources(ctx, dynamicClient, requireMissing, newExternalOIDCArchitectureEnabled)...)
 		validationErrs = append(validationErrs, validateOAuthRoutes(ctx, tc.routeClient, tc.configClient, requireMissing)...)
-		validationErrs = append(validationErrs, validateOAuthControllerConditions(tc.operatorClient, requireMissing)...)
-		validationErrs = append(validationErrs, validateOperandVersions(ctx, tc.configClient, requireMissing)...)
+		validationErrs = append(validationErrs, validateOAuthControllerConditions(tc.operatorClient, requireMissing, newExternalOIDCArchitectureEnabled)...)
+		validationErrs = append(validationErrs, validateOperandVersions(ctx, tc.configClient, requireMissing, newExternalOIDCArchitectureEnabled)...)
 		validationErrs = append(validationErrs, validateOAuthRelatedObjects(ctx, tc.configClient, requireMissing)...)
 		return len(validationErrs) == 0, nil
 	})
@@ -737,13 +748,16 @@ func (tc *testClient) validateOAuthState(t *testing.T, ctx context.Context, requ
 	require.NoError(t, waitErr, "failed to wait for OAuth state validation")
 }
 
-func validateOAuthResources(ctx context.Context, dynamicClient *dynamic.DynamicClient, requireMissing bool) []error {
+func validateOAuthResources(ctx context.Context, dynamicClient *dynamic.DynamicClient, requireMissing, newExternalOIDCArchitectureEnabled bool) []error {
 	errs := make([]error, 0)
-	for _, obj := range []struct {
+
+	type resourceReference struct {
 		gvr       schema.GroupVersionResource
 		namespace string
 		name      string
-	}{
+	}
+
+	resourceReferences := []resourceReference{
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, "openshift-authentication", "v4-0-config-system-cliconfig"},
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, "openshift-authentication", "v4-0-config-system-metadata"},
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, "openshift-authentication", "v4-0-config-system-service-ca"},
@@ -751,23 +765,32 @@ func validateOAuthResources(ctx context.Context, dynamicClient *dynamic.DynamicC
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, "openshift-config-managed", "oauth-serving-cert"},
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, "openshift-authentication", "v4-0-config-system-ocp-branding-template"},
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, "openshift-authentication", "v4-0-config-system-session"},
-		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, "openshift-config", "webhook-authentication-integrated-oauth"},
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, "openshift-authentication", "oauth-openshift"},
-		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, "openshift-oauth-apiserver", "oauth-apiserver-sa"},
 		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, "openshift-authentication", "oauth-openshift"},
-		{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, "openshift-oauth-apiserver", "api"},
 		{schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}, "", "v1.oauth.openshift.io"},
 		{schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}, "", "v1.user.openshift.io"},
 		{schema.GroupVersionResource{Group: "oauth.openshift.io", Version: "v1", Resource: "oauthclients"}, "", "openshift-browser-client"},
 		{schema.GroupVersionResource{Group: "oauth.openshift.io", Version: "v1", Resource: "oauthclients"}, "", "openshift-challenging-client"},
 		{schema.GroupVersionResource{Group: "oauth.openshift.io", Version: "v1", Resource: "oauthclients"}, "", "openshift-cli-client"},
-		{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, "", "system:openshift:oauth-apiserver"},
 		{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, "", "system:openshift:openshift-authentication"},
 		{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, "", "system:openshift:useroauthaccesstoken-manager"},
 		{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}, "", "system:openshift:useroauthaccesstoken-manager"},
 		{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}, "openshift-config-managed", "system:openshift:oauth-servercert-trust"},
 		{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}, "openshift-config-managed", "system:openshift:oauth-servercert-trust"},
-	} {
+	}
+
+	// when running under the new architecture, the following resources should
+	// always be present and shouldn't be included in our checks
+	if !newExternalOIDCArchitectureEnabled {
+		resourceReferences = append(resourceReferences,
+			resourceReference{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, "openshift-config", "webhook-authentication-integrated-oauth"},
+			resourceReference{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, "openshift-oauth-apiserver", "api"},
+			resourceReference{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, "openshift-oauth-apiserver", "oauth-apiserver-sa"},
+			resourceReference{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, "", "system:openshift:oauth-apiserver"},
+		)
+	}
+
+	for _, obj := range resourceReferences {
 		_, err := dynamicClient.Resource(obj.gvr).Namespace(obj.namespace).Get(ctx, obj.name, metav1.GetOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			errs = append(errs, fmt.Errorf("unexpected error while getting resource %s/%s: %v", obj.namespace, obj.name, err))
@@ -815,7 +838,7 @@ func validateOAuthRoutes(ctx context.Context, routeClient routeclient.Interface,
 	return errs
 }
 
-func validateOAuthControllerConditions(operatorClient v1helpers.OperatorClient, requireMissing bool) []error {
+func validateOAuthControllerConditions(operatorClient v1helpers.OperatorClient, requireMissing, newExternalOIDCArchitectureEnabled bool) []error {
 	errs := make([]error, 0)
 	controllerConditionTypes := sets.New[string](
 		// endpointAccessibleController
@@ -842,12 +865,15 @@ func validateOAuthControllerConditions(operatorClient v1helpers.OperatorClient, 
 		// serviceCAController
 		"OAuthServiceDegraded",
 		"SystemServiceCAConfigDegraded",
-		// webhookAuthenticatorController
-		"AuthenticatorCertKeyProgressing",
 		// wellKnownReadyController
 		"WellKnownAvailable",
 		"WellKnownReadyControllerProgressing",
 	)
+
+	if !newExternalOIDCArchitectureEnabled {
+		// webhookAuthenticatorController
+		controllerConditionTypes.Insert("AuthenticatorCertKeyProgressing")
+	}
 
 	_, operatorStatus, _, err := operatorClient.GetOperatorState()
 	if err != nil {
@@ -875,8 +901,15 @@ func validateOAuthControllerConditions(operatorClient v1helpers.OperatorClient, 
 	return nil
 }
 
-func validateOperandVersions(ctx context.Context, cfgClient *configclient.Clientset, requireMissing bool) []error {
-	operands := sets.New("oauth-apiserver", "oauth-openshift")
+func validateOperandVersions(ctx context.Context, cfgClient *configclient.Clientset, requireMissing, newExternalOIDCArchitectureEnabled bool) []error {
+	operands := sets.New("oauth-openshift")
+
+	// If the new architecture for external OIDC is not enabled,
+	// test this as we always did and ensure that the oauth-apiserver
+	// operand version gets removed appropriately.
+	if !newExternalOIDCArchitectureEnabled {
+		operands.Insert("oauth-apiserver")
+	}
 
 	authnClusterOperator, err := cfgClient.ConfigV1().ClusterOperators().Get(ctx, "authentication", metav1.GetOptions{})
 	if err != nil {
@@ -897,6 +930,22 @@ func validateOperandVersions(ctx context.Context, cfgClient *configclient.Client
 	foundSet := sets.New(foundOperands...)
 	if !requireMissing && !foundSet.Equal(operands) {
 		return []error{fmt.Errorf("authentication ClusterOperator status expected to have operands %v in versions but got %v", operands.UnsortedList(), foundOperands)}
+	}
+
+	// If the new architecture for external OIDC is enabled,
+	// ensure the oauth-apiserver operand is always present.
+	if newExternalOIDCArchitectureEnabled {
+		found := false
+		for _, version := range authnClusterOperator.Status.Versions {
+			if version.Name == "oauth-apiserver" {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return []error{fmt.Errorf("authentication ClusterOperator status expected to have operand \"oauth-apiserver\" in versions but it was missing")}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
# Description

This PR updates the cluster-authentication-operator to deploy the oauth-apiserver in the new external OIDC mode when the authentication type is set to `OIDC` _and_ the new `ExternalOIDCExternalClaimsSourcing` feature gate is enabled.

Currently, this feature gate is only enabled in DevPreviewNoUpgrade.

For more information as to the motivation of this change, see https://github.com/openshift/enhancements/pull/1907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new external OIDC authentication architecture with dedicated api-server deployment option
  * Added feature gate to enable/disable new OIDC external claims sourcing capability
  * Integrated automatic configuration synchronization for external OIDC scenarios

* **Refactor**
  * Updated OIDC availability detection to support both legacy and new architecture paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->