### PR TITLE
CNTRLPLANE-3237: encryptionstatusprovider: use AuthenticationInterface instead of Clientset

### DIFF
--- a/pkg/operator/encryptionstatusprovider/provider.go
+++ b/pkg/operator/encryptionstatusprovider/provider.go
@@ -10,6 +10,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorv1typed "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 )
@@ -18,21 +19,21 @@ import (
 // for Authentication/cluster from a rest.Config. It reads and writes the encryption
 // status at .status.oauthAPIServer.encryptionStatus.
 func NewAuthenticationEncryptionStatusProviderFromConfig(restConfig *rest.Config) (kms.EncryptionStatusProvider, error) {
-	client, err := operatorclient.NewForConfig(restConfig)
+	opClient, err := operatorclient.NewForConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("build operator client: %w", err)
 	}
-	return &authenticationEncryptionStatusProvider{client: client}, nil
+	return &authenticationEncryptionStatusProvider{client: opClient.OperatorV1().Authentications()}, nil
 }
 
 var _ kms.EncryptionStatusProvider = &authenticationEncryptionStatusProvider{}
 
 type authenticationEncryptionStatusProvider struct {
-	client *operatorclient.Clientset
+	client operatorv1typed.AuthenticationInterface
 }
 
 func (p *authenticationEncryptionStatusProvider) GetKMSEncryptionStatus(ctx context.Context) (*operatorv1.KMSEncryptionStatus, error) {
-	obj, err := p.client.OperatorV1().Authentications().Get(ctx, "cluster", metav1.GetOptions{})
+	obj, err := p.client.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func (p *authenticationEncryptionStatusProvider) GetKMSEncryptionStatus(ctx cont
 }
 
 func (p *authenticationEncryptionStatusProvider) ApplyKMSEncryptionStatus(ctx context.Context, fieldManager string, status *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error {
-	_, err := p.client.OperatorV1().Authentications().ApplyStatus(
+	_, err := p.client.ApplyStatus(
 		ctx,
 		applyoperatorv1.Authentication("cluster").WithStatus(
 			applyoperatorv1.AuthenticationStatus().WithOAuthAPIServer(


### PR DESCRIPTION
xref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/2235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cluster authentication encryption status retrieval and updates.
  * Encryption status changes are now applied more consistently through the operator API.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->