### PR TITLE
NO-JIRA: Store authentication-operator image as OPERATOR_IMAGE

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -66,6 +66,8 @@ spec:
           value: quay.io/openshift/origin-oauth-server:v4.2
         - name: IMAGE_OAUTH_APISERVER
           value: quay.io/openshift/origin-oauth-apiserver:v4.6
+        - name: OPERATOR_IMAGE
+          value: quay.io/openshift/origin-cluster-authentication-operator:v4.0
         - name: OPERATOR_IMAGE_VERSION
           value: "0.0.1-snapshot"
         - name: OPERAND_OAUTH_SERVER_IMAGE_VERSION


### PR DESCRIPTION
[Operators](https://github.com/openshift/cluster-openshift-apiserver-operator/blob/a58b396aa57f3efdc520ea4e2a1bfa82ae40f7ec/manifests/07_deployment.yaml#L63-L64) typically store their images in `OPERATOR_IMAGE` environment variable. So that these images can be used to run a command implemented and distributed in operator image. 

Cluster-authentication-operator passes this [environment variable](https://github.com/openshift/cluster-authentication-operator/blob/28632f237aa003bb191100eabdc46c3e20c1fb49/pkg/operator/starter.go#L509) to its controllers. 

However, due to the missing `OPERATOR_IMAGE` env var definition in [deployment manifest](https://github.com/openshift/cluster-authentication-operator/blob/28632f237aa003bb191100eabdc46c3e20c1fb49/manifests/07_deployment.yaml#L64-L76), the fields that are supposed to store `OPERATOR_IMAGE` are empty. See `openshiftapiservers.operator.openshift.io/operator-pull-spec` field of authentication-operator Deployment in https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-ovn-serial-1of2/2068659878863310848/artifacts/e2e-aws-ovn-serial/gather-extra/artifacts/deployments.json

This PR adds this environment variable in Deployment manifest, so that CVO will replace it with the correct one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the authentication operator configuration to explicitly set the operator image reference to `quay.io/openshift/origin-cluster-authentication-operator:v4.0`.
  * This makes the operator image selection more direct alongside the existing image version settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->