### PR TITLE
NO-JIRA: Automatic agentic rebase: Update library-go to d8f45c2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20260715165912-72066cc9718b
 	github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af
 	github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec
-	github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb
+	github.com/openshift/library-go v0.0.0-20260722141911-d8f45c2a4f64
 	github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d
 	github.com/openshift/oauth-apiserver v0.0.0-20260520145010-97a820bd5412
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af h1:Ui
 github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec h1:UDjX+mot5IVLpcChyBqLXG1oSB29s4UkqFmgNb0Xsqc=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec/go.mod h1:iMHec0APKVjOH8GfL/RxddX8DuiuSvPlRe+s7KDqlyA=
-github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb h1:YcPGRGfuAMMZb1qJxLBBNWbr51c9UVog0CdBCOM6dNs=
-github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
+github.com/openshift/library-go v0.0.0-20260722141911-d8f45c2a4f64 h1:pJm/aglcdT+TnBlxdtcEVvKfMHn+KqjiFOloYPK2tss=
+github.com/openshift/library-go v0.0.0-20260722141911-d8f45c2a4f64/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d h1:Rzx23P63JFNNz5D23ubhC0FCN5rK8CeJhKcq5QKcdyU=
 github.com/openshift/multi-operator-manager v0.0.0-20241205181422-20aa3906b99d/go.mod h1:iVi9Bopa5cLhjG5ie9DoZVVqkH8BGb1FQVTtecOLn4I=
 github.com/openshift/oauth-apiserver v0.0.0-20260520145010-97a820bd5412 h1:oDB0GmUXLp8y85fWz+LGRE0hM5JqbXTfNPi5GjEqiX0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -403,7 +403,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	}
 
 	// Scenario 3b: pod has not reported its config hash yet.
-	hashCondition := findPodCondition(podStatus.Conditions, KMSPreflightConfigHashPodCondition)
+	hashCondition := FindPodCondition(podStatus.Conditions, KMSPreflightConfigHashPodCondition)
 	if hashCondition == nil {
 		if podStatus.Phase == corev1.PodSucceeded {
 			return false, &preflightError{reason: "PodCompletedWithoutResult", message: fmt.Sprintf("preflight pod completed without reporting result for hash %s", requiredHash)}
@@ -420,7 +420,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	}
 
 	// Scenario 3d: hash matches, waiting for result.
-	resultCondition := findPodCondition(podStatus.Conditions, KMSPreflightResultPodCondition)
+	resultCondition := FindPodCondition(podStatus.Conditions, KMSPreflightResultPodCondition)
 	if resultCondition == nil {
 		if podStatus.Phase == corev1.PodSucceeded {
 			return false, &preflightError{reason: "PodCompletedWithoutResult", message: fmt.Sprintf("preflight pod completed without reporting result for hash %s", requiredHash)}
@@ -505,7 +505,7 @@ func podStartupTimestamp(podStatus corev1.PodStatus) *metav1.Time {
 	if podStatus.StartTime != nil {
 		return podStatus.StartTime
 	}
-	if c := findPodCondition(podStatus.Conditions, corev1.PodScheduled); c != nil {
+	if c := FindPodCondition(podStatus.Conditions, corev1.PodScheduled); c != nil {
 		return &c.LastTransitionTime
 	}
 	return nil
@@ -531,7 +531,7 @@ func podStuckReasonAndMessage(podStatus corev1.PodStatus) (string, string) {
 	return reason, fmt.Sprintf("pod is in %s phase", podStatus.Phase)
 }
 
-func findPodCondition(conditions []corev1.PodCondition, condType corev1.PodConditionType) *corev1.PodCondition {
+func FindPodCondition(conditions []corev1.PodCondition, condType corev1.PodConditionType) *corev1.PodCondition {
 	for i := range conditions {
 		if conditions[i].Type == condType {
 			return &conditions[i]

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/deployer.go
@@ -19,11 +19,15 @@ import (
 )
 
 const (
-	preflightPodName                    = "kms-preflight"
-	preflightCheckContainerName         = "kms-preflight-check"
-	preflightEncryptionConfigSecretName = "kms-preflight-encryption-config"
-	preflightRBACName                   = "kms-preflight"
-	preflightAppLabel                   = "openshift-kms-preflight"
+	// PodName is the fixed name of the preflight pod created by Deploy.
+	PodName = "kms-preflight"
+	// CheckContainerName is the container that runs the preflight checker command.
+	CheckContainerName = "kms-preflight-check"
+	// EncryptionConfigSecretName is the secret Deploy creates for the preflight pod.
+	EncryptionConfigSecretName = "kms-preflight-encryption-config"
+
+	preflightRBACName = "kms-preflight"
+	preflightAppLabel = "openshift-kms-preflight"
 )
 
 var (
@@ -64,14 +68,14 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 	encryptionConfigSecret = encryptionConfigSecret.DeepCopy()
 	// rewrite the entire ObjectMeta to avoid copying resource versions or managed fields
-	encryptionConfigSecret.ObjectMeta = metav1.ObjectMeta{Namespace: d.namespace, Name: preflightEncryptionConfigSecretName, Labels: labels}
+	encryptionConfigSecret.ObjectMeta = metav1.ObjectMeta{Namespace: d.namespace, Name: EncryptionConfigSecretName, Labels: labels}
 	_, err := d.coreClient.Secrets(d.namespace).Create(ctx, encryptionConfigSecret, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create preflight encryption config secret: %w", err)
 	}
 
 	pod, err := renderPreflightPodTemplate(
-		preflightPodName,
+		PodName,
 		d.namespace,
 		configHash,
 		d.operatorImage,
@@ -85,8 +89,8 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 	err = pluginlifecycle.NewKMSPluginBuilder().
 		WithSecretRequired().
-		FromEncryptionConfigSecret(d.namespace, preflightEncryptionConfigSecretName, d.coreClient).
-		Apply(ctx, &pod.Spec, preflightCheckContainerName)
+		FromEncryptionConfigSecret(d.namespace, EncryptionConfigSecretName, d.coreClient).
+		Apply(ctx, &pod.Spec, CheckContainerName)
 	if err != nil {
 		return fmt.Errorf("failed to apply preflight plugin: %w", err)
 	}
@@ -108,9 +112,9 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 func (d *PodPreflightDeployer) Status(ctx context.Context) (corev1.PodStatus, error) {
 	// preflight status checks are not very frequent, so we use the live client instead of a cached lister
-	pod, err := d.coreClient.Pods(d.namespace).Get(ctx, preflightPodName, metav1.GetOptions{})
+	pod, err := d.coreClient.Pods(d.namespace).Get(ctx, PodName, metav1.GetOptions{})
 	if err != nil {
-		return corev1.PodStatus{}, fmt.Errorf("failed to get pod for preflight %s/%s: %w", d.namespace, preflightPodName, err)
+		return corev1.PodStatus{}, fmt.Errorf("failed to get pod for preflight %s/%s: %w", d.namespace, PodName, err)
 	}
 
 	return pod.Status, nil
@@ -120,14 +124,14 @@ func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {
 	// See Deploy: preflight RBAC is intentionally not deleted here.
 	var errs []error
 
-	err := d.coreClient.Pods(d.namespace).Delete(ctx, preflightPodName, metav1.DeleteOptions{})
+	err := d.coreClient.Pods(d.namespace).Delete(ctx, PodName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		errs = append(errs, fmt.Errorf("failed to delete pod %s/%s: %w", d.namespace, preflightPodName, err))
+		errs = append(errs, fmt.Errorf("failed to delete pod %s/%s: %w", d.namespace, PodName, err))
 	}
 
-	err = d.coreClient.Secrets(d.namespace).Delete(ctx, preflightEncryptionConfigSecretName, metav1.DeleteOptions{})
+	err = d.coreClient.Secrets(d.namespace).Delete(ctx, EncryptionConfigSecretName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		errs = append(errs, fmt.Errorf("failed to delete secret %s/%s: %w", d.namespace, preflightEncryptionConfigSecretName, err))
+		errs = append(errs, fmt.Errorf("failed to delete secret %s/%s: %w", d.namespace, EncryptionConfigSecretName, err))
 	}
 
 	return errors.Join(errs...)

--- a/vendor/github.com/openshift/library-go/test/library/encryption/preflight_deploy.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/preflight_deploy.go
@@ -1,0 +1,198 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
+)
+
+const (
+	preflightDeployConfigHash = "e2e-preflight-drift"
+	// PreflightDeployCallTimeout is the KMS gRPC call timeout used by preflight e2e Deploy.
+	PreflightDeployCallTimeout  = 10 * time.Second
+	preflightKMSSocketEndpoint  = "unix:///var/run/kmsplugin/kms.sock"
+	preflightStatusPollInterval = 5 * time.Second
+	preflightStatusPollTimeout  = 5 * time.Minute
+	openshiftConfigNS           = "openshift-config"
+)
+
+// PreflightDeployScenario configures a real-cluster Deploy() check against a live
+// operand namespace. The operand namespace must already have preflight RBAC.
+//
+// BasicScenario.Namespace is the operand namespace (Deploy target).
+// BasicScenario.LabelSelector is reserved for a follow-up operand pod drift check.
+type PreflightDeployScenario struct {
+	BasicScenario
+	// CreateDeployerFunc builds the deployer (image, command, static-pod mode).
+	CreateDeployerFunc func(ctx context.Context, t testing.TB, clientSet ClientSet) *preflight.PodPreflightDeployer
+	// CreateEncryptionConfigFunc builds the encryption-config Secret Deploy mounts.
+	// Use VaultPreflightEncryptionConfigSecret for Vault.
+	CreateEncryptionConfigFunc func(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, plugin configv1.KMSPluginConfig) *corev1.Secret
+	// AssertDeployFunc validates the deployed preflight pod. Use AssertPreflightDeploy.
+	AssertDeployFunc func(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, deployer *preflight.PodPreflightDeployer)
+	// EncryptionProvider supplies KMS plugin config and optional Setup (e.g. AppRole
+	// secret). Prefer kms.DefaultVaultEncryptionProvider so references resolve.
+	EncryptionProvider EncryptionProvider
+}
+
+// TestPreflightDeployAndPodMatchesOperand deploys a preflight pod into the operand
+// namespace and runs AssertDeployFunc against it.
+func TestPreflightDeployAndPodMatchesOperand(ctx context.Context, t testing.TB, scenario PreflightDeployScenario) {
+	t.Helper()
+	require.NotEmpty(t, scenario.Namespace)
+	require.NotNil(t, scenario.CreateDeployerFunc)
+	require.NotNil(t, scenario.CreateEncryptionConfigFunc)
+	require.NotNil(t, scenario.AssertDeployFunc)
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.EncryptionProvider.Type)
+	require.NotEmpty(t, scenario.EncryptionProvider.KMS.Type)
+
+	if scenario.EncryptionProvider.Setup != nil {
+		scenario.EncryptionProvider.Setup(ctx, t)
+	}
+
+	clientSet := GetClients(t)
+	deployer := scenario.CreateDeployerFunc(ctx, t, clientSet)
+	require.NotNil(t, deployer)
+
+	secret := scenario.CreateEncryptionConfigFunc(ctx, t, clientSet, scenario.Namespace, scenario.EncryptionProvider.KMS)
+	require.NotNil(t, secret)
+
+	t.Cleanup(func() {
+		if err := deployer.Cleanup(context.Background()); err != nil {
+			t.Errorf("preflight Cleanup: %v", err)
+		}
+	})
+
+	require.NoError(t, deployer.Deploy(ctx, preflightDeployConfigHash, secret))
+	scenario.AssertDeployFunc(ctx, t, clientSet, scenario.Namespace, deployer)
+}
+
+// AssertPreflightDeploy waits for checker pod conditions and validates Deploy side effects
+// (check container, plugin init container, config-hash / result / KEK-ID conditions).
+func AssertPreflightDeploy(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, deployer *preflight.PodPreflightDeployer) {
+	t.Helper()
+	require.NotNil(t, deployer)
+	require.NotEmpty(t, namespace)
+
+	preflightPod, err := clientSet.Kube.CoreV1().Pods(namespace).Get(ctx, preflight.PodName, metav1.GetOptions{})
+	require.NoError(t, err, "preflight pod %s/%s", namespace, preflight.PodName)
+
+	require.Len(t, preflightPod.Spec.Containers, 1)
+	require.Equal(t, preflight.CheckContainerName, preflightPod.Spec.Containers[0].Name)
+	require.NotEmpty(t, preflightPod.Spec.InitContainers, "expected KMS plugin init container")
+
+	var status corev1.PodStatus
+	err = wait.PollUntilContextTimeout(ctx, preflightStatusPollInterval, preflightStatusPollTimeout, true, func(ctx context.Context) (bool, error) {
+		var statusErr error
+		status, statusErr = deployer.Status(ctx)
+		if statusErr != nil {
+			return false, statusErr
+		}
+		if status.Phase == corev1.PodFailed {
+			return false, fmt.Errorf("preflight pod failed: reason=%q message=%q", status.Reason, status.Message)
+		}
+		return controllers.FindPodCondition(status.Conditions, controllers.KMSPreflightResultPodCondition) != nil, nil
+	})
+	require.NoError(t, err, "waiting for KMSPreflightResult condition")
+
+	hashCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightConfigHashPodCondition, corev1.ConditionTrue)
+	require.Equal(t, preflightDeployConfigHash, hashCond.Message)
+
+	resultCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightResultPodCondition, corev1.ConditionTrue)
+	require.Equal(t, "Succeeded", resultCond.Reason)
+
+	kekCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightKEKIDPodCondition, corev1.ConditionTrue)
+	require.NotEmpty(t, kekCond.Message, "KEK ID")
+}
+
+func requirePodCondition(t testing.TB, conditions []corev1.PodCondition, condType corev1.PodConditionType, wantStatus corev1.ConditionStatus) *corev1.PodCondition {
+	t.Helper()
+	cond := controllers.FindPodCondition(conditions, condType)
+	require.NotNil(t, cond, "missing %s condition", condType)
+	require.Equal(t, wantStatus, cond.Status, "condition %s: %s", condType, cond.Message)
+	return cond
+}
+
+// OperatorImageFromDeployment returns the image of containerName from the named
+// Deployment. Used by preflight e2e to run the same operator binary the cluster
+// is already running, without requiring OPERATOR_IMAGE.
+func OperatorImageFromDeployment(ctx context.Context, t testing.TB, namespace, deploymentName, containerName string) string {
+	t.Helper()
+	clientSet := GetClients(t)
+	deploy, err := clientSet.Kube.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	require.NoError(t, err, "get operator deployment %s/%s", namespace, deploymentName)
+	for _, c := range deploy.Spec.Template.Spec.Containers {
+		if c.Name == containerName {
+			require.NotEmpty(t, c.Image, "operator container %q image must not be empty", containerName)
+			return c.Image
+		}
+	}
+	require.FailNow(t, fmt.Sprintf("container %q not found in deployment %s/%s", containerName, namespace, deploymentName))
+	return ""
+}
+
+// TODO(thomas): this should go away once we have an official mapping function between plugin config and transient encryption config
+func VaultPreflightEncryptionConfigSecret(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, plugin configv1.KMSPluginConfig) *corev1.Secret {
+	t.Helper()
+	require.Equal(t, configv1.VaultKMSProvider, plugin.Type, "preflight deploy e2e currently supports Vault only")
+	require.Equal(t, configv1.VaultAuthenticationTypeAppRole, plugin.Vault.Authentication.Type)
+
+	secretName := plugin.Vault.Authentication.AppRole.Secret.Name
+	require.NotEmpty(t, secretName, "Vault AppRole secret name")
+	refSecret, err := clientSet.Kube.CoreV1().Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
+	require.NoError(t, err, "referenced AppRole secret %s/%s", openshiftConfigNS, secretName)
+
+	var secretData encryptiondata.KMSPluginsReferenceData
+	for _, key := range []string{"role-id", "secret-id"} {
+		v, ok := refSecret.Data[key]
+		require.True(t, ok, "secret %s/%s missing key %q", openshiftConfigNS, secretName, key)
+		require.NoError(t, secretData.SetFromRawKey("1", secretName+"_"+key, v))
+	}
+
+	var configMapData encryptiondata.KMSPluginsReferenceData
+	if cmName := plugin.Vault.TLS.CABundle.Name; cmName != "" {
+		refCM, err := clientSet.Kube.CoreV1().ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
+		require.NoError(t, err, "referenced CA ConfigMap %s/%s", openshiftConfigNS, cmName)
+		v, ok := refCM.Data["ca-bundle.crt"]
+		require.True(t, ok, "configmap %s/%s missing key ca-bundle.crt", openshiftConfigNS, cmName)
+		require.NoError(t, configMapData.SetFromRawKey("1", cmName+"_ca-bundle.crt", []byte(v)))
+	}
+
+	config := &encryptiondata.Config{
+		Encryption: &apiserverconfigv1.EncryptionConfiguration{
+			TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
+			Resources: []apiserverconfigv1.ResourceConfiguration{{
+				Resources: []string{"secrets"},
+				Providers: []apiserverconfigv1.ProviderConfiguration{
+					{KMS: &apiserverconfigv1.KMSConfiguration{
+						APIVersion: "v2",
+						Name:       "1_secrets",
+						Endpoint:   preflightKMSSocketEndpoint,
+						Timeout:    &metav1.Duration{Duration: PreflightDeployCallTimeout},
+					}},
+					{Identity: &apiserverconfigv1.IdentityConfiguration{}},
+				},
+			}},
+		},
+		KMSPlugins: map[string]configv1.KMSPluginConfig{
+			"1": plugin,
+		},
+		KMSPluginsSecretData:    secretData,
+		KMSPluginsConfigMapData: configMapData,
+	}
+	secret, err := encryptiondata.ToSecret(namespace, preflight.EncryptionConfigSecretName, config)
+	require.NoError(t, err)
+	return secret
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -411,7 +411,7 @@ github.com/openshift/client-go/user/applyconfigurations/internal
 github.com/openshift/client-go/user/applyconfigurations/user/v1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb
+# github.com/openshift/library-go v0.0.0-20260722141911-d8f45c2a4f64
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/apps/deployment


### PR DESCRIPTION
## Summary

Automated dependency update for `github.com/openshift/library-go`.

## Details

- **library-go commit**: [`d8f45c2`](https://github.com/openshift/library-go/commit/d8f45c2a4f649fdf4320eede1a93522b1ae54064)
- **Update date**: 2026-07-23
- **Generated by**: Claude Code agentic workflow

## Changes

- Updated `go.mod` and `go.sum`
- Refreshed vendor directory

## Testing

- [ ] CI tests pass
- [ ] Manual verification recommended

---

🤖 This PR was created automatically by an AI agent using Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying library dependency to a newer version.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->