### PR TITLE
CNTRLPLANE-3237: encryptionstatusprovider: implement UpdateKMSEncryptionStatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20260715165912-72066cc9718b
 	github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af
 	github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec
-	github.com/openshift/library-go v0.0.0-20260720072157-74b319aba2d7
+	github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb
 	github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d
 	github.com/openshift/oauth-apiserver v0.0.0-20260520145010-97a820bd5412
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af h1:Ui
 github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec h1:UDjX+mot5IVLpcChyBqLXG1oSB29s4UkqFmgNb0Xsqc=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec/go.mod h1:iMHec0APKVjOH8GfL/RxddX8DuiuSvPlRe+s7KDqlyA=
-github.com/openshift/library-go v0.0.0-20260720072157-74b319aba2d7 h1:hbF+eG9SJW5UodGDK0hJVEPGdKL5KkC1BuiFdSBIV7g=
-github.com/openshift/library-go v0.0.0-20260720072157-74b319aba2d7/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
+github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb h1:YcPGRGfuAMMZb1qJxLBBNWbr51c9UVog0CdBCOM6dNs=
+github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d h1:Rzx23P63JFNNz5D23ubhC0FCN5rK8CeJhKcq5QKcdyU=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d/go.mod h1:iVi9Bopa5cLhjG5ie9DoZVVqkH8BGb1FQVTtecOLn4I=
 github.com/openshift/oauth-apiserver v0.0.0-20260520145010-97a820bd5412 h1:oDB0GmUXLp8y85fWz+LGRE0hM5JqbXTfNPi5GjEqiX0=

--- a/pkg/operator/encryptionstatusprovider/provider.go
+++ b/pkg/operator/encryptionstatusprovider/provider.go
@@ -52,3 +52,13 @@ func (p *authenticationEncryptionStatusProvider) ApplyKMSEncryptionStatus(ctx co
 	)
 	return err
 }
