### PR TITLE
CNTRLPLANE-2621: Restart operator when TLS config changes

### DIFF
--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -7,9 +7,8 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    config.openshift.io/inject-tls: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig
-    servingInfo:
-      bindNetwork: "tcp"

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -36,7 +36,7 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          exec authentication-operator operator --config=/var/run/configmaps/config/operator-config.yaml --v=2 --terminate-on-files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt --terminate-on-files=/tmp/terminate
+          exec authentication-operator operator --config=/var/run/configmaps/config/operator-config.yaml --v=2 --terminate-on-files=/var/run/configmaps/config/operator-config.yaml --terminate-on-files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt --terminate-on-files=/tmp/terminate
         resources:
           requests:
             memory: 200Mi


### PR DESCRIPTION
related to https://github.com/openshift/cluster-version-operator/pull/1322 and 
https://github.com/openshift/library-go/pull/657