### PR TITLE
OCPBUGS-87480: Updating ose-cluster-authentication-operator-container image to be consistent with ART for 5.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 # This pattern is documented in https://github.com/openshift/enhancements/pull/1672. Use ARG to build images based on platform.
 ARG TAGS=ocp
 WORKDIR /go/src/github.com/openshift/cluster-authentication-operator
@@ -8,7 +8,7 @@ RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe 
 RUN GO_BUILD_PACKAGES=./cmd/cluster-authentication-operator-tests-ext make build --warn-undefined-variables \
     && gzip cluster-authentication-operator-tests-ext
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/authentication-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/cluster-authentication-operator-tests-ext.gz /usr/bin/
 COPY manifests /manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-authentication-operator
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
Replaces #910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and CI configurations to use newer OpenShift/RHEL 9 release images.
  * Upgraded the Go toolchain version to 1.26.
  * Refreshed the container runtime base image to match the newer platform release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->