### PR TITLE
CNTRLPLANE-3363: Register health monitor as command

### DIFF
--- a/cmd/authentication-operator/main.go
+++ b/cmd/authentication-operator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/openshift/cluster-authentication-operator/pkg/cmd/mom"
@@ -8,7 +9,11 @@ import (
 	"github.com/openshift/cluster-authentication-operator/pkg/cmd/render"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest"
 	"k8s.io/component-base/cli"
+
+	kmshealth "github.com/openshift/library-go/pkg/operator/encryption/kms/health"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 func main() {
@@ -36,6 +41,11 @@ func NewAuthenticationOperatorCommand() *cobra.Command {
 	cmd.AddCommand(mom.NewInputResourcesCommand(ioStreams))
 	cmd.AddCommand(mom.NewOutputResourcesCommand(ioStreams))
 	cmd.AddCommand(render.NewRender())
+	cmd.AddCommand(kmshealth.NewCommand(context.Background(), func(config *rest.Config) (v1helpers.OperatorClient, error) {
+		// TODO: replace with a real operator client once the health reporter's condition writer
+		// is implemented in library-go.
+		return nil, nil
+	}))
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
 	github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f
+	github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b
 	github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d
 	github.com/openshift/oauth-apiserver v0.0.0-20260430140618-160ac7fb4ea6
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af h1:Ui
 github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f h1:1wVATH1wpPdtryIhjtngrHKi4d0ucrN2o0IIZAoHPTw=
-github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
+github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b h1:fmTTzoHLhRf4QsMKw4cEbnvUeUcgcaNesh5mueWnaVs=
+github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d h1:Rzx23P63JFNNz5D23ubhC0FCN5rK8CeJhKcq5QKcdyU=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d/go.mod h1:iVi9Bopa5cLhjG5ie9DoZVVqkH8BGb1FQVTtecOLn4I=
 github.com/openshift/oauth-apiserver v0.0.0-20260430140618-160ac7fb4ea6 h1:WvXToDt/IVTXb4NxbqEjY0cuPpVadTK6ATu75mlVM/s=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/health/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/health/cmd.go
@@ -1,0 +1,205 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server"
+	k8senvelopekmsv2 "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+const providerName = "kms-health-reporter"
+
+// kmsSocketPattern matches the socket path each co-located KMSv2 plugin is
+// mounted at, e.g. unix:///var/run/kmsplugin/kms-1.sock.
+var kmsSocketPattern = regexp.MustCompile(`^unix:///var/run/kmsplugin/kms-(\d+)\.sock$`)
+
+// options' flag-bound fields are exported so the struct can be logged as a
+// whole via klog.InfoS, which JSON-marshals its values.
+type options struct {
+	KMSSockets   []string
+	Interval     time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	NodeName     string
+	Kubeconfig   string
+
+	newOperatorClient func(*rest.Config) (v1helpers.OperatorClient, error)
+}
+
+type Config struct {
+	operatorClient v1helpers.OperatorClient
+	prober         *prober
+
+	interval     time.Duration
+	writeTimeout time.Duration
+	nodeName     string
+}
+
+func NewCommand(ctx context.Context, newOperatorClient func(*rest.Config) (v1helpers.OperatorClient, error)) *cobra.Command {
+	o := &options{
+		newOperatorClient: newOperatorClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "kms-health-reporter",
+		Short: "Observes co-located KMSv2 plugins and publishes status as an OperatorCondition.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.validate(); err != nil {
+				return err
+			}
+
+			// Arm signal handling before Config builds anything needing graceful teardown.
+			// Idiomatically the caller's main would own this; kept here because
+			// library-go ships the command, not the main.
+			ctx := setupSignalContext(ctx)
+			klog.InfoS("kms-health-reporter starting", "config", o)
+
+			cfg, err := o.Config(ctx)
+			if err != nil {
+				return err
+			}
+			return cfg.Run(ctx)
+		},
+	}
+	o.addFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringSliceVar(&o.KMSSockets, "kms-sockets", nil, "KMS plugin endpoints in unix:// URI format (e.g. unix:///var/run/kmsplugin/kms-1.sock)")
+	fs.DurationVar(&o.Interval, "interval", 30*time.Second, "cadence between probe+emit cycles")
+	fs.DurationVar(&o.ReadTimeout, "read-timeout", 5*time.Second, "deadline for each Status RPC")
+	fs.DurationVar(&o.WriteTimeout, "write-timeout", 10*time.Second, "deadline for each condition update")
+	fs.StringVar(&o.NodeName, "node-name", "", "node name recorded in the condition used to help to identify the origin")
+	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "path to a kubeconfig; empty uses in-cluster config")
+}
+
+func (o *options) validate() error {
+	if len(o.KMSSockets) == 0 {
+		return fmt.Errorf("--kms-sockets is required, at least one")
+	}
+	socketSet := sets.New[string]()
+	for _, s := range o.KMSSockets {
+		if !kmsSocketPattern.MatchString(s) {
+			return fmt.Errorf("--kms-sockets entry %q must match %s", s, kmsSocketPattern)
+		}
+		if socketSet.Has(s) {
+			return fmt.Errorf("--kms-sockets entry %q is duplicated", s)
+		}
+		socketSet.Insert(s)
+	}
+
+	if o.Interval <= 0 {
+		return fmt.Errorf("--interval must be positive")
+	}
+	if o.ReadTimeout <= 0 {
+		return fmt.Errorf("--read-timeout must be positive")
+	}
+	if o.WriteTimeout <= 0 {
+		return fmt.Errorf("--write-timeout must be positive")
+	}
+	if o.NodeName == "" {
+		return fmt.Errorf("--node-name is required")
+	}
+
+	return nil
+}
+
+func (o *options) Config(ctx context.Context) (*Config, error) {
+	// Empty kubeconfig falls back to the in-cluster config (service account
+	// token + KUBERNETES_SERVICE_HOST), which is the deployed path.
+	restCfg, err := clientcmd.BuildConfigFromFlags("", o.Kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("build rest config: %w", err)
+	}
+
+	operatorClient, err := o.newOperatorClient(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build operator client: %w", err)
+	}
+
+	plugins, err := buildPlugins(ctx, o.KMSSockets, o.ReadTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{
+		operatorClient: operatorClient,
+		prober:         newProber(plugins),
+		interval:       o.Interval,
+		writeTimeout:   o.WriteTimeout,
+		nodeName:       o.NodeName,
+	}, nil
+}
+
+func (c *Config) Run(ctx context.Context) error {
+	wait.JitterUntilWithContext(ctx, func(ctx context.Context) {
+		// Each Status RPC enforces the read timeout internally (set at dial
+		// time); ctx here only carries shutdown cancellation.
+		conditions := c.prober.probeAll(ctx)
+		// TODO: hand conditions to the writer once it lands; logging is a placeholder.
+		klog.InfoS("kms plugin health", "conditions", conditions)
+	}, c.interval, 0.1, false)
+
+	return nil
+}
+
+func buildPlugins(ctx context.Context, sockets []string, timeout time.Duration) ([]pluginClient, error) {
+	plugins := make([]pluginClient, 0, len(sockets))
+
+	for _, socket := range sockets {
+		keyID, err := keyIDFromSocket(socket)
+		if err != nil {
+			return nil, err
+		}
+
+		// Unique name per plugin so the gRPC client's KMS operation metrics
+		// don't merge both plugins into one series.
+		service, err := k8senvelopekmsv2.NewGRPCService(ctx, socket, providerName+"-"+keyID, timeout)
+		if err != nil {
+			// With the current dependency version this should never happen with a validated GRPC endpoint.
+			return nil, fmt.Errorf("setting up grpc service failed at %q: %w", socket, err)
+		}
+
+		plugins = append(plugins, pluginClient{keyID: keyID, service: service})
+	}
+
+	return plugins, nil
+}
+
+// keyIDFromSocket extracts the sequential key id captured by kmsSocketPattern,
+// e.g. "1" from unix:///var/run/kmsplugin/kms-1.sock.
+func keyIDFromSocket(socket string) (string, error) {
+	m := kmsSocketPattern.FindStringSubmatch(socket)
+	if m == nil {
+		return "", fmt.Errorf("socket %q must match %s", socket, kmsSocketPattern)
+	}
+	return m[1], nil
+}
+
+// setupSignalContext registers for SIGTERM and SIGINT and returns a context
+// that will be cancelled once a signal is received. Compare startupmonitor's
+// setupSignalContext.
+func setupSignalContext(baseCtx context.Context) context.Context {
+	shutdownCtx, cancel := context.WithCancel(baseCtx)
+	shutdownHandler := server.SetupSignalHandler()
+	go func() {
+		defer cancel()
+		<-shutdownHandler
+		klog.Infof("Received SIGTERM or SIGINT signal, shutting down the process.")
+	}()
+	return shutdownCtx
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/health/prober.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/health/prober.go
@@ -1,0 +1,93 @@
+package health
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	kmsservice "k8s.io/kms/pkg/service"
+)
+
+// healthzOK is the value the KMS plugin returns when healthy.
+// See https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kms/apis/v2/api.proto#L39
+const healthzOK = "ok"
+
+const (
+	statusHealthy   = "healthy"
+	statusUnhealthy = "unhealthy"
+	statusError     = "error"
+)
+
+type pluginHealthReport struct {
+	// KeyID is the controller's sequential key id; KEKID is the KMS provider's
+	// encryption key id. Distinct identifiers, easy to confuse.
+	KeyID       string
+	KEKID       string
+	Status      string
+	LastChecked time.Time
+	Detail      string
+}
+
+// pluginClient is the dialed handle to one co-located KMS plugin; the plugin
+// itself is a separate process behind the unix socket.
+type pluginClient struct {
+	keyID   string
+	service kmsservice.Service
+}
+
+type prober struct {
+	plugins []pluginClient
+	now     func() time.Time
+}
+
+func newProber(plugins []pluginClient) *prober {
+	return &prober{
+		plugins: plugins,
+		now:     time.Now,
+	}
+}
+
+// probeAll never returns an error: a failed probe is encoded as a report
+// with Status "error" so the caller always gets one entry per plugin.
+// Probes run concurrently so one hung plugin doesn't delay the others;
+// worst-case duration is one read-timeout, not the sum.
+func (p *prober) probeAll(ctx context.Context) []pluginHealthReport {
+	reports := make([]pluginHealthReport, len(p.plugins))
+
+	var wg sync.WaitGroup
+	for i, plugin := range p.plugins {
+		wg.Go(func() {
+			reports[i] = p.probe(ctx, plugin)
+		})
+	}
+	wg.Wait()
+
+	return reports
+}
+
+func (p *prober) probe(ctx context.Context, plugin pluginClient) pluginHealthReport {
+	report := pluginHealthReport{
+		KeyID:       plugin.keyID,
+		LastChecked: p.now(),
+	}
+
+	resp, err := plugin.service.Status(ctx)
+	switch {
+	case err != nil:
+		report.Status = statusError
+		report.Detail = err.Error()
+	case resp == nil:
+		// The in-tree gRPC client never returns (nil, nil), but a misbehaving
+		// plugin must not panic the reporter.
+		report.Status = statusError
+		report.Detail = "kms plugin returned nil status response"
+	case resp.Healthz == healthzOK:
+		report.Status = statusHealthy
+		report.KEKID = resp.KeyID
+	default:
+		report.Status = statusUnhealthy
+		report.Detail = resp.Healthz
+	}
+
+	return report
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -383,7 +383,7 @@ github.com/openshift/client-go/user/applyconfigurations/internal
 github.com/openshift/client-go/user/applyconfigurations/user/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f
+# github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/deployment
@@ -428,6 +428,7 @@ github.com/openshift/library-go/pkg/operator/encryption/crypto
 github.com/openshift/library-go/pkg/operator/encryption/deployer
 github.com/openshift/library-go/pkg/operator/encryption/encoding
 github.com/openshift/library-go/pkg/operator/encryption/encryptiondata
+github.com/openshift/library-go/pkg/operator/encryption/kms/health
 github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle
 github.com/openshift/library-go/pkg/operator/encryption/observer
 github.com/openshift/library-go/pkg/operator/encryption/secrets


### PR DESCRIPTION
This PR registers health monitor binary as a new command in this repository, so that plugin lifecycle can inject it as a new sidecar container alongside with oauth-apiserver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KMS health command support to the authentication-operator CLI for enhanced health monitoring capabilities.

* **Chores**
  * Updated library-go dependency to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->