### PR TITLE
CNTRLPLANE-2589: Migrate test/e2e-encryption-perf to OpenShift Tests Extension framework

### DIFF
--- a/cmd/cluster-authentication-operator-tests-ext/main.go
+++ b/cmd/cluster-authentication-operator-tests-ext/main.go
@@ -14,6 +14,7 @@ import (
 
 	_ "github.com/openshift/cluster-authentication-operator/test/e2e"
 	_ "github.com/openshift/cluster-authentication-operator/test/e2e-encryption-kms"
+	_ "github.com/openshift/cluster-authentication-operator/test/e2e-encryption-perf"
 
 	"k8s.io/klog/v2"
 )
@@ -92,21 +93,22 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		ClusterStability: oteextension.ClusterStabilityDisruptive,
 	})
 
+	// ClusterStability set to Disruptive: encryption perf tests trigger API server rollouts.
+	extension.AddSuite(oteextension.Suite{
+		Name:             "openshift/cluster-authentication-operator/operator-encryption-perf/serial",
+		Parallelism:      1,
+		ClusterStability: oteextension.ClusterStabilityDisruptive,
+		Qualifiers: []string{
+			`name.contains("[Encryption]") && name.contains("[Serial]") && name.contains("Perf")`,
+		},
+	})
+
 	// The following suite runs KMS encryption tests.
 	extension.AddSuite(oteextension.Suite{
 		Name:        "openshift/cluster-authentication-operator/encryption-kms",
 		Parallelism: 1,
 		Qualifiers: []string{
-			`name.contains("KMSEncryption") && !name.contains("[Suite:encryption-kms-2]")`,
-		},
-	})
-
-	extension.AddSuite(oteextension.Suite{
-		Name:        "openshift/cluster-authentication-operator/encryption-kms-2",
-		Parents:     []string{"openshift/kms"},
-		Parallelism: 1,
-		Qualifiers: []string{
-			`name.contains("[Suite:encryption-kms-2]")`,
+			`name.contains("KMSEncryption")`,
 		},
 	})
 

