### PR TITLE
WIP: poc: deploying upstream component

### DIFF
--- a/bindata/oauth-apiserver/externaloidc-deploy.yaml
+++ b/bindata/oauth-apiserver/externaloidc-deploy.yaml
@@ -38,7 +38,7 @@ spec:
       - name: oauth-apiserver
         terminationMessagePolicy: FallbackToLogsOnError
         image: ${IMAGE}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         command: ["/bin/bash", "-ec"]
         args:
           - |
@@ -46,7 +46,7 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             fi
-            exec oauth-apiserver external-oidc \
+            exec padlok run \
               --secure-port=8443 \
               --tls-private-key-file=/var/run/secrets/serving-cert/tls.key \
               --tls-cert-file=/var/run/secrets/serving-cert/tls.crt \

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -240,9 +241,17 @@ func (c *OAuthAPIServerWorkload) syncStandardDeployment(ctx context.Context, ope
 	// log level verbosity is taken from the spec always
 	args["v"] = []string{loglevelToKlog(operatorSpec.LogLevel)}
 
+	imageToUse := c.targetImagePullSpec
+	if upstreamImage := os.Getenv("UPSTREAM_OIDC_COMPONENT_IMAGE"); upstreamImage != "" {
+		imageToUse = upstreamImage
+
+		// configure the API endpoint on the upstream component
+		args["authenticate-path"] = []string{"/apis/oauth.openshift.io/v1/tokenreviews"}
+	}
+
 	// use string replacer for simple things
 	r := strings.NewReplacer(
-		"${IMAGE}", c.targetImagePullSpec,
+		"${IMAGE}", imageToUse,
 		"${REVISION}", strconv.Itoa(int(operatorStatus.LatestAvailableRevision)),
 	)
 

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -241,17 +241,9 @@ func (c *OAuthAPIServerWorkload) syncStandardDeployment(ctx context.Context, ope
 	// log level verbosity is taken from the spec always
 	args["v"] = []string{loglevelToKlog(operatorSpec.LogLevel)}
 
-	imageToUse := c.targetImagePullSpec
-	if upstreamImage := os.Getenv("UPSTREAM_OIDC_COMPONENT_IMAGE"); upstreamImage != "" {
-		imageToUse = upstreamImage
-
-		// configure the API endpoint on the upstream component
-		args["authenticate-path"] = []string{"/apis/oauth.openshift.io/v1/tokenreviews"}
-	}
-
 	// use string replacer for simple things
 	r := strings.NewReplacer(
-		"${IMAGE}", imageToUse,
+		"${IMAGE}", c.targetImagePullSpec,
 		"${REVISION}", strconv.Itoa(int(operatorStatus.LatestAvailableRevision)),
 	)
 
@@ -358,9 +350,20 @@ func (c *OAuthAPIServerWorkload) syncExternalOIDCDeployment(ctx context.Context,
 	// log level verbosity is taken from the spec always
 	args["v"] = []string{loglevelToKlog(operatorSpec.LogLevel)}
 
+	imageToUse := c.targetImagePullSpec
+	klog.Info("UPSTREAM_OIDC_COMPONENT_IMAGE", os.Getenv("UPSTREAM_OIDC_COMPONENT_IMAGE"))
+	if upstreamImage := os.Getenv("UPSTREAM_OIDC_COMPONENT_IMAGE"); len(upstreamImage) > 0 {
+		imageToUse = upstreamImage
+
+		klog.Info("using UPSTREAM_OIDC_COMPONENT_IMAGE", os.Getenv("UPSTREAM_OIDC_COMPONENT_IMAGE"))
+
+		// configure the API endpoint on the upstream component
+		args["authenticate-path"] = []string{"/apis/oauth.openshift.io/v1/tokenreviews"}
+	}
+
 	// use string replacer for simple things
 	r := strings.NewReplacer(
-		"${IMAGE}", c.targetImagePullSpec,
+		"${IMAGE}", imageToUse,
 		"${REVISION}", strconv.Itoa(int(operatorStatus.LatestAvailableRevision)),
 	)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth API Server external OIDC deployment can now use an alternate component image when a specific environment variable is set, including automatic injection of the appropriate authentication-path argument.
* **Deployment Updates**
  * OAuth API Server now always pulls its image on startup.
  * Container startup has been adjusted to run via the configured launcher while preserving existing CA bundle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->