### PR TITLE
CNTRLPLANE-3431: restart operator upon config change

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -36,7 +36,7 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          exec authentication-operator operator --config=/var/run/configmaps/config/operator-config.yaml --v=2 --terminate-on-files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt --terminate-on-files=/tmp/terminate
+          exec authentication-operator operator --config=/var/run/configmaps/config/operator-config.yaml --v=2 --terminate-on-files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt --terminate-on-files=/tmp/terminate --terminate-on-files=/var/run/configmaps/config/operator-config.yaml
         resources:
           requests:
             memory: 200Mi


### PR DESCRIPTION
if the operator config changes we need to restart the operator. e.g. if the tls config has been updated we need to make sure the servers we keep online are respecting the new config.

this commit makes the operator config part of the --terminate-on-files flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The authentication operator now detects and responds to operator configuration file changes, enabling automatic updates without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->