+
+func (p *authenticationEncryptionStatusProvider) UpdateKMSEncryptionStatus(ctx context.Context, mutateFn func(*operatorv1.KMSEncryptionStatus)) error {
+	obj, err := p.client.Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	mutateFn(&obj.Status.OAuthAPIServer.EncryptionStatus)
+	_, err = p.client.UpdateStatus(ctx, obj, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/operator/workload/sync_openshift_oauth_apiserver.go
+++ b/pkg/operator/workload/sync_openshift_oauth_apiserver.go
@@ -315,7 +315,7 @@ func (c *OAuthAPIServerWorkload) syncStandardDeployment(ctx context.Context, ope
 	}
 	required.Spec.Replicas = masterNodeCount
 
-	if err := kmspluginlifecycle.AddKMSPluginSidecarToPodSpec(
+	if err := kmspluginlifecycle.EnsureKMSPluginSidecarInPodSpec(
 		ctx,
 		&required.Spec.Template.Spec,
 		"oauth-apiserver",

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/encryption_status_provider.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/encryption_status_provider.go
@@ -15,4 +15,13 @@ type EncryptionStatusProvider interface {
 	// ApplyKMSEncryptionStatus uses Server-Side Apply. Each caller owns only
 	// the fields it explicitly sets, identified by fieldManager.
 	ApplyKMSEncryptionStatus(ctx context.Context, fieldManager string, status *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error
+
+	// UpdateKMSEncryptionStatus reads the current status, applies the mutation,
+	// and writes it back. A conflict (409) is returned as-is.
+	//
+	// Note: use this instead of ApplyKMSEncryptionStatus when the controller is
+	// the sole owner of a field. Apply requires re-sending every owned field on
+	// every sync, omitting one causes the server to remove it, which is
+	// cumbersome for a controller that only writes a field once.
+	UpdateKMSEncryptionStatus(ctx context.Context, mutate func(*operatorv1.KMSEncryptionStatus)) error
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -107,6 +107,10 @@ func (b *KMSPluginBuilder) Apply(ctx context.Context, podSpec *corev1.PodSpec, c
 	if err != nil {
 		return fmt.Errorf("failed to get KMS configurations: %w", err)
 	}
+
+	// Strip all existing KMS-related resources before re-adding exactly what the current encryption config requires.
+	removeAllKMSManagedResources(podSpec, containerName)
+
 	if len(kmsConfigurations) == 0 {
 		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
 		return nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -3,10 +3,12 @@ package pluginlifecycle
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/health"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -25,6 +27,11 @@ const (
 	kmsPluginSocketMountPath  = "/var/run/kmsplugin"
 )
 
+const (
+	vaultSidecarPrefix = "vault-kms-plugin"
+	healthReporterName = "kms-health-reporter"
+)
+
 // sidecarProvider abstracts the construction of a KMS plugin sidecar container for a specific provider (e.g. Vault).
 type sidecarProvider interface {
 	// Name returns the identifier used to name the sidecar container and locate its volume mounts.
@@ -38,13 +45,15 @@ type sidecarProvider interface {
 func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, refData *referenceDataResolver) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, refData)
+		return newVaultSidecarProvider(vaultSidecarPrefix, keyID, udsPath, pluginConfig.Vault, refData)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}
 }
 
-// AddKMSPluginSidecarToStaticPodSpec injects KMS plugin sidecar containers into a kube-apiserver static pod spec.
+// EnsureKMSPluginSidecarInStaticPodSpec reconciles KMS plugin sidecar containers in a kube-apiserver static pod spec.
+// It removes all KMS-managed resources (sidecars, volumes, volume mounts) and then re-adds exactly what the
+// current encryption config requires, ensuring stale resources from a previous configuration are pruned.
 //
 // Static pods access KMS plugin data through the resource-dir volume, which the static pod revision controller
 // populates on disk from the encryption-config Secret. Because those files are owned by root, each sidecar
@@ -52,7 +61,7 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, diskSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func EnsureKMSPluginSidecarInStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, diskSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -72,11 +81,13 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 		Apply(ctx, podSpec, containerName)
 }
 
-// AddKMSPluginSidecarToPodSpec injects KMS plugin sidecar containers into an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
+// EnsureKMSPluginSidecarInPodSpec reconciles KMS plugin sidecar containers in an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
+// It removes all KMS-managed resources (sidecars, volumes, volume mounts) and then re-adds exactly what the
+// current encryption config requires, ensuring stale resources from a previous configuration are pruned.
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func EnsureKMSPluginSidecarInPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -170,6 +181,57 @@ func ensureReferenceDataVolume(podSpec *corev1.PodSpec, secretName string) error
 		},
 	}
 	return ensureVolume(podSpec, volume)
+}
+
+func isKMSManagedContainer(name string) bool {
+	// Check if this is the KMS health reporter sidecar
+	if name == health.Subcommand {
+		return true
+	}
+	// Check if this is a Vault KMS plugin sidecar
+	if strings.HasPrefix(name, vaultSidecarPrefix+"-") {
+		return true
+	}
+	return false
+}
+
+func isKMSManagedVolume(name string) bool {
+	return name == kmsPluginSocketVolumeName || name == referenceDataVolumeName
+}
+
+// removeAllKMSManagedResources removes all KMS-managed initContainers, volumes, and volume mounts from the pod spec.
+// IMPORTANT: When adding new KMS resource types (e.g., ephemeral containers, config maps), update this function
+// and the corresponding isKMSManaged* helper functions. Failure to do so breaks the pre-ready revision checks
+// that rely on this Ensure function to achieve the desired state.
+func removeAllKMSManagedResources(podSpec *corev1.PodSpec, containerName string) {
+	filtered := podSpec.InitContainers[:0]
+	for _, c := range podSpec.InitContainers {
+		if !isKMSManagedContainer(c.Name) {
+			filtered = append(filtered, c)
+		}
+	}
+	podSpec.InitContainers = filtered
+
+	filteredVolumes := podSpec.Volumes[:0]
+	for _, v := range podSpec.Volumes {
+		if !isKMSManagedVolume(v.Name) {
+			filteredVolumes = append(filteredVolumes, v)
+		}
+	}
+	podSpec.Volumes = filteredVolumes
+
+	for i, c := range podSpec.Containers {
+		if c.Name == containerName {
+			mounts := c.VolumeMounts[:0]
+			for _, m := range c.VolumeMounts {
+				if m.Name != kmsPluginSocketVolumeName {
+					mounts = append(mounts, m)
+				}
+			}
+			podSpec.Containers[i].VolumeMounts = mounts
+			break
+		}
+	}
 }
 
 // setRunAsRoot sets RunAsUser=0 on the named container.

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -12,9 +12,7 @@ spec:
   # This is a one-shot preflight check, not a long-running pod.
   # The operator creates it, waits for completion, and inspects the result.
   restartPolicy: Never
-{{- if not .StaticPod}}
   serviceAccountName: kms-preflight
-{{- end}}
   priorityClassName: system-cluster-critical
   nodeSelector:
     node-role.kubernetes.io/master: ""
@@ -28,10 +26,6 @@ spec:
       effect: "NoExecute"
 {{- if .StaticPod}}
   hostNetwork: true
-  volumes:
-    - name: resource-dir
-      hostPath:
-        path: /etc/kubernetes/manifests
 {{- end}}
   containers:
     - name: kms-preflight-check
@@ -42,9 +36,6 @@ spec:
         - --config-hash=$(CONFIG_HASH)
         - --pod-name=$(POD_NAME)
         - --pod-namespace=$(POD_NAMESPACE)
-{{- if .StaticPod}}
-        - --kubeconfig=/etc/kubernetes/static-pod-resources/secrets/kms-preflight-encryption-config/lb-int.kubeconfig
-{{- end}}
       env:
       - name: POD_NAME
         valueFrom: { fieldRef: { fieldPath: metadata.name } }
@@ -57,11 +48,3 @@ spec:
         requests:
           memory: 50Mi
           cpu: 5m
-{{- if .StaticPod}}
-      securityContext:
-        runAsUser: 0
-      volumeMounts:
-        - name: resource-dir
-          mountPath: /etc/kubernetes/static-pod-resources
-          readOnly: true
-{{- end}}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/deployer.go
@@ -45,6 +45,8 @@ type PodPreflightDeployer struct {
 	operatorImage   string
 	operatorCommand []string
 	kmsCallTimeout  time.Duration
+	// virtualStaticPod will use settings like a static pod, e.g. hostNetwork=True, but run as a normal pod
+	virtualStaticPod bool
 }
 
 func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, encryptionConfigSecret *corev1.Secret) error {
@@ -68,13 +70,14 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 		return fmt.Errorf("failed to create preflight encryption config secret: %w", err)
 	}
 
