### PR TITLE
OCPBUGS-99774: remove redundant cluster-wide informer and unused kube-system registration

### DIFF
--- a/pkg/operator/replacement_starter.go
+++ b/pkg/operator/replacement_starter.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/utils/clock"
 
 	kubemigratorclient "sigs.k8s.io/kube-storage-version-migrator/pkg/clients/clientset"
@@ -236,8 +235,6 @@ type authenticationOperatorInformerFactories struct {
 	operatorInformer           operatorinformer.SharedInformerFactory
 	apiregistrationInformers   apiregistrationinformers.SharedInformerFactory
 	migrationInformer          migrationv1alpha1informer.SharedInformerFactory
-	// TODO remove
-	kubeInformers kubeinformers.SharedInformerFactory
 
 	namespacedOpenshiftAuthenticationRoutes routeinformer.SharedInformerFactory
 }
@@ -254,14 +251,12 @@ func newInformerFactories(authOperatorInput *authenticationOperatorInput) authen
 			"openshift-authentication-operator",
 			"openshift-kube-apiserver",
 			"", // an informer for non-namespaced resources
-			"kube-system",
 			libgoetcd.EtcdEndpointNamespace,
 		),
 		operatorConfigInformer:   configinformer.NewSharedInformerFactoryWithOptions(authOperatorInput.configClient, resync),
 		operatorInformer:         operatorinformer.NewSharedInformerFactory(authOperatorInput.operatorClient, 24*time.Hour),
 		apiregistrationInformers: apiregistrationinformers.NewSharedInformerFactory(authOperatorInput.apiregistrationv1Client, 10*time.Minute),
 		migrationInformer:        migrationv1alpha1informer.NewSharedInformerFactory(authOperatorInput.migrationClient, time.Minute*30),
-		kubeInformers:            kubeinformers.NewSharedInformerFactory(authOperatorInput.kubeClient, resync),
 
 		namespacedOpenshiftAuthenticationRoutes: routeinformer.NewSharedInformerFactoryWithOptions(authOperatorInput.routeClient, resync,
 			routeinformer.WithNamespace("openshift-authentication"),
@@ -277,7 +272,6 @@ func (a authenticationOperatorInformerFactories) simplifiedInformerFactories() [
 		libraryapplyconfiguration.GeneratedInformerFactoryAdapter(a.operatorConfigInformer),
 		libraryapplyconfiguration.GeneratedInformerFactoryAdapter(a.apiregistrationInformers),
 		libraryapplyconfiguration.GeneratedInformerFactoryAdapter(a.migrationInformer),
-		libraryapplyconfiguration.GeneratedInformerFactoryAdapter(a.kubeInformers),
 		libraryapplyconfiguration.GeneratedInformerFactoryAdapter(a.namespacedOpenshiftAuthenticationRoutes),
 	}
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -791,7 +791,7 @@ func prepareOauthAPIServerOperator(
 			Subject:    &pkix.Name{CommonName: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"},
 			SignerName: certapiv1.KubeAPIServerClientSignerName,
 		},
-		informerFactories.kubeInformers.Certificates().V1().CertificateSigningRequests(),
+		informerFactories.kubeInformersForNamespaces.InformersFor("").Certificates().V1().CertificateSigningRequests(),
 		authOperatorInput.kubeClient.CertificatesV1().CertificateSigningRequests(),
 		informerFactories.kubeInformersForNamespaces.InformersFor("openshift-oauth-apiserver").Core().V1().Secrets(),
 		authOperatorInput.kubeClient.CoreV1(),
@@ -812,7 +812,7 @@ func prepareOauthAPIServerOperator(
 		"OpenShiftAuthenticator",
 		authOperatorInput.authenticationOperatorClient,
 		authOperatorInput.kubeClient.CertificatesV1().CertificateSigningRequests(),
-		informerFactories.kubeInformers.Certificates().V1().CertificateSigningRequests(),
+		informerFactories.kubeInformersForNamespaces.InformersFor("").Certificates().V1().CertificateSigningRequests(),
 		csr.NewLabelFilter(labelSelector),
 		csr.NewServiceAccountApprover(
 			"openshift-authentication-operator",


### PR DESCRIPTION
## Bug

https://redhat.atlassian.net/browse/OCPBUGS-99774

## Problem

The `cluster-authentication-operator` has two informer cleanup issues:

1. **Redundant cluster-wide informer**: A `kubeInformers` field (marked `// TODO remove`) creates a separate `kubeinformers.NewSharedInformerFactory` that duplicates the `""` (cluster-wide) entry already in `kubeInformersForNamespaces`. It is only used for `CertificateSigningRequests` informer in two places.

2. **Unused namespace registration**: `kube-system` is registered in `kubeInformersForNamespaces` but never queried via `InformersFor("kube-system")` anywhere in the operator, wasting a watch connection.

## Fix

- Migrate the two CSR informer usages in `starter.go` from `informerFactories.kubeInformers` to `informerFactories.kubeInformersForNamespaces.InformersFor("")`, which provides the same cluster-wide informer
- Remove the `kubeInformers` field, its initialization, and its entry in `simplifiedInformerFactories()`
- Remove the unused `kubeinformers` import
- Remove `kube-system` from `kubeInformersForNamespaces` registration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication operator monitoring by using the correct namespace configuration.
  * Added monitoring for the etcd endpoint namespace while removing unnecessary system namespace monitoring.
  * Updated certificate request and approval handling to consistently monitor cluster-wide signing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->