### PR TITLE
bugfix: external-oidc: omit client-credential TLS generated config when empty

### DIFF
--- a/pkg/controllers/externaloidc/generation/oauthapiserver/generate.go
+++ b/pkg/controllers/externaloidc/generation/oauthapiserver/generate.go
@@ -887,14 +887,13 @@ func generateExternalClaimsSourceAuthenticationClientCredential(clientCredential
 		return nil, fmt.Errorf("generating scopes: %w", err)
 	}
 
-	var certificateAuthority *string
-	if len(clientCredentialConfig.TLS.CertificateAuthority.Name) > 0 {
-		ca, err := getCertificateAuthorityFromConfigMap(clientCredentialConfig.TLS.CertificateAuthority.Name, cmLister)
+	zeroValueExternalSourceTLS := configv1.ExternalSourceTLS{}
+	var tls *authenticationv1alpha1.TLS
+	if clientCredentialConfig.TLS != zeroValueExternalSourceTLS {
+		tls, err = generateExternalClaimsSourceTLS(clientCredentialConfig.TLS, cmLister)
 		if err != nil {
-			return nil, fmt.Errorf("getting certificate authority: %w", err)
+			return nil, err
 		}
-
-		certificateAuthority = &ca
 	}
 
 	return &authenticationv1alpha1.ClientCredentialConfig{
@@ -902,9 +901,7 @@ func generateExternalClaimsSourceAuthenticationClientCredential(clientCredential
 		ClientSecret:  clientSecret,
 		TokenEndpoint: clientCredentialConfig.TokenEndpoint,
 		Scopes:        scopes,
-		TLS: &authenticationv1alpha1.TLS{
-			CertificateAuthority: certificateAuthority,
-		},
+		TLS:           tls,
 	}, nil
 }
 

--- a/pkg/controllers/externaloidc/generation/oauthapiserver/generate_test.go
+++ b/pkg/controllers/externaloidc/generation/oauthapiserver/generate_test.go
@@ -1605,6 +1605,116 @@ func TestAuthenticationConfigurationGeneratorGenerateAuthenticationConfiguration
 			),
 		},
 		{
+			name:              "valid auth config with external claims source using client credential auth with nil TLS config",
+			caBundleConfigMap: &baseCABundleConfigMap,
+			configMapIndexer: func() cache.Indexer {
+				idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+				idx.Add(&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ext-source-ca-bundle",
+						Namespace: configNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": testCertData,
+					},
+				})
+				return idx
+			}(),
+			secretIndexer: func() cache.Indexer {
+				idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+				idx.Add(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "client-secret-ref",
+						Namespace: configNamespace,
+					},
+					Data: map[string][]byte{
+						"client-secret": []byte("my-secret-value"),
+					},
+				})
+				return idx
+			}(),
+			auth: *authWithUpdates(baseAuthResource, []func(auth *configv1.Authentication){
+				func(auth *configv1.Authentication) {
+					for i := range auth.Spec.OIDCProviders {
+						auth.Spec.OIDCProviders[i].Issuer.URL = "https://example.com"
+						auth.Spec.OIDCProviders[i].ExternalClaimsSources = []configv1.ExternalClaimsSource{
+							{
+								Authentication: configv1.ExternalSourceAuthentication{
+									Type: configv1.ExternalSourceAuthenticationTypeClientCredential,
+									ClientCredential: configv1.ClientCredentialConfig{
+										ClientID: "my-client-id",
+										ClientSecret: configv1.ClientSecretSecretReference{
+											Name: "client-secret-ref",
+										},
+										TokenEndpoint: "https://idp.example.com/oauth2/token",
+										Scopes:        []configv1.OAuth2Scope{"openid", "profile"},
+									},
+								},
+								TLS: configv1.ExternalSourceTLS{
+									CertificateAuthority: configv1.ExternalSourceCertificateAuthorityConfigMapReference{
+										Name: "ext-source-ca-bundle",
+									},
+								},
+								URL: configv1.SourceURL{
+									Hostname:       "claims.example.com",
+									PathExpression: "claims.sub",
+								},
+								Mappings: []configv1.SourcedClaimMapping{
+									{
+										Name:       "custom_claim",
+										Expression: "response.custom_claim",
+									},
+								},
+							},
+						}
+					}
+				},
+			}),
+			expectedAuthConfig: authConfigWithUpdates(baseAuthConfig, []func(authConfig *authenticationv1alpha1.AuthenticationConfiguration){
+				func(authConfig *authenticationv1alpha1.AuthenticationConfiguration) {
+					for i := range authConfig.JWT {
+						authConfig.JWT[i].Issuer.URL = "https://example.com"
+						authConfig.JWT[i].ExternalClaimsSources = []authenticationv1alpha1.ExternalClaimsSource{
+							{
+								Authentication: &authenticationv1alpha1.Authentication{
+									Type: ptr.To(authenticationv1alpha1.AuthenticationTypeClientCredential),
+									ClientCredential: &authenticationv1alpha1.ClientCredentialConfig{
+										ClientID:      "my-client-id",
+										ClientSecret:  "my-secret-value",
+										TokenEndpoint: "https://idp.example.com/oauth2/token",
+										Scopes:        []string{"openid", "profile"},
+									},
+								},
+								TLS: &authenticationv1alpha1.TLS{
+									CertificateAuthority: ptr.To(testCertData),
+								},
+								URL: &authenticationv1alpha1.SourceURL{
+									Hostname:       ptr.To("claims.example.com"),
+									PathExpression: ptr.To("claims.sub"),
+								},
+								Mappings: []authenticationv1alpha1.SourcedClaimMapping{
+									{
+										Name:       ptr.To("custom_claim"),
+										Expression: ptr.To("response.custom_claim"),
+									},
+								},
+							},
+						}
+					}
+				},
+			}),
+			expectError: false,
+			featureGates: featuregates.NewFeatureGate(
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCExternalClaimsSourcing,
+				},
+				[]configv1.FeatureGateName{
+					features.FeatureGateExternalOIDCWithAdditionalClaimMappings,
+					features.FeatureGateExternalOIDCWithUpstreamParity,
+				},
+			),
+		},
+		{
 			name:              "auth config with external claims source with unknown auth type, error",
 			caBundleConfigMap: &baseCABundleConfigMap,
 			auth: *authWithUpdates(baseAuthResource, []func(auth *configv1.Authentication){


### PR DESCRIPTION
## Description

During some testing using an identity provider that already uses certificates signed by a well known certificate authority (i.e included in the system default trust store), omitting the TLS configuration option for the external claims source authentication type `ClientCredential` resulted in generation of an invalid configuration that set `tls: {}`.

Example generated config:
```yaml
apiVersion: v1
data:
  auth-config.json: '{"kind":"AuthenticationConfiguration","apiVersion":"authentication.openshift.io/v1alpha1","jwt":[{"issuer":{"url":"https://login.microsoftonline.com/<redacted>/v2.0","audiences":["<redacted>"],"audienceMatchPolicy":"MatchAny"},"claimMappings":{"username":{"claim":"preferred_username","prefix":""},"groups":{"expression":"claims.?groups.orValue('''').split('','')"},"uid":{"claim":"sub"}},"externalClaimsSources":[{"authentication":{"type":"ClientCredential","clientCredential":{"clientID":"<redacted>","clientSecret":"<redacted>","tokenEndpoint":"https://login.microsoftonline.com/<redacted>/oauth2/v2.0/token","scopes":[".default"],"tls":{}}},"url":{"hostname":"graph.microsoft.com","pathExpression":"[''v1.0'',
    ''users''] + [claims.oid] + [''memberOf'', ''microsoft.graph.group'']"},"mappings":[{"name":"groups","expression":"response.body.value.map(x,
    x.displayName).join('','')"}]}]}]}'
kind: ConfigMap
metadata:
  creationTimestamp: "2026-08-14T16:31:07Z"
  name: auth-config
  namespace: openshift-oauth-apiserver
  resourceVersion: "97832"
  uid: de9f81b3-00a8-43f7-a787-76db7a84f2c9
```

Example error from oauth-apiserver pod:
```sh
E0814 17:52:49.284670       1 configurator.go:94] reloading configuration: validating configuration: validating authentication configuration: jwt[0].externalClaimsSources[0].authentication.clientCredential.tls: Invalid value: {"CertificateAuthority":null}: at least one field must be set when tls is specified
```

---

This PR fixes this issue by checking if the provided TLS configuration is the zero-value and omitting the TLS configuration if it is instead of always setting the TLS configuration. Additionally, a new unit test was added to test this case acts as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS configuration handling for client-credential authentication.
  * TLS settings are now created only when explicitly provided, avoiding unnecessary configuration.

* **Tests**
  * Added coverage for client-credential authentication without TLS settings.
  * Verified token endpoint, scopes, external source URL, secrets, and claim mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->