### PR TITLE
OCPBUGS-84951: Fix terminationMessagePolicy on network policy e2e test pods

### DIFF
--- a/test/e2e/network_policy_enforcement.go
+++ b/test/e2e/network_policy_enforcement.go
@@ -312,8 +312,9 @@ func netexecPod(name, namespace string, labels map[string]string, port int32) *c
 			},
 			Containers: []corev1.Container{
 				{
-					Name:  "netexec",
-					Image: agnhostImage,
+					Name:                     "netexec",
+					Image:                    agnhostImage,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: boolptr(false),
 						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
@@ -532,8 +533,9 @@ func createConnectivityClientPod(ctx context.Context, kubeClient kubernetes.Inte
 			},
 			Containers: []corev1.Container{
 				{
-					Name:  "connect",
-					Image: agnhostImage,
+					Name:                     "connect",
+					Image:                    agnhostImage,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: boolptr(false),
 						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},


### PR DESCRIPTION
## Summary
- Set `terminationMessagePolicy: FallbackToLogsOnError` on all containers
  created by the NetworkPolicy e2e enforcement tests (`netexec` server pods
  and `connect` client pods).
- Without this, leftover test pods in `openshift-authentication` (and other
  auth namespaces) violate the monitor invariant
  "all containers must have terminationMessagePolicy=FallbackToLogsOnError",
  which was recently promoted from flake to hard failure by
  openshift/origin#30993.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reformatted and realigned struct fields in network policy enforcement test code for improved readability.

* **Tests**
  * Updated test containers to ensure termination messages fall back to logs on errors, improving diagnostic output during test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->