### PR TITLE
CNTRLPLANE-3431: enable tls config injection

### DIFF
--- a/cmd/cluster-authentication-operator-tests-ext/main.go
+++ b/cmd/cluster-authentication-operator-tests-ext/main.go
@@ -18,6 +18,7 @@ import (
 )
 
 func main() {
+	klog.LogToStderr(true)
 	cmd, err := newOperatorTestCommand()
 	if err != nil {
 		klog.Fatal(err)

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    config.openshift.io/inject-tls: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1


### PR DESCRIPTION
enable cvo cluster wide tls injection on the operator config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automatic TLS certificate injection in the platform configuration; no other platform settings were modified.
* **Tests**
  * Improved operator test diagnostics by configuring test logging to emit to stderr for clearer output during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->