### PR TITLE
CNTRLPLANE-3762: Include system cert pool in proxy resolver transport

### DIFF
--- a/pkg/controllers/common/proxy_resolver.go
+++ b/pkg/controllers/common/proxy_resolver.go
@@ -28,7 +28,11 @@ type transportConfig struct {
 
 func (c *transportConfig) appendToPool(data []byte) error {
 	if c.pool == nil {
-		c.pool = x509.NewCertPool()
+		var err error
+		c.pool, err = x509.SystemCertPool()
+		if err != nil {
+			return fmt.Errorf("error loading system cert pool: %w", err)
+		}
 	}
 	ok, err := transport.AppendPEMCerts(c.pool, data)
 	if err != nil {


### PR DESCRIPTION
When explicit CAs are provided (IdP CA, proxy trustedCA), the proxy resolver initialized an empty cert pool and only added the explicit CAs. This differs from the original transport.NewTransport which starts from x509.SystemCertPool.

In practice this is unlikely to cause issues since IdP CA configmaps typically contain the full trust chain, but it could break if an IdP CA configmap contains only an intermediate cert that chains to a root in the system trust store.

Use x509.SystemCertPool as the base for robustness, matching the behavior of pkg/transport.NewTransport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate validation by including trusted system certificates when establishing secure connections.
  * Added clearer error handling when the system trust store cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->