### PR TITLE
NO-JIRA: Add test for KMS to KMS migration

### DIFF
--- a/cmd/cluster-authentication-operator-tests-ext/main.go
+++ b/cmd/cluster-authentication-operator-tests-ext/main.go
@@ -97,7 +97,16 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		Name:        "openshift/cluster-authentication-operator/encryption-kms",
 		Parallelism: 1,
 		Qualifiers: []string{
-			`name.contains("KMSEncryption")`,
+			`name.contains("KMSEncryption") && !name.contains("[Suite:encryption-kms-2]")`,
+		},
+	})
+
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-authentication-operator/encryption-kms-2",
+		Parents:     []string{"openshift/kms"},
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("[Suite:encryption-kms-2]")`,
 		},
 	})
 

--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -21,6 +21,7 @@ var _ = g.Describe("[sig-auth] cluster-authentication-operator", func() {
 	g.It("TestKMSEncryptionProvidersMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m]", func(ctx context.Context) {
 		testKMSEncryptionProvidersMigration(ctx, g.GinkgoTB())
 	})
+
 })
 
 // testKMSEncryptionOnOff tests KMS encryption on/off cycle.
@@ -58,12 +59,11 @@ func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 
 // testKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
 // This test:
-// 1. Deploys the real Vault KMS plugin
-// 2. Creates a test OAuth access token (TokenOfLife)
-// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
-// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
-// 5. Migrates between the providers in the shuffled order
-// 6. Verifies token is correctly encrypted after each migration
+// 1. Creates a test OAuth access token (TokenOfLife)
+// 2. Randomly picks one AES encryption provider (AESGCM or AESCBC)
+// 3. Shuffles the selected AES provider with KMS to create a randomized migration order
+// 4. Migrates between the providers in the shuffled order
+// 5. Verifies token is correctly encrypted after each migration
 func testKMSEncryptionProvidersMigration(ctx context.Context, t testing.TB) {
 	library.TestEncryptionProvidersMigration(ctx, t, library.ProvidersMigrationScenario{
 		BasicScenario: library.BasicScenario{

--- a/test/e2e-encryption-kms/encryption_kms_2.go
+++ b/test/e2e-encryption-kms/encryption_kms_2.go
@@ -1,0 +1,51 @@
+package e2e_encryption_kms
+
+import (
+	"context"
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	operatorencryption "github.com/openshift/cluster-authentication-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
+)
+
+var _ = g.Describe("[sig-auth] cluster-authentication-operator", func() {
+	g.It("TestKMSEncryptionKMSToKMSMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m][Suite:encryption-kms-2]", func(ctx context.Context) {
+		testKMSEncryptionKMSToKMSMigration(ctx, g.GinkgoTB())
+	})
+})
+
+// testKMSEncryptionKMSToKMSMigration tests migration between two distinct KMS providers
+// (default Vault instance and secondary Vault instance).
+// This test:
+// 1. Shuffles the KMS and AES providers to create a randomized migration order
+// 2. Migrates between the providers in the shuffled order
+// 3. Verifies token is correctly encrypted after each migration
+// 4. Switches to identity (off) to verify the resource is re-written unencrypted
+func testKMSEncryptionKMSToKMSMigration(ctx context.Context, t testing.TB) {
+	library.TestEncryptionProvidersMigration(ctx, t, library.ProvidersMigrationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       "openshift-config-managed",
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
+			EncryptionConfigSecretName:      "encryption-config-openshift-oauth-apiserver",
+			EncryptionConfigSecretNamespace: "openshift-config-managed",
+			OperatorNamespace:               "openshift-authentication-operator",
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertTokens,
+		},
+		CreateResourceFunc: func(t testing.TB, _ library.ClientSet, namespace string) runtime.Object {
+			return operatorencryption.CreateAndStoreTokenOfLife(context.TODO(), t, operatorencryption.GetClients(t))
+		},
+		AssertResourceEncryptedFunc:    operatorencryption.AssertTokenOfLifeEncrypted,
+		AssertResourceNotEncryptedFunc: operatorencryption.AssertTokenOfLifeNotEncrypted,
+		ResourceFunc:                   func(t testing.TB, _ string) runtime.Object { return operatorencryption.TokenOfLife(t) },
+		ResourceName:                   "TokenOfLife",
+		EncryptionProviders: library.ShuffleEncryptionProviders([]library.EncryptionProvider{
+			librarykms.DefaultVaultEncryptionProvider(ctx, t),
+			librarykms.SecondaryVaultEncryptionProvider(ctx, t),
+		}),
+	})
+}


### PR DESCRIPTION
This PR adds new test for kms to kms migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new end-to-end encryption migration test covering movement between two KMS providers and a final switch to unencrypted mode.
  * Expanded test coverage for KMS encryption scenarios with a separate suite for the new migration flow.

* **Tests**
  * Updated test selection so the existing KMS suite and the new KMS migration suite run independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->