-	pod, err := generatePodTemplate(
+	pod, err := renderPreflightPodTemplate(
 		preflightPodName,
 		d.namespace,
 		configHash,
 		d.operatorImage,
 		d.operatorCommand,
 		d.kmsCallTimeout,
+		d.virtualStaticPod,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate preflight pod template: %w", err)
@@ -210,4 +213,20 @@ func NewPodPreflightDeployer(
 		operatorCommand: operatorCommand,
 		kmsCallTimeout:  kmsCallTimeout,
 	}
+}
+
+// NewStaticPodPreflightDeployer creates a deployer that virtualizes a static pod
+// (e.g. hostNetwork=true) while still running as a normal pod.
+func NewStaticPodPreflightDeployer(
+	namespace string,
+	coreClient corev1client.CoreV1Interface,
+	rbacClient rbacclientv1.RbacV1Interface,
+	eventRecorder events.Recorder,
+	operatorImage string,
+	operatorCommand []string,
+	kmsCallTimeout time.Duration,
+) *PodPreflightDeployer {
+	deployer := NewPodPreflightDeployer(namespace, coreClient, rbacClient, eventRecorder, operatorImage, operatorCommand, kmsCallTimeout)
+	deployer.virtualStaticPod = true
+	return deployer
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/pod_template.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/pod_template.go
@@ -47,32 +47,6 @@ func newKmsPreflightTemplate(
 	}
 }
 
-// generatePodTemplate renders the KMS preflight pod YAML template.
-// The pod runs the preflight checker as a one-shot command and shares an emptyDir
-// volume with the KMS plugin sidecar at /var/run/kmsplugin.
-func generatePodTemplate(
-	podName string,
-	namespace string,
-	configHash string,
-	operatorImage string,
-	operatorCommand []string,
-	kmsCallTimeout time.Duration,
-) (*corev1.Pod, error) {
-	return renderPreflightPodTemplate(podName, namespace, configHash, operatorImage, operatorCommand, kmsCallTimeout, false)
-}
-
-// generateStaticPodTemplate renders the KMS preflight static pod YAML template.
-func generateStaticPodTemplate(
-	podName string,
-	namespace string,
-	configHash string,
-	operatorImage string,
-	operatorCommand []string,
-	kmsCallTimeout time.Duration,
-) (*corev1.Pod, error) {
-	return renderPreflightPodTemplate(podName, namespace, configHash, operatorImage, operatorCommand, kmsCallTimeout, true)
-}
-
 func renderPreflightPodTemplate(
 	podName string,
 	namespace string,
@@ -86,11 +60,7 @@ func renderPreflightPodTemplate(
 	tmplVal := newKmsPreflightTemplate(
 		podName, namespace, configHash, operatorImage, operatorCommand, kmsCallTimeout, staticPod,
 	)
-	return renderPodTemplate("kms-preflight", string(rawManifest), tmplVal)
-}
-
-func renderPodTemplate(name, rawManifest string, tmplVal any) (*corev1.Pod, error) {
-	tmpl, err := template.New(name).Parse(rawManifest)
+	tmpl, err := template.New("kms-preflight").Parse(string(rawManifest))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -553,17 +553,27 @@ func inParallel(steps ...testStep) testStep {
 		name: strings.Join(names, " | "),
 		testFunc: func(t testing.TB) {
 			var wg sync.WaitGroup
+			var mu sync.Mutex
+			var panicMsgs []string
 			for _, s := range steps {
 				wg.Go(func() {
 					defer func() {
 						if r := recover(); r != nil {
-							t.Errorf("step %q panicked: %v", s.name, r)
+							// don't call t.Errorf here: in Ginkgo, t.Errorf panics,
+							// and a panic inside recover crashes the goroutine.
+							mu.Lock()
+							panicMsgs = append(panicMsgs, fmt.Sprintf("step %q panicked: %v", s.name, r))
+							mu.Unlock()
 						}
 					}()
 					s.testFunc(t)
 				})
 			}
 			wg.Wait()
+			// report all panics at once from the outer goroutine, where t.Errorf is safe.
+			if len(panicMsgs) > 0 {
+				t.Errorf("%s", strings.Join(panicMsgs, "\n"))
+			}
 		},
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -411,7 +411,7 @@ github.com/openshift/client-go/user/applyconfigurations/internal
 github.com/openshift/client-go/user/applyconfigurations/user/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20260720072157-74b319aba2d7
+# github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/deployment


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved KMS encryption status updates for the OAuth API server.
  * Ensured the KMS plugin sidecar is correctly maintained in OAuth API server pods.

* **Bug Fixes**
  * Updated the supporting OpenShift library dependency to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->