### PR TITLE
CNTRLPLANE-3364: add the kms suite and migrate the kms tests of auth-o to ote

### DIFF
--- a/cmd/cluster-authentication-operator-tests-ext/main.go
+++ b/cmd/cluster-authentication-operator-tests-ext/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/cluster-authentication-operator/pkg/version"
 
 	_ "github.com/openshift/cluster-authentication-operator/test/e2e"
+	_ "github.com/openshift/cluster-authentication-operator/test/e2e-encryption-kms"
 
 	"k8s.io/klog/v2"
 )
@@ -89,6 +90,15 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 			`name.contains("[Disruptive]")`,
 		},
 		ClusterStability: oteextension.ClusterStabilityDisruptive,
+	})
+
+	// The following suite runs KMS encryption tests.
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-authentication-operator/encryption-kms",
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("KMSEncryption")`,
+		},
 	})
 
 	specs, err := oteginkgo.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()

--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -1,0 +1,96 @@
+package e2e_encryption_kms
+
+import (
+	"context"
+	"math/rand/v2"
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
+)
+
+var _ = g.Describe("[sig-auth] cluster-authentication-operator", func() {
+	g.It("TestKMSEncryptionOnOff [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m]", func() {
+		testKMSEncryptionOnOff(g.GinkgoTB())
+	})
+
+	g.It("TestKMSEncryptionProvidersMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m]", func() {
+		testKMSEncryptionProvidersMigration(g.GinkgoTB())
+	})
+})
+
+// testKMSEncryptionOnOff tests KMS encryption on/off cycle.
+// This test:
+// 2. Creates a test OAuth access token (TokenOfLife)
+// 3. Enables KMS encryption
+// 4. Verifies token is encrypted
+// 5. Disables encryption (Identity)
+// 6. Verifies token is NOT encrypted
+// 7. Re-enables KMS encryption
+// 8. Verifies token is encrypted again
+// 9. Disables encryption (Identity) again
+// 10. Verifies token is NOT encrypted again
+func testKMSEncryptionOnOff(t testing.TB) {
+	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
+	library.TestEncryptionTurnOnAndOff(t, library.OnOffScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       "openshift-config-managed",
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
+			EncryptionConfigSecretName:      "encryption-config-openshift-oauth-apiserver",
+			EncryptionConfigSecretNamespace: "openshift-config-managed",
+			OperatorNamespace:               "openshift-authentication-operator",
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertTokens,
+		},
+		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
+			return operatorencryption.CreateAndStoreTokenOfLife(context.TODO(), t, operatorencryption.GetClients(t))
+		},
+		AssertResourceEncryptedFunc:    operatorencryption.AssertTokenOfLifeEncrypted,
+		AssertResourceNotEncryptedFunc: operatorencryption.AssertTokenOfLifeNotEncrypted,
+		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.TokenOfLife(t) },
+		ResourceName:                   "TokenOfLife",
+		EncryptionProvider: configv1.APIServerEncryption{
+			Type: configv1.EncryptionTypeKMS,
+			KMS:  librarykms.DefaultFakeKMSPluginConfig,
+		},
+	})
+}
+
+// testKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
+// This test:
+// 1. Deploys the mock KMS plugin
+// 2. Creates a test OAuth access token (TokenOfLife)
+// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
+// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
+// 5. Migrates between the providers in the shuffled order
+// 6. Verifies token is correctly encrypted after each migration
+func testKMSEncryptionProvidersMigration(t testing.TB) {
+	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
+	library.TestEncryptionProvidersMigration(t, library.ProvidersMigrationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       "openshift-config-managed",
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
+			EncryptionConfigSecretName:      "encryption-config-openshift-oauth-apiserver",
+			EncryptionConfigSecretNamespace: "openshift-config-managed",
+			OperatorNamespace:               "openshift-authentication-operator",
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertTokens,
+		},
+		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
+			return operatorencryption.CreateAndStoreTokenOfLife(context.TODO(), t, operatorencryption.GetClients(t))
+		},
+		AssertResourceEncryptedFunc:    operatorencryption.AssertTokenOfLifeEncrypted,
+		AssertResourceNotEncryptedFunc: operatorencryption.AssertTokenOfLifeNotEncrypted,
+		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.TokenOfLife(t) },
+		ResourceName:                   "TokenOfLife",
+		EncryptionProviders: library.ShuffleEncryptionProviders([]configv1.APIServerEncryption{
+			{Type: configv1.EncryptionTypeKMS, KMS: librarykms.DefaultFakeKMSPluginConfig},
+			library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
+		}),
+	})
+}

--- a/test/e2e-encryption-kms/encryption_kms_test.go
+++ b/test/e2e-encryption-kms/encryption_kms_test.go
@@ -1,88 +1,23 @@
 package e2e_encryption_kms
 
 import (
-	"context"
-	"math/rand/v2"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/runtime"
-
-	configv1 "github.com/openshift/api/config/v1"
-	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
-	library "github.com/openshift/library-go/test/library/encryption"
-	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
 )
 
-// TestKMSEncryptionOnOff tests KMS encryption on/off cycle.
-// This test:
-// 2. Creates a test OAuth access token (TokenOfLife)
-// 3. Enables KMS encryption
-// 4. Verifies token is encrypted
-// 5. Disables encryption (Identity)
-// 6. Verifies token is NOT encrypted
-// 7. Re-enables KMS encryption
-// 8. Verifies token is encrypted again
-// 9. Disables encryption (Identity) again
-// 10. Verifies token is NOT encrypted again
+// This test calls the shared test function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-encryption-kms-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestKMSEncryptionOnOff(t *testing.T) {
-	// Deploy the mock KMS plugin for testing.
-	// NOTE: This manual deployment is only required for KMS v1. In the future,
-	// the platform will manage the KMS plugins, and this code will no longer be needed.
-	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-	library.TestEncryptionTurnOnAndOff(t, library.OnOffScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       "openshift-config-managed",
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
-			EncryptionConfigSecretName:      "encryption-config-openshift-oauth-apiserver",
-			EncryptionConfigSecretNamespace: "openshift-config-managed",
-			OperatorNamespace:               "openshift-authentication-operator",
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertTokens,
-		},
-		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
-			return operatorencryption.CreateAndStoreTokenOfLife(context.TODO(), t, operatorencryption.GetClients(t))
-		},
-		AssertResourceEncryptedFunc:    operatorencryption.AssertTokenOfLifeEncrypted,
-		AssertResourceNotEncryptedFunc: operatorencryption.AssertTokenOfLifeNotEncrypted,
-		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.TokenOfLife(t) },
-		ResourceName:                   "TokenOfLife",
-		EncryptionProvider: configv1.APIServerEncryption{
-			Type: configv1.EncryptionTypeKMS,
-			KMS:  librarykms.DefaultFakeKMSPluginConfig,
-		},
-	})
+	testKMSEncryptionOnOff(t)
 }
 
-// TestKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
-// This test:
-// 1. Deploys the mock KMS plugin
-// 2. Creates a test OAuth access token (TokenOfLife)
-// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
-// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
-// 5. Migrates between the providers in the shuffled order
-// 6. Verifies token is correctly encrypted after each migration
+// This test calls the shared test function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-encryption-kms-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestKMSEncryptionProvidersMigration(t *testing.T) {
-	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-	library.TestEncryptionProvidersMigration(t, library.ProvidersMigrationScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       "openshift-config-managed",
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
-			EncryptionConfigSecretName:      "encryption-config-openshift-oauth-apiserver",
-			EncryptionConfigSecretNamespace: "openshift-config-managed",
-			OperatorNamespace:               "openshift-authentication-operator",
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertTokens,
-		},
-		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
-			return operatorencryption.CreateAndStoreTokenOfLife(context.TODO(), t, operatorencryption.GetClients(t))
-		},
-		AssertResourceEncryptedFunc:    operatorencryption.AssertTokenOfLifeEncrypted,
-		AssertResourceNotEncryptedFunc: operatorencryption.AssertTokenOfLifeNotEncrypted,
-		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.TokenOfLife(t) },
-		ResourceName:                   "TokenOfLife",
-		EncryptionProviders: library.ShuffleEncryptionProviders([]configv1.APIServerEncryption{
-			{Type: configv1.EncryptionTypeKMS, KMS: librarykms.DefaultFakeKMSPluginConfig},
-			library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
-		}),
-	})
+	testKMSEncryptionProvidersMigration(t)
 }


### PR DESCRIPTION
add the kms suite and migrate the kms encryption tests to ote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for KMS encryption functionality
  * Implemented test coverage for KMS encryption activation/deactivation scenarios
  * Added validation tests for encryption provider migration workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->