### PR TITLE
CNTRLPLANE-3762: Watch openshift-config ConfigMaps in OAuth route health check controller

### DIFF
--- a/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
+++ b/pkg/controllers/oauthendpoints/oauth_endpoints_controller.go
@@ -45,6 +45,7 @@ func NewOAuthRouteCheckController(
 	cmLister := kubeInformersForConfigManagedNS.Core().V1().ConfigMaps().Lister()
 	cmInformer := kubeInformersForConfigManagedNS.Core().V1().ConfigMaps().Informer()
 	configNSCMLister := kubeInformersForConfigNS.Core().V1().ConfigMaps().Lister()
+	configNSCMInformer := kubeInformersForConfigNS.Core().V1().ConfigMaps().Informer()
 
 	secretLister := kubeInformersForTargetNS.Core().V1().Secrets().Lister()
 	secretInformer := kubeInformersForTargetNS.Core().V1().Secrets().Informer()
@@ -77,6 +78,7 @@ func NewOAuthRouteCheckController(
 
 	informers := []factory.Informer{
 		cmInformer,
+		configNSCMInformer,
 		secretInformer,
 		routeInformer,
 		ingressInformer,


### PR DESCRIPTION
The OAuthServerRouteEndpointAccessibleController reads the proxy
trusted CA from a ConfigMap in the openshift-config namespace, but
did not watch that namespace's ConfigMap informer as a trigger. This
meant that after a proxy CA rotation, the controller would not
re-sync until its periodic resync (1-2 minutes), delaying recovery.

Add the openshift-config ConfigMap informer to the controller's
trigger list so it re-syncs immediately when the proxy CA content
changes. The informer is already running (used for the lister),
so this adds no new API watches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy trusted-CA configuration changes are now detected automatically, triggering reconciliation when the relevant configuration is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->