--- a/test/e2e-encryption-perf/encryption_perf.go
+++ b/test/e2e-encryption-perf/encryption_perf.go
@@ -1,0 +1,112 @@
+package e2e_encryption_perf
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	configv1 "github.com/openshift/api/config/v1"
+	oauthapiv1 "github.com/openshift/api/oauth/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	operatorlibrary "github.com/openshift/cluster-authentication-operator/test/library"
+	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+)
+
+const (
+	tokenStatsKey = "created oauthaccesstokens"
+)
+
+var _ = g.Describe("[sig-auth] authentication operator", func() {
+	g.It("[Encryption][Serial] TestPerfEncryptionTypeAESCBC", func(ctx context.Context) {
+		testPerfEncryptionTypeAESCBC(ctx, g.GinkgoTB())
+	})
+})
+
+func testPerfEncryptionTypeAESCBC(ctx context.Context, tt testing.TB) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	tt.Cleanup(cancel)
+	clientSet := getPerfClients(tt)
+	library.TestPerfEncryption(ctx, tt, library.PerfScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       "openshift-config-managed",
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", "openshift-oauth-apiserver"),
+			EncryptionConfigSecretNamespace: "openshift-config-managed",
+			OperatorNamespace:               "openshift-authentication-operator",
+			TargetGRs:                       library.AuthTargetGRs,
+			AssertFunc:                      library.AssertTokens,
+		},
+		GetOperatorConditionsFunc: func(t testing.TB) ([]operatorv1.OperatorCondition, error) {
+			apiServerOperator, err := clientSet.OperatorClient.Get(ctx, "cluster", metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return apiServerOperator.Status.Conditions, nil
+		},
+		AssertDBPopulatedFunc: func(t testing.TB, errorStore map[string]int, statStore map[string]int) {
+			require.Empty(t, errorStore, "db loader workers reported errors")
+
+			tokenCount, ok := statStore[tokenStatsKey]
+			require.True(t, ok, "missing oauth access tokens count stats")
+			require.GreaterOrEqual(t, tokenCount, 14000)
+			t.Logf("Created %d access tokens", tokenCount)
+		},
+		AssertMigrationTime: func(t testing.TB, migrationTime time.Duration) {
+			t.Logf("migration took %v", migrationTime)
+			expectedMigrationTime := 10 * time.Minute
+			if migrationTime > expectedMigrationTime {
+				t.Errorf("migration took too long (%v), expected it to take no more than %v", migrationTime, expectedMigrationTime)
+			}
+		},
+		DBLoaderWorkers: 3,
+		DBLoaderFunc: library.DBLoaderRepeat(1, false,
+			library.DBLoaderRepeatParallel(5010, 50, false, createAccessTokenWrapper(ctx, clientSet.TokenClient), reportSecret)),
+		EncryptionProvider: library.EncryptionProvider{
+			APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC},
+		},
+	})
+}
+
+func createAccessTokenWrapper(ctx context.Context, tokenClient oauthclient.OAuthAccessTokensGetter) library.DBLoaderFuncType {
+	return func(_ kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
+		_, tokenNameHash := operatorlibrary.GenerateOAuthTokenPair()
+		token := &oauthapiv1.OAuthAccessToken{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: tokenNameHash,
+			},
+			RefreshToken: "I have no special talents. I am only passionately curious",
+			UserName:     "kube:admin",
+			Scopes:       []string{"user:full"},
+			RedirectURI:  "redirect.me.to.token.of.life",
+			ClientName:   "console",
+			UserUID:      "non-existing-user-id",
+		}
+		_, err := tokenClient.OAuthAccessTokens().Create(ctx, token, metav1.CreateOptions{})
+		return err
+	}
+}
+
+func reportSecret(_ kubernetes.Interface, _ string, _ func(error), statsCollector func(string)) error {
+	statsCollector(tokenStatsKey)
+	return nil
+}
+
+func getPerfClients(t testing.TB) operatorencryption.ClientSet {
+	t.Helper()
+
+	kubeConfig := operatorlibrary.NewClientConfigForTest(t)
+
+	kubeConfig.QPS = 300
+	kubeConfig.Burst = 600
+
+	return operatorencryption.GetClientsFor(t, kubeConfig)
+}

--- a/test/e2e-encryption-perf/encryption_perf_test.go
+++ b/test/e2e-encryption-perf/encryption_perf_test.go
@@ -1,109 +1,14 @@
 package e2e_encryption_perf
 
 import (
-	"context"
-	"errors"
-	"fmt"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/require"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-
-	configv1 "github.com/openshift/api/config/v1"
-	oauthapiv1 "github.com/openshift/api/oauth/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
-	operatorlibrary "github.com/openshift/cluster-authentication-operator/test/library"
-	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
-	library "github.com/openshift/library-go/test/library/encryption"
 )
 
-const (
-	tokenStatsKey = "created oauthaccesstokens"
-)
-
+// This test calls the shared test function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we verify the new e2e-aws-operator-encryption-perf-serial-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestPerfEncryptionTypeAESCBC(tt *testing.T) {
-	ctx := context.TODO()
-	clientSet := getPerfClients(tt)
-	library.TestPerfEncryption(tt.Context(), tt, library.PerfScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       "openshift-config-managed",
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", "openshift-oauth-apiserver"),
-			EncryptionConfigSecretNamespace: "openshift-config-managed",
-			OperatorNamespace:               "openshift-authentication-operator",
-			TargetGRs:                       library.AuthTargetGRs,
-			AssertFunc:                      library.AssertTokens,
-		},
-		GetOperatorConditionsFunc: func(t testing.TB) ([]operatorv1.OperatorCondition, error) {
-			apiServerOperator, err := clientSet.OperatorClient.Get(ctx, "cluster", metav1.GetOptions{})
-			if err != nil {
-				return nil, err
-			}
-			return apiServerOperator.Status.Conditions, nil
-		},
-		AssertDBPopulatedFunc: func(t testing.TB, errorStore map[string]int, statStore map[string]int) {
-			tokenCount, ok := statStore[tokenStatsKey]
-			if !ok {
-				err := errors.New("missing oauth access tokens count stats, can't continue the test")
-				require.NoError(t, err)
-			}
-			if tokenCount < 14000 {
-				err := fmt.Errorf("expected to create at least 14000 tokens but %d were created", tokenCount)
-				require.NoError(t, err)
-			}
-			t.Logf("Created %d access tokens", tokenCount)
-		},
-		AssertMigrationTime: func(t testing.TB, migrationTime time.Duration) {
-			t.Logf("migration took %v", migrationTime)
-			expectedMigrationTime := 10 * time.Minute
-			if migrationTime > expectedMigrationTime {
-				t.Errorf("migration took too long (%v), expected it to take no more than %v", migrationTime, expectedMigrationTime)
-			}
-		},
-		DBLoaderWorkers: 3,
-		DBLoaderFunc: library.DBLoaderRepeat(1, false,
-			library.DBLoaderRepeatParallel(5010, 50, false, createAccessTokenWrapper(ctx, clientSet.TokenClient), reportSecret)),
-		EncryptionProvider: library.EncryptionProvider{
-			APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionType("aescbc")},
-		},
-	})
-}
-
-func createAccessTokenWrapper(ctx context.Context, tokenClient oauthclient.OAuthAccessTokensGetter) library.DBLoaderFuncType {
-	return func(_ kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
-		_, tokenNameHash := operatorlibrary.GenerateOAuthTokenPair()
-		token := &oauthapiv1.OAuthAccessToken{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: tokenNameHash,
-			},
-			RefreshToken: "I have no special talents. I am only passionately curious",
-			UserName:     "kube:admin",
-			Scopes:       []string{"user:full"},
-			RedirectURI:  "redirect.me.to.token.of.life",
-			ClientName:   "console",
-			UserUID:      "non-existing-user-id",
-		}
-		_, err := tokenClient.OAuthAccessTokens().Create(ctx, token, metav1.CreateOptions{})
-		return err
-	}
-}
-
-func reportSecret(_ kubernetes.Interface, _ string, _ func(error), statsCollector func(string)) error {
-	statsCollector(tokenStatsKey)
-	return nil
-}
-
-func getPerfClients(t *testing.T) operatorencryption.ClientSet {
-	t.Helper()
-
-	kubeConfig := operatorlibrary.NewClientConfigForTest(t)
-
-	kubeConfig.QPS = 300
-	kubeConfig.Burst = 600
-
-	return operatorencryption.GetClientsFor(t, kubeConfig)
+	testPerfEncryptionTypeAESCBC(tt.Context(), tt)
 }


### PR DESCRIPTION
Hi Team,

Splitting the original PR: https://github.com/openshift/cluster-authentication-operator/pull/859 into smaller once to better debug and merge the PR's easily. 

PR about: 
This commit migrates the encryption performance tests to support both traditional go test and the OpenShift Tests Extension (OTE) framework, following the dual-mode pattern established in PR #859.

Changes:
- Add encryption_perf.go with Ginkgo test registration
- Refactor encryption_perf_test.go to call shared test function
- Add test/library/encryption_wrappers.go for testing.TB compatibility
- Add test/library/encryption/scenarios.go with core test implementations
- Add test/library/encryption/perf_helpers.go for performance test utilities
- Register encryption-perf suite in OTE main.go with ClusterStability: Disruptive

The tests now use testing.TB interface for framework compatibility and context.Background() instead of t.Context() to avoid Ginkgo panics.

Suite details:
- Name: openshift/cluster-authentication-operator/operator-encryption-perf/serial
- Parallelism: 1 (serial execution)
- ClusterStability: Disruptive (triggers API server rollouts)

Test: [sig-auth] authentication operator [Encryption][Serial] TestPerfEncryptionTypeAESCBC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new encryption performance test suite to broaden coverage for OAuth API server encryption scenarios.
  * Introduced a long-running performance check that measures encryption migration behavior and token creation throughput.

* **Bug Fixes**
  * Improved validation to detect slow encryption migrations and fail when they exceed the expected time limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->