### PR TITLE
CNTRLPLANE-3762: Clear IdP validation hash when all identity providers are removed

### DIFF
--- a/pkg/controllers/proxyconfig/proxyconfig_controller.go
+++ b/pkg/controllers/proxyconfig/proxyconfig_controller.go
@@ -134,6 +134,7 @@ func (p *proxyConfigChecker) validateIdPConnectivity(ctx context.Context, record
 
 	idpURLs := extractIdPURLs(oauthConfig)
 	if len(idpURLs) == 0 {
+		p.lastIdPValidationHash = ""
 		return
 	}
 

--- a/pkg/controllers/proxyconfig/proxyconfig_controller_test.go
+++ b/pkg/controllers/proxyconfig/proxyconfig_controller_test.go
@@ -350,6 +350,41 @@ func Test_validateIdPConnectivity_hashDedup(t *testing.T) {
 		}
 	})
 
+	t.Run("removing all IdPs clears hash so re-adding triggers validation", func(t *testing.T) {
+		recorder := events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now()))
+		p := &proxyConfigChecker{
+			oauthLister: configv1listers.NewOAuthLister(indexer),
+		}
+
+		reachable := &http.Client{Transport: &workingHTTPRoundTripper{}}
+		p.validateIdPConnectivity(context.Background(), recorder, reachable, "http://proxy:3128", "", "")
+		if p.lastIdPValidationHash == "" {
+			t.Fatal("hash should be set after successful validation")
+		}
+
+		noIdPConfig := &configv1.OAuth{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec:       configv1.OAuthSpec{},
+		}
+		noIdPIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		if err := noIdPIndexer.Add(noIdPConfig); err != nil {
+			t.Fatal(err)
+		}
+		p.oauthLister = configv1listers.NewOAuthLister(noIdPIndexer)
+		p.validateIdPConnectivity(context.Background(), recorder, reachable, "http://proxy:3128", "", "")
+		if p.lastIdPValidationHash != "" {
+			t.Fatal("hash should be cleared when no IdPs are configured")
+		}
+
+		p.oauthLister = configv1listers.NewOAuthLister(indexer)
+		unreachable := &http.Client{Transport: &faultyHTTPRoundTripper{}}
+		followupRecorder := events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now()))
+		p.validateIdPConnectivity(context.Background(), followupRecorder, unreachable, "http://proxy:3128", "", "")
+		if len(followupRecorder.Events()) != 1 {
+			t.Fatalf("expected validation to run after IdPs re-added, got %d events", len(followupRecorder.Events()))
+		}
+	})
+
 	t.Run("hash not saved on failure allows retry", func(t *testing.T) {
 		recorder := events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now()))
 		p := &proxyConfigChecker{


### PR DESCRIPTION
When all IdPs were removed from the OAuth config, the stale lastIdPValidationHash was preserved. Re-adding the same IdPs with the same proxy config produced a matching hash, causing validateIdPConnectivity to skip validation entirely.

Clear the hash in the no-IdP early return so re-added IdPs are always validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Identity Provider connectivity validation to refresh correctly after all Identity Provider endpoints are removed and later re-added.
  - Prevented stale validation results from being reused after configuration changes.
  - Ensured unreachable endpoint checks run again and generate the expected notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->