### PR TITLE
OCPBUGS-69977: Fix OAuth page showing OKD branding instead of OpenShift

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -5,7 +5,7 @@ WORKDIR /go/src/github.com/openshift/cluster-authentication-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-authentication-operator
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" -tags="${TAGS}" -o authentication-operator ./cmd/authentication-operator
-RUN make build --warn-undefined-variables \
+RUN GO_BUILD_PACKAGES=./cmd/cluster-authentication-operator-tests-ext make build --warn-undefined-variables \
     && gzip cluster-authentication-operator-tests-ext
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9


### PR DESCRIPTION
Hi Team,

PTAL on the PR. 

The OAuth login page was displaying OKD branding instead of the correct Red Hat OpenShift branding due to missing build tags in the operator binary.

Root cause:
In PR #816 ([CNTRLPLANE-2196](https://redhat.atlassian.net/browse/CNTRLPLANE-2196)), the Dockerfile was updated to use 'make build' to build the OTE test binary. However, this command builds ALL binaries in cmd/ directory, including authentication-operator, and does so WITHOUT the '-tags=ocp' flag. This clobbered the correctly-built operator binary from line 7 that had the ocp tag, causing the branding to default to OKD.

The branding selection is controlled by Go build tags:
- pkg/controllers/configobservation/oauth/brand_ocp.go (build tag: ocp)
- pkg/controllers/configobservation/oauth/brand_okd.go (build tag: !ocp)

Solution:
Scope 'make build' to only build the OTE test binary by setting GO_BUILD_PACKAGES=./cmd/cluster-authentication-operator-tests-ext. This prevents rebuilding the authentication-operator binary and preserves the ocp build tag from line 7.

Verified:
- Operator binary contains 'build -tags=ocp' metadata
- OTE test binary builds correctly with proper ldflags
- All unit tests pass
- make verify passes

Fixes: https://issues.redhat.com/browse/OCPBUGS-69977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to enable more targeted package compilation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->