### PR TITLE
kms: wire up config overrides for KMS values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,3 +133,5 @@ require (
 )
 
 replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+
+replace github.com/openshift/library-go => github.com/kevinrizza/library-go v0.0.0-20260610202501-42a0e5fc0061

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kevinrizza/library-go v0.0.0-20260610202501-42a0e5fc0061 h1:bZWgY3gNpmlagPKZKHZLtL9BRUneokLA2sxSYRRLUFE=
+github.com/kevinrizza/library-go v0.0.0-20260610202501-42a0e5fc0061/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -152,8 +154,6 @@ github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af h1:Ui
 github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260608110537-04693132679d h1:+n/LOE9kXr8TDLV5ynhx4j3ZuOjeqMc2rKwDKB74W3g=
-github.com/openshift/library-go v0.0.0-20260608110537-04693132679d/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d h1:Rzx23P63JFNNz5D23ubhC0FCN5rK8CeJhKcq5QKcdyU=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d/go.mod h1:iVi9Bopa5cLhjG5ie9DoZVVqkH8BGb1FQVTtecOLn4I=
 github.com/openshift/oauth-apiserver v0.0.0-20260430140618-160ac7fb4ea6 h1:WvXToDt/IVTXb4NxbqEjY0cuPpVadTK6ATu75mlVM/s=

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -322,7 +322,8 @@ func (c *OAuthAPIServerWorkload) syncStandardDeployment(ctx context.Context, ope
 		c.targetNamespace,
 		fmt.Sprintf("encryption-config-%d", operatorStatus.LatestAvailableRevision),
 		c.kubeClient.CoreV1(),
-		c.featureGateAccessor); err != nil {
+		c.featureGateAccessor,
+		operatorSpec.UnsupportedConfigOverrides.Raw); err != nil {
 		return nil, fmt.Errorf("failed to add KMS plugin to pod spec: %w", err)
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -40,10 +40,10 @@ type sidecarProvider interface {
 
 // newSidecarProvider creates a provider-specific sidecarProvider for the given keyID and plugin configuration,
 // wiring in credentials via the credentialResolver.
-func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, creds *credentialResolver) (sidecarProvider, error) {
+func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, creds *credentialResolver, unsupportedConfig []byte) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, creds)
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, creds, unsupportedConfig)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}
@@ -57,11 +57,11 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, unsupportedConfig []byte) error {
 	// The static pod revision controller copies secret data to disk under resourcesDir/secrets/<secretName>/.
 	credentialsDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
 
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsDir)
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsDir, unsupportedConfig)
 	if err != nil {
 		return err
 	}
@@ -89,8 +89,8 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsMountPath)
+func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, unsupportedConfig []byte) error {
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsMountPath, unsupportedConfig)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 
 // addKMSPluginSidecars contains the shared logic for discovering KMS plugins and injecting sidecar containers.
 // It returns the names of the sidecar containers that were injected, so callers can add deployment-mode-specific volume mounts.
-func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, credentialsDir string) ([]string, error) {
+func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, credentialsDir string, unsupportedConfig []byte) ([]string, error) {
 	if podSpec == nil {
 		return nil, fmt.Errorf("pod spec cannot be nil")
 	}
@@ -183,7 +183,7 @@ func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containe
 			keyID:             keyID,
 		}
 
-		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, creds)
+		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, creds, unsupportedConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/unsupported_config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/unsupported_config.go
@@ -1,0 +1,38 @@
+package pluginlifecycle
+
+import (
+	"encoding/json"
+
+	"k8s.io/klog/v2"
+
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type unsupportedKMSConfig struct {
+	Encryption struct {
+		KMS struct {
+			Vault struct {
+				LogLevel string `json:"logLevel"`
+			} `json:"vault"`
+		} `json:"kms"`
+	} `json:"encryption"`
+}
+
+func parseUnsupportedKMSConfig(raw []byte) (unsupportedKMSConfig, error) {
+	if len(raw) == 0 {
+		return unsupportedKMSConfig{}, nil
+	}
+
+	jsonRaw, err := kyaml.ToJSON(raw)
+	if err != nil {
+		klog.Warning(err)
+		return unsupportedKMSConfig{}, err
+	}
+
+	config := unsupportedKMSConfig{}
+	if err := json.Unmarshal(jsonRaw, &config); err != nil {
+		return unsupportedKMSConfig{}, nil
+	}
+
+	return config, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -11,7 +11,7 @@ import (
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin data.
 // It assumes the input data has been already been validated.
-func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *credentialResolver) (*vault, error) {
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *credentialResolver, unsupportedConfig []byte) (*vault, error) {
 	secretName := vaultConfig.Authentication.AppRole.Secret.Name
 	if secretName == "" {
 		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")
@@ -22,7 +22,20 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		return nil, err
 	}
 
+	if roleID == "" {
+		return nil, fmt.Errorf("role ID cannot be empty")
+	}
+
 	secretIDPath, err := creds.FilePath(secretName, "secret-id")
+	if err != nil {
+		return nil, err
+	}
+
+	if secretIDPath == "" {
+		return nil, fmt.Errorf("secret ID path cannot be empty")
+	}
+
+	kmsConfig, err := parseUnsupportedKMSConfig(unsupportedConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -34,6 +47,7 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		config:       vaultConfig,
 		roleID:       roleID,
 		secretIDPath: secretIDPath,
+		logLevel:     kmsConfig.Encryption.KMS.Vault.LogLevel,
 	}, nil
 }
 
@@ -45,6 +59,7 @@ type vault struct {
 	config       configv1.VaultKMSPluginConfig
 	roleID       string
 	secretIDPath string
+	logLevel     string
 }
 
 // Name returns the sidecar name appended by the key id.
@@ -69,10 +84,19 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 	if v.config.VaultNamespace != "" {
 		args = append(args, fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace))
 	}
+	if v.logLevel != "" {
+		args = append(args, fmt.Sprintf("-log-level=%s", v.logLevel))
+	}
 
-	// TODO(bertinatto): this is a temporary workaround until the ca bundle is wired into the
-	// encryption config secret. This should be removed before shipping the KMS feature.
-	args = append(args, "-tls-skip-verify")
+	// Temporary workarounds. These should go away as we progress with the feature.
+	args = append(args,
+		// TODO: remove before GA once the CA bundle is wired into the encryption config secret.
+		"-tls-skip-verify=true",
+		// TODO: remove once we support scraping metrics from each KMS plugin sidecar independently.
+		// Set the port to zero to disable metrics serving.
+		// Slack discussion: https://redhat-external.slack.com/archives/C09KZ5QCBUH/p1780926464635219
+		"-metrics-port=0",
+	)
 
 	return corev1.Container{
 		Name:            v.Name(),

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -27,6 +27,7 @@ const (
 	defaultVaultPodName            = "vault-0"
 	defaultVaultCredentialsSecret  = "vault-credentials"
 	defaultVaultAppRoleSecretName  = "vault-approle-secret"
+	defaultVaultConfigMapName      = "vault-ca-bundle"
 	defaultFAKEVaultKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:958a2f8276037468aa47dc2137d3c30dfcd96489455eddb2fe655f8168a57622"
 	defaultVaultKMSPluginImage     = "registry.ci.openshift.org/control-plane-custom-builds/vault-kube-kms@sha256:33599dd6eee61dcf9a60138759fafda3d88593a3c2072585156882c6b5bd3fa5"
 	defaultVaultAddress            = "https://vault.vault-kms.svc:8200"
@@ -73,6 +74,12 @@ var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
 				AppRole: configv1.VaultAppRoleAuthentication{
 					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
 				},
+			},
+			TLS: configv1.VaultTLSConfig{
+				CABundle: configv1.VaultConfigMapReference{
+					Name: defaultVaultConfigMapName,
+				},
+				ServerName: fmt.Sprintf("vault.%s.svc", defaultVaultNamespace),
 			},
 		},
 	},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -383,7 +383,7 @@ github.com/openshift/client-go/user/applyconfigurations/internal
 github.com/openshift/client-go/user/applyconfigurations/user/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20260608110537-04693132679d
+# github.com/openshift/library-go v0.0.0-20260608110537-04693132679d => github.com/kevinrizza/library-go v0.0.0-20260610202501-42a0e5fc0061
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/deployment
@@ -1651,3 +1651,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+# github.com/openshift/library-go => github.com/kevinrizza/library-go v0.0.0-20260610202501-42a0e5fc0061


### PR DESCRIPTION
pass log level along to vault

WIP - this commit is using a replaces directive for my library-go fork. needs to be updated to vendor real change in library-go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to redirect a core library to an alternative source repository for builds, ensuring the project uses the specified upstream variant.
  * Extended KMS plugin sidecar setup to accept additional runtime configuration (unsupported overrides), allowing more granular sidecar behavior and improved runtime